### PR TITLE
Brighter battery-000.svg

### DIFF
--- a/Numix/16x16/status/battery-000.svg
+++ b/Numix/16x16/status/battery-000.svg
@@ -12,7 +12,7 @@
    height="16"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
+   inkscape:version="0.91 r"
    sodipodi:docname="battery-000.svg">
   <metadata
      id="metadata12">
@@ -36,16 +36,16 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="757"
+     inkscape:window-height="422"
      id="namedview8"
      showgrid="true"
-     inkscape:zoom="17.096617"
-     inkscape:cx="0.5087464"
-     inkscape:cy="12.392995"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
+     inkscape:zoom="14.75"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-x="317"
+     inkscape:window-y="193"
+     inkscape:window-maximized="0"
      inkscape:current-layer="svg2">
     <inkscape:grid
        type="xygrid"
@@ -59,12 +59,12 @@
      d="m 6,2.7647059 0,1.5294121 -2,0 L 4,15 l 8,0 0,-10.705882 -2,0 0,-1.5294121 z"
      id="path4"
      inkscape:connector-curvature="0"
-     style="opacity:0.15" />
+     style="opacity:0.3" />
   <path
      d="M 6,2 6,4 4,4 4,14 12,14 12,4 10,4 10,2 z"
      id="path6"
      class="error"
      inkscape:connector-curvature="0"
-     style="opacity:0.5;fill:#ef555c"
+     style="opacity:0.99999999;fill:#ef555c"
      sodipodi:nodetypes="ccccccccc" />
 </svg>

--- a/Numix/22x22/status/battery-000.svg
+++ b/Numix/22x22/status/battery-000.svg
@@ -12,7 +12,7 @@
    height="22"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.4 r9939"
+   inkscape:version="0.91 r"
    sodipodi:docname="battery-000.svg">
   <metadata
      id="metadata12">
@@ -36,25 +36,26 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1366"
-     inkscape:window-height="740"
+     inkscape:window-width="1215"
+     inkscape:window-height="776"
      id="namedview8"
      showgrid="false"
-     inkscape:zoom="24.178267"
-     inkscape:cx="11.082719"
+     inkscape:zoom="26.818182"
+     inkscape:cx="11"
      inkscape:cy="11"
-     inkscape:window-x="0"
-     inkscape:window-y="28"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2" />
   <path
      d="M 8,4 8,6 5,6 5,20 17,20 17,6 14,6 14,4 z"
      opacity="0.15"
-     id="path4" />
+     id="path4"
+     style="opacity:0.3" />
   <path
      d="M 8,3 8,5 5,5 5,19 17,19 17,5 14,5 14,3 z"
      id="path6"
      class="error"
      inkscape:connector-curvature="0"
-     style="opacity:0.5;fill:#ef555c" />
+     style="opacity:0.99999999;fill:#ef555c" />
 </svg>

--- a/Numix/24x24/status/battery-000.svg
+++ b/Numix/24x24/status/battery-000.svg
@@ -12,7 +12,7 @@
    height="24"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
+   inkscape:version="0.91 r"
    sodipodi:docname="battery-000.svg">
   <metadata
      id="metadata12">
@@ -36,15 +36,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1215"
+     inkscape:window-height="776"
      id="namedview8"
      showgrid="true"
-     inkscape:zoom="24.178267"
-     inkscape:cx="11.165438"
-     inkscape:cy="10.917281"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:zoom="24.583333"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
@@ -59,11 +59,11 @@
      d="M 9,5 9,7 6,7 6,21 18,21 18,7 15,7 15,5 z"
      id="path4"
      inkscape:connector-curvature="0"
-     style="opacity:0.15" />
+     style="opacity:0.3" />
   <path
      d="M 9,4 9,6 6,6 6,20 18,20 18,6 15,6 15,4 z"
      id="path6"
      class="error"
      inkscape:connector-curvature="0"
-     style="opacity:0.5;fill:#ef555c" />
+     style="opacity:0.99999999;fill:#ef555c" />
 </svg>


### PR DESCRIPTION
Brighter battery-000.svg. Fixes https://github.com/numixproject/numix-icon-theme/issues/256.

This is the same as my previous pull request https://github.com/numixproject/numix-icon-theme/pull/290, for a more detailed description please cf. over there (this time the pull request is based off of a branch of my master).