### PR TITLE
Add .xspf support

### DIFF
--- a/Numix/128x128/mimetypes/application-xspf+xml.svg
+++ b/Numix/128x128/mimetypes/application-xspf+xml.svg
@@ -1,0 +1,1 @@
+application-audio-playlist.svg

--- a/Numix/16x16/mimetypes/application-xspf+xml.svg
+++ b/Numix/16x16/mimetypes/application-xspf+xml.svg
@@ -1,0 +1,1 @@
+application-audio-playlist.svg

--- a/Numix/22x22/mimetypes/application-xspf+xml.svg
+++ b/Numix/22x22/mimetypes/application-xspf+xml.svg
@@ -1,0 +1,1 @@
+application-audio-playlist.svg

--- a/Numix/24x24/mimetypes/application-xspf+xml.svg
+++ b/Numix/24x24/mimetypes/application-xspf+xml.svg
@@ -1,0 +1,1 @@
+application-audio-playlist.svg

--- a/Numix/256x256/mimetypes/application-xspf+xml.svg
+++ b/Numix/256x256/mimetypes/application-xspf+xml.svg
@@ -1,0 +1,1 @@
+application-audio-playlist.svg

--- a/Numix/32x32/mimetypes/application-xspf+xml.svg
+++ b/Numix/32x32/mimetypes/application-xspf+xml.svg
@@ -1,0 +1,1 @@
+application-audio-playlist.svg

--- a/Numix/48x48/mimetypes/application-xspf+xml.svg
+++ b/Numix/48x48/mimetypes/application-xspf+xml.svg
@@ -1,0 +1,1 @@
+application-audio-playlist.svg

--- a/Numix/64x64/mimetypes/application-xspf+xml.svg
+++ b/Numix/64x64/mimetypes/application-xspf+xml.svg
@@ -1,0 +1,1 @@
+application-audio-playlist.svg


### PR DESCRIPTION
files: .xspf are used as playlist by programs like VLC:
![image](https://cloud.githubusercontent.com/assets/11244067/6779937/832ba8fc-d13f-11e4-8a7d-283f0d7f19c7.png)

created a symlink **application-xspf+xml.svg** in all of available mimetype sizes