### PR TITLE
Added nm-device-wired.svg symlinks to Numix-Light. Fixes #209

### DIFF
--- a/Numix-Light/16x16/status/nm-device-wired.svg
+++ b/Numix-Light/16x16/status/nm-device-wired.svg
@@ -1,0 +1,1 @@
+network-transmit-receive.svg

--- a/Numix-Light/22x22/status/nm-device-wired.svg
+++ b/Numix-Light/22x22/status/nm-device-wired.svg
@@ -1,0 +1,1 @@
+network-transmit-receive.svg

--- a/Numix-Light/24x24/status/nm-device-wired.svg
+++ b/Numix-Light/24x24/status/nm-device-wired.svg
@@ -1,0 +1,1 @@
+network-transmit-receive.svg


### PR DESCRIPTION
Hi, I have added `nm-device-wired.svg` symlinks (relative ones) to `network-transmit-receive.svg` in `16x16/status`, `22x22/status` and `24x24/status` by copying the symlinks over from Numix to Numix-Light.