### PR TITLE
Added user-trash-full-symbolic-AmbianceGTK.svg

### DIFF
--- a/Numix/scalable/places/user-trash-full-symbolic-AmbianceGTK.svg
+++ b/Numix/scalable/places/user-trash-full-symbolic-AmbianceGTK.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="user-trash-full-symbolic_neu2.svg">
+  <metadata
+     id="metadata20">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs18" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1215"
+     inkscape:window-height="776"
+     id="namedview16"
+     showgrid="true"
+     inkscape:zoom="34.6875"
+     inkscape:cx="8.952187"
+     inkscape:cy="8"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2997" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#bebebe;fill-opacity:1;stroke:none"
+     d="m 3,7 0,7 c 0,1.108 0.892,2 2,2 l 6,0 c 1.108,0 2,-0.892 2,-2 L 13,7 z M 6.5,9 C 6.777,9 7,9.223 7,9.5 l 0,4 C 7,13.777 6.777,14 6.5,14 6.223,14 6,13.777 6,13.5 l 0,-4 C 6,9.223 6.223,9 6.5,9 z m 3,0 C 9.777,9 10,9.223 10,9.5 l 0,4 C 10,13.777 9.777,14 9.5,14 9.223,14 9,13.777 9,13.5 l 0,-4 C 9,9.223 9.223,9 9.5,9 z"
+     id="rect2999"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cssssccssssssssssssss" />
+  <path
+     style="fill:#bebebe;fill-opacity:1;stroke:none"
+     d="M 2,6 14,6 C 15,6 15,6 14,4.5 13,3 13,3 12,3 L 4,3 C 3,3 3,3 2,4.5 1,6 1,6 2,6 z"
+     id="path3002"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccccc" />
+  <path
+     style="fill:#bebebe;fill-opacity:1;stroke:none"
+     d="M 8,0 C 6.3431457,0 5,1.3431457 5,3 5,4.6568543 6.3431457,6 8,6 9.656854,6 11,4.6568543 11,3 11,1.3431457 9.656854,0 8,0 z M 8,1.5 C 8.8284272,1.5 9.5,2.1715729 9.5,3 9.5,3.8284271 8.8284272,4.5 8,4.5 7.1715728,4.5 6.5,3.8284271 6.5,3 6.5,2.1715729 7.1715728,1.5 8,1.5 z"
+     id="path3772"
+     inkscape:connector-curvature="0" />
+  <rect
+     style="fill:#ff0000;fill-opacity:1;fill-rule:evenodd;stroke:#ff0000;stroke-width:1.12535548000000007px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="rect3812"
+     width="13.250015"
+     height="1.3381076"
+     x="1.3794966"
+     y="6.0153947"
+     ry="0.66905379"
+     inkscape:transform-center-y="-0.92175378" />
+</svg>


### PR DESCRIPTION
Added `user-trash-full-symbolic-AmbianceGTK.svg`  to `/scalable/places`. Temporarily addresses https://github.com/numixproject/numix-icon-theme/issues/240 from Numix's side.

In continuation of https://github.com/numixproject/numix-icon-theme/issues/240, I would like to suggest to add this "workaround" icon to Numix base. This has worked just fine for me for a couple of months now with Ubuntu default Ambiance GTK theme.

![workaround-icon](https://cloud.githubusercontent.com/assets/7164227/6760910/d6b926be-cf4d-11e4-9505-f4813f08b125.png)

Bug report against Ambiance GTK theme: https://bugs.launchpad.net/ubuntu/+source/ubuntu-themes/+bug/1426774

Here is a screenshot of the result in Ubuntu 14.10 with Ambiance GTK theme (after renaming this "workaround" icon to `user-trash-full-symbolic.svg`):

![user-trash-full-symbolic-ambiancegtk](https://cloud.githubusercontent.com/assets/7164227/6761079/96b6bfb6-cf4f-11e4-8c0f-f50c658462dc.png)

In contrast, this is what is displayed with current Numix icon theme in combination with Ambiance GTK theme (same problem in Ubuntu 15.04 daily, currently in development):

![06ef43e8-c118-11e4-89bd-0201742ef55b](https://cloud.githubusercontent.com/assets/7164227/6760981/99f43e48-cf4e-11e4-9d60-c78b1529eabf.png)

Temporarily adding this "workaround" icon would give the user the opportunity to manually change the icon names and use this visible and functional icon in combination with Ambiance GTK theme.