### PR TITLE
Fix .deb files

### DIFF
--- a/Numix/128x128/mimetypes/application-vnd.debian.binary-package.svg
+++ b/Numix/128x128/mimetypes/application-vnd.debian.binary-package.svg
@@ -1,0 +1,1 @@
+application-x-deb.svg

--- a/Numix/16x16/mimetypes/application-vnd.debian.binary-package.svg
+++ b/Numix/16x16/mimetypes/application-vnd.debian.binary-package.svg
@@ -1,0 +1,1 @@
+application-x-deb.svg

--- a/Numix/22x22/mimetypes/application-vnd.debian.binary-package.svg
+++ b/Numix/22x22/mimetypes/application-vnd.debian.binary-package.svg
@@ -1,0 +1,1 @@
+application-x-deb.svg

--- a/Numix/24x24/mimetypes/application-vnd.debian.binary-package.svg
+++ b/Numix/24x24/mimetypes/application-vnd.debian.binary-package.svg
@@ -1,0 +1,1 @@
+application-x-deb.svg

--- a/Numix/256x256/mimetypes/application-vnd.debian.binary-package.svg
+++ b/Numix/256x256/mimetypes/application-vnd.debian.binary-package.svg
@@ -1,0 +1,1 @@
+application-x-deb.svg

--- a/Numix/32x32/mimetypes/application-vnd.debian.binary-package.svg
+++ b/Numix/32x32/mimetypes/application-vnd.debian.binary-package.svg
@@ -1,0 +1,1 @@
+application-x-deb.svg

--- a/Numix/48x48/mimetypes/application-vnd.debian.binary-package.svg
+++ b/Numix/48x48/mimetypes/application-vnd.debian.binary-package.svg
@@ -1,0 +1,1 @@
+application-x-deb.svg

--- a/Numix/64x64/mimetypes/application-vnd.debian.binary-package.svg
+++ b/Numix/64x64/mimetypes/application-vnd.debian.binary-package.svg
@@ -1,0 +1,1 @@
+application-x-deb.svg


### PR DESCRIPTION
Outside the Debian and derivatives systems the .deb files uses a different mimetype:
![image](https://cloud.githubusercontent.com/assets/11244067/6781806/1cfcbe12-d14f-11e4-9dee-5b5016daf04e.png)

mimetype: **application-vnd.debian.binary-package**

Image captured in Arch Linux