### PR TITLE
add stock_volume* icon symlinks as in gnome theme for compatibility

### DIFF
--- a/Numix/16x16/status/stock_volume-0.svg
+++ b/Numix/16x16/status/stock_volume-0.svg
@@ -1,0 +1,1 @@
+audio-volume-low-zero-panel.svg

--- a/Numix/16x16/status/stock_volume-max.svg
+++ b/Numix/16x16/status/stock_volume-max.svg
@@ -1,0 +1,1 @@
+audio-volume-high-panel.svg

--- a/Numix/16x16/status/stock_volume-med.svg
+++ b/Numix/16x16/status/stock_volume-med.svg
@@ -1,0 +1,1 @@
+audio-volume-medium-panel.svg

--- a/Numix/16x16/status/stock_volume-min.svg
+++ b/Numix/16x16/status/stock_volume-min.svg
@@ -1,0 +1,1 @@
+audio-volume-low-panel.svg

--- a/Numix/16x16/status/stock_volume-mute.svg
+++ b/Numix/16x16/status/stock_volume-mute.svg
@@ -1,0 +1,1 @@
+audio-volume-muted-panel.svg

--- a/Numix/16x16/status/stock_volume.svg
+++ b/Numix/16x16/status/stock_volume.svg
@@ -1,0 +1,1 @@
+audio-volume-high-panel.svg

--- a/Numix/22x22/status/stock_volume-0.svg
+++ b/Numix/22x22/status/stock_volume-0.svg
@@ -1,0 +1,1 @@
+audio-volume-low-zero-panel.svg

--- a/Numix/22x22/status/stock_volume-max.svg
+++ b/Numix/22x22/status/stock_volume-max.svg
@@ -1,0 +1,1 @@
+audio-volume-high-panel.svg

--- a/Numix/22x22/status/stock_volume-med.svg
+++ b/Numix/22x22/status/stock_volume-med.svg
@@ -1,0 +1,1 @@
+audio-volume-medium-panel.svg

--- a/Numix/22x22/status/stock_volume-min.svg
+++ b/Numix/22x22/status/stock_volume-min.svg
@@ -1,0 +1,1 @@
+audio-volume-low-panel.svg

--- a/Numix/22x22/status/stock_volume-mute.svg
+++ b/Numix/22x22/status/stock_volume-mute.svg
@@ -1,0 +1,1 @@
+audio-volume-muted-panel.svg

--- a/Numix/22x22/status/stock_volume.svg
+++ b/Numix/22x22/status/stock_volume.svg
@@ -1,0 +1,1 @@
+audio-volume-high-panel.svg

--- a/Numix/24x24/status/stock_volume-0.svg
+++ b/Numix/24x24/status/stock_volume-0.svg
@@ -1,0 +1,1 @@
+audio-volume-low-zero-panel.svg

--- a/Numix/24x24/status/stock_volume-max.svg
+++ b/Numix/24x24/status/stock_volume-max.svg
@@ -1,0 +1,1 @@
+audio-volume-high-panel.svg

--- a/Numix/24x24/status/stock_volume-med.svg
+++ b/Numix/24x24/status/stock_volume-med.svg
@@ -1,0 +1,1 @@
+audio-volume-medium-panel.svg

--- a/Numix/24x24/status/stock_volume-min.svg
+++ b/Numix/24x24/status/stock_volume-min.svg
@@ -1,0 +1,1 @@
+audio-volume-low-panel.svg

--- a/Numix/24x24/status/stock_volume-mute.svg
+++ b/Numix/24x24/status/stock_volume-mute.svg
@@ -1,0 +1,1 @@
+audio-volume-muted-panel.svg

--- a/Numix/24x24/status/stock_volume.svg
+++ b/Numix/24x24/status/stock_volume.svg
@@ -1,0 +1,1 @@
+audio-volume-high-panel.svg


### PR DESCRIPTION
This fixes volume icon set display for tray applications like [pasystray](https://github.com/christophgysin/pasystray/)
