### PR TITLE
Moved c[++]src to point to c[++]

### DIFF
--- a/Numix/128x128/mimetypes/gnome-mime-text-x-c++src.svg
+++ b/Numix/128x128/mimetypes/gnome-mime-text-x-c++src.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c++.svg

--- a/Numix/128x128/mimetypes/gnome-mime-text-x-csrc.svg
+++ b/Numix/128x128/mimetypes/gnome-mime-text-x-csrc.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c.svg

--- a/Numix/128x128/mimetypes/text-x-c++src.svg
+++ b/Numix/128x128/mimetypes/text-x-c++src.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c++.svg

--- a/Numix/128x128/mimetypes/text-x-csrc.svg
+++ b/Numix/128x128/mimetypes/text-x-csrc.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c.svg

--- a/Numix/16x16/mimetypes/gnome-mime-text-x-c++src.svg
+++ b/Numix/16x16/mimetypes/gnome-mime-text-x-c++src.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c++.svg

--- a/Numix/16x16/mimetypes/gnome-mime-text-x-csrc.svg
+++ b/Numix/16x16/mimetypes/gnome-mime-text-x-csrc.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c.svg

--- a/Numix/16x16/mimetypes/text-x-c++src.svg
+++ b/Numix/16x16/mimetypes/text-x-c++src.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c++.svg

--- a/Numix/16x16/mimetypes/text-x-csrc.svg
+++ b/Numix/16x16/mimetypes/text-x-csrc.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c.svg

--- a/Numix/22x22/mimetypes/gnome-mime-text-x-c++src.svg
+++ b/Numix/22x22/mimetypes/gnome-mime-text-x-c++src.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c++.svg

--- a/Numix/22x22/mimetypes/gnome-mime-text-x-csrc.svg
+++ b/Numix/22x22/mimetypes/gnome-mime-text-x-csrc.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c.svg

--- a/Numix/22x22/mimetypes/text-x-c++src.svg
+++ b/Numix/22x22/mimetypes/text-x-c++src.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c++.svg

--- a/Numix/22x22/mimetypes/text-x-csrc.svg
+++ b/Numix/22x22/mimetypes/text-x-csrc.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c.svg

--- a/Numix/24x24/mimetypes/gnome-mime-text-x-c++src.svg
+++ b/Numix/24x24/mimetypes/gnome-mime-text-x-c++src.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c++.svg

--- a/Numix/24x24/mimetypes/gnome-mime-text-x-csrc.svg
+++ b/Numix/24x24/mimetypes/gnome-mime-text-x-csrc.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c.svg

--- a/Numix/24x24/mimetypes/text-x-c++src.svg
+++ b/Numix/24x24/mimetypes/text-x-c++src.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c++.svg

--- a/Numix/24x24/mimetypes/text-x-csrc.svg
+++ b/Numix/24x24/mimetypes/text-x-csrc.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c.svg

--- a/Numix/256x256/mimetypes/gnome-mime-text-x-c++src.svg
+++ b/Numix/256x256/mimetypes/gnome-mime-text-x-c++src.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c++.svg

--- a/Numix/256x256/mimetypes/gnome-mime-text-x-csrc.svg
+++ b/Numix/256x256/mimetypes/gnome-mime-text-x-csrc.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c.svg

--- a/Numix/256x256/mimetypes/text-x-c++src.svg
+++ b/Numix/256x256/mimetypes/text-x-c++src.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c++.svg

--- a/Numix/256x256/mimetypes/text-x-csrc.svg
+++ b/Numix/256x256/mimetypes/text-x-csrc.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c.svg

--- a/Numix/32x32/mimetypes/gnome-mime-text-x-c++src.svg
+++ b/Numix/32x32/mimetypes/gnome-mime-text-x-c++src.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c++.svg

--- a/Numix/32x32/mimetypes/gnome-mime-text-x-csrc.svg
+++ b/Numix/32x32/mimetypes/gnome-mime-text-x-csrc.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c.svg

--- a/Numix/32x32/mimetypes/text-x-c++src.svg
+++ b/Numix/32x32/mimetypes/text-x-c++src.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c++.svg

--- a/Numix/32x32/mimetypes/text-x-csrc.svg
+++ b/Numix/32x32/mimetypes/text-x-csrc.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c.svg

--- a/Numix/48x48/mimetypes/gnome-mime-text-x-c++src.svg
+++ b/Numix/48x48/mimetypes/gnome-mime-text-x-c++src.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c++.svg

--- a/Numix/48x48/mimetypes/gnome-mime-text-x-csrc.svg
+++ b/Numix/48x48/mimetypes/gnome-mime-text-x-csrc.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c.svg

--- a/Numix/48x48/mimetypes/text-x-c++src.svg
+++ b/Numix/48x48/mimetypes/text-x-c++src.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c++.svg

--- a/Numix/48x48/mimetypes/text-x-csrc.svg
+++ b/Numix/48x48/mimetypes/text-x-csrc.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c.svg

--- a/Numix/64x64/mimetypes/gnome-mime-text-x-c++src.svg
+++ b/Numix/64x64/mimetypes/gnome-mime-text-x-c++src.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c++.svg

--- a/Numix/64x64/mimetypes/gnome-mime-text-x-csrc.svg
+++ b/Numix/64x64/mimetypes/gnome-mime-text-x-csrc.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c.svg

--- a/Numix/64x64/mimetypes/text-x-c++src.svg
+++ b/Numix/64x64/mimetypes/text-x-c++src.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c++.svg

--- a/Numix/64x64/mimetypes/text-x-csrc.svg
+++ b/Numix/64x64/mimetypes/text-x-csrc.svg
@@ -1,1 +1,1 @@
-text-x-script.svg
+text-x-c.svg


### PR DESCRIPTION
My system (Gnome shell 3.10.4 with nemo) identifies C source code as text-x-csrc and C++ code as text-x-c++src. The icons for those types are links to text-x-script rather than links to their C[++] icons.

This changes the links for those types to point to the C[++] icons.

Feel free to reject this if csrc actually means something different.
