### PR TITLE
Fixing wrong gpm-mouse-020.svg in 16 22 and 24

### DIFF
--- a/Numix-Light/16x16/status/gpm-mouse-020.svg
+++ b/Numix-Light/16x16/status/gpm-mouse-020.svg
@@ -7,24 +7,27 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 16 16"
    width="16"
    height="16"
-   viewBox="0 0 16 16"
-   id="svg3035"
+   id="svg3003"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
+   inkscape:version="0.91 r"
    sodipodi:docname="gpm-mouse-020.svg">
   <metadata
-     id="metadata3067">
+     id="metadata3029">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <defs
+     id="defs3027" />
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -34,80 +37,30 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
-     id="namedview3065"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview3025"
      showgrid="false"
-     inkscape:zoom="29.5"
-     inkscape:cx="2.0177611"
-     inkscape:cy="5.2356201"
+     inkscape:zoom="15.170655"
+     inkscape:cx="-18.133016"
+     inkscape:cy="14.91816"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg3035" />
-  <defs
-     id="defs3037">
-    <filter
-       id="0"
-       filterUnits="objectBoundingBox"
-       x="0"
-       y="0"
-       width="16"
-       height="16">
-      <feColorMatrix
-         type="matrix"
-         in="SourceGraphic"
-         values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0"
-         id="feColorMatrix3040" />
-    </filter>
-    <mask
-       id="1">
-      <g
-         filter="url(#0)"
-         id="g3043">
-        <rect
-           width="16"
-           height="16"
-           fill-opacity="0.302"
-           id="rect3045" />
-      </g>
-    </mask>
-    <clipPath
-       id="2">
-      <rect
-         width="16"
-         height="16"
-         id="rect3048" />
-    </clipPath>
-    <g
-       id="3"
-       clip-path="url(#2)">
-      <path
-         d="M 12.5 5.334473 L 12.5 8.664551 "
-         transform="matrix(1.066667,0,0,0.727273,-5.333333,-0.727273)"
-         fill="none"
-         stroke="#dcdcdc"
-         stroke-linecap="round"
-         stroke-width="2"
-         id="path3051" />
-      <path
-         d="M -16.452637 8.248291 L -7.547363 8.248291 C -6.279785 8.248291 -5.248535 9.727783 -5.248535 11.551514 L -5.248535 13.448486 C -5.248535 15.272217 -6.279785 16.751709 -7.547363 16.751709 L -16.452637 16.751709 C -17.720215 16.751709 -18.751465 15.272217 -18.751465 13.448486 L -18.751465 11.551514 C -18.751465 9.727783 -17.720215 8.248291 -16.452637 8.248291 Z "
-         transform="matrix(0,-0.727273,1.066667,0,-5.333333,-0.727273)"
-         fill="none"
-         stroke="#dcdcdc"
-         stroke-linecap="round"
-         stroke-width="0.5"
-         id="path3053" />
-    </g>
-  </defs>
+     inkscape:current-layer="svg3003" />
   <path
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#353535;fill-opacity:1;stroke:none;stroke-width:0.88077134000000001;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-     d="m 6.9375,2.09375 c -1.2420574,0 -2.3665991,0.2519802 -3.21875,0.6875 -0.8521509,0.4355198 -1.5,1.1026273 -1.5,1.9375 l 0,6.5625 c 0,0.834873 0.6478491,1.50198 1.5,1.9375 0.8521509,0.43552 1.9766926,0.6875 3.21875,0.6875 l 2.125,0 c 1.242057,0 2.366599,-0.25198 3.21875,-0.6875 0.852151,-0.43552 1.5,-1.102627 1.5,-1.9375 l 0,-6.5625 c 0,-0.8348727 -0.647849,-1.5019802 -1.5,-1.9375 C 11.429099,2.3457302 10.304557,2.09375 9.0625,2.09375 l -0.9375,0 -0.125,0 -1.0625,0 z m 0,0.90625 0.65625,0 0,2.46875 a 0.44042971,0.44042971 0 0 0 0.875,0 L 8.46875,3 9.0625,3 c 1.121224,0 2.122658,0.2099337 2.8125,0.5625 0.689842,0.3525663 1.03125,0.7840909 1.03125,1.15625 l 0,6.5625 c 0,0.372159 -0.341408,0.803684 -1.03125,1.15625 C 11.185158,12.790066 10.183724,13 9.0625,13 l -2.125,0 C 5.8162756,13 4.8148416,12.790066 4.125,12.4375 3.4351584,12.084934 3.09375,11.653409 3.09375,11.28125 l 0,-6.5625 C 3.09375,4.3465909 3.4351584,3.9150663 4.125,3.5625 4.8148416,3.2099337 5.8162756,3 6.9375,3 z"
-     id="path3061"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     d="M 7.2727273,2.1875 C 6.3937223,2.1875 5.5971492,2.4439328 5,2.8913574 4.4028508,3.338782 4,3.996713 4,4.730469 l 0,6.539062 c 0,0.733756 0.4028508,1.391687 1,1.839112 0.5971492,0.447424 1.3937223,0.703857 2.2727273,0.703857 l 1.4545457,0 c 0.879005,0 1.675578,-0.256433 2.272727,-0.703857 0.597149,-0.447425 1,-1.105356 1,-1.839112 L 12,4.730469 C 12,3.996713 11.597149,3.338782 11,2.8913574 10.402851,2.4439328 9.606278,2.1875 8.727273,2.1875 l -0.590909,0 -0.181819,0 -0.6818177,0 z m 0,0.7265625 0.3863637,0 0,2.5429685 a 0.36367273,0.36331758 0 1 0 0.727273,0 l 0,-2.5429685 0.340909,0 c 0.732631,0 1.386422,0.2270945 1.840909,0.567627 0.454487,0.3405325 0.704545,0.7749885 0.704545,1.2487795 l 0,6.539062 c 0,0.473791 -0.250058,0.908247 -0.704545,1.24878 -0.454487,0.340532 -1.108278,0.567626 -1.840909,0.567626 l -1.4545457,0 c -0.7326314,0 -1.386422,-0.227094 -1.8409091,-0.567626 -0.4544871,-0.340533 -0.7045455,-0.774989 -0.7045455,-1.24878 l 0,-6.539062 c 0,-0.473791 0.2500584,-0.908247 0.7045455,-1.2487795 0.4544871,-0.3405325 1.1082777,-0.567627 1.8409091,-0.567627 z"
+     id="path3019"
      inkscape:connector-curvature="0" />
-  <path
-     style="fill:#ef555c;fill-rule:evenodd;fill-opacity:1"
-     inkscape:connector-curvature="0"
-     id="path3063"
-     d="m 4.570312,10.910156 c -0.753906,0 -1.386718,0.324219 -1.371093,0.726563 0.046875,1.050781 1.714843,1.453125 4.113281,1.453125 l 1.375,0 c 2.164062,0 3.949219,-0.300782 4.113281,-1.453125 0.05078,-0.375 -0.53125,-0.726563 -1.371093,-0.726563 z" />
+  <g
+     transform="matrix(0.93506495,0,0,0.7265625,0.9870129,5.09375)"
+     id="g3021"
+     style="fill:#ef555c;fill-opacity:1">
+    <path
+       d="M 5,8 C 4.4484,8 3.9877082,8.4489371 4,9 c 0.032187,1.442998 1.249741,2 3,2 l 1,0 c 1.5780187,0 2.880255,-0.41302 3,-2 0.03892,-0.5158337 -0.386,-1 -1,-1 z"
+       id="path3023"
+       style="fill:#ef555c;fill-opacity:1;fill-rule:evenodd"
+       inkscape:connector-curvature="0" />
+  </g>
 </svg>

--- a/Numix-Light/22x22/status/gpm-mouse-020.svg
+++ b/Numix-Light/22x22/status/gpm-mouse-020.svg
@@ -7,12 +7,12 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   viewBox="0 0 15 22"
-   width="15"
+   viewBox="0 0 22 22"
+   width="22"
    height="22"
    id="svg3003"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
+   inkscape:version="0.91 r"
    sodipodi:docname="gpm-mouse-020.svg">
   <metadata
      id="metadata3029">
@@ -22,6 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -36,31 +37,30 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview3025"
      showgrid="false"
-     inkscape:zoom="30.341309"
-     inkscape:cx="5.6413952"
-     inkscape:cy="16.011888"
+     inkscape:zoom="21.454545"
+     inkscape:cx="-3.2260746"
+     inkscape:cy="14.314442"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg3003" />
   <path
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-     d="M 6.5,3 C 5.2913682,3 4.1960802,3.3529398 3.375,3.96875 2.5539198,4.5845602 2,5.4900991 2,6.5 l 0,9 c 0,1.009901 0.5539198,1.91544 1.375,2.53125 C 4.1960802,18.64706 5.2913682,19 6.5,19 l 2,0 c 1.2086318,0 2.30392,-0.35294 3.125,-0.96875 C 12.44608,17.41544 13,16.509901 13,15.5 l 0,-9 C 13,5.4900991 12.44608,4.5845602 11.625,3.96875 10.80392,3.3529398 9.7086318,3 8.5,3 L 7.6875,3 7.4375,3 6.5,3 z m 0,1 0.53125,0 0,3.5 a 0.50005,0.50005 0 1 0 1,0 l 0,-3.5 L 8.5,4 C 9.5073682,4 10.40633,4.3125602 11.03125,4.78125 11.65617,5.2499398 12,5.8479009 12,6.5 l 0,9 c 0,0.652099 -0.34383,1.25006 -0.96875,1.71875 C 10.40633,17.68744 9.5073682,18 8.5,18 l -2,0 C 5.4926318,18 4.5936698,17.68744 3.96875,17.21875 3.3438302,16.75006 3,16.152099 3,15.5 l 0,-9 C 3,5.8479009 3.3438302,5.2499398 3.96875,4.78125 4.5936698,4.3125602 5.4926318,4 6.5,4 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     d="M 10,3 C 8.7913682,3 7.6960802,3.3529398 6.875,3.96875 6.0539198,4.5845602 5.5,5.4900991 5.5,6.5 l 0,9 c 0,1.009901 0.5539198,1.91544 1.375,2.53125 C 7.6960802,18.64706 8.7913682,19 10,19 l 2,0 c 1.208632,0 2.30392,-0.35294 3.125,-0.96875 C 15.94608,17.41544 16.5,16.509901 16.5,15.5 l 0,-9 C 16.5,5.4900991 15.94608,4.5845602 15.125,3.96875 14.30392,3.3529398 13.208632,3 12,3 L 11.1875,3 10.9375,3 10,3 Z m 0,1 0.53125,0 0,3.5 a 0.50005,0.50005 0 1 0 1,0 l 0,-3.5 L 12,4 c 1.007368,0 1.90633,0.3125602 2.53125,0.78125 C 15.15617,5.2499398 15.5,5.8479009 15.5,6.5 l 0,9 c 0,0.652099 -0.34383,1.25006 -0.96875,1.71875 C 13.90633,17.68744 13.007368,18 12,18 l -2,0 C 8.9926318,18 8.0936698,17.68744 7.46875,17.21875 6.8438302,16.75006 6.5,16.152099 6.5,15.5 l 0,-9 C 6.5,5.8479009 6.8438302,5.2499398 7.46875,4.78125 8.0936698,4.3125602 8.9926318,4 10,4 Z"
      id="path3019"
      inkscape:connector-curvature="0" />
   <g
-     transform="matrix(1.2857143,0,0,1,-2.1428572,7)"
+     transform="matrix(1.2857143,0,0,1,1.3571428,7)"
      id="g3021"
      style="fill:#ef555c;fill-opacity:1">
     <path
        d="M 5,8 C 4.4484,8 3.9877082,8.4489371 4,9 c 0.032187,1.442998 1.249741,2 3,2 l 1,0 c 1.5780187,0 2.880255,-0.41302 3,-2 0.03892,-0.5158337 -0.386,-1 -1,-1 z"
-       fill="#df382c"
-       fill-rule="evenodd"
        id="path3023"
-       style="fill:#ef555c;fill-opacity:1" />
+       style="fill:#ef555c;fill-opacity:1;fill-rule:evenodd"
+       inkscape:connector-curvature="0" />
   </g>
 </svg>

--- a/Numix-Light/24x24/status/gpm-mouse-020.svg
+++ b/Numix-Light/24x24/status/gpm-mouse-020.svg
@@ -7,24 +7,27 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 24 24"
    width="24"
    height="24"
-   viewBox="0 0 24 24"
-   id="svg2"
+   id="svg3003"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
+   inkscape:version="0.91 r"
    sodipodi:docname="gpm-mouse-020.svg">
   <metadata
-     id="metadata34">
+     id="metadata3029">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <defs
+     id="defs3027" />
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -34,80 +37,30 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
-     id="namedview32"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview3025"
      showgrid="false"
-     inkscape:zoom="27.812867"
-     inkscape:cx="7.3552517"
-     inkscape:cy="12.597544"
+     inkscape:zoom="15.170655"
+     inkscape:cx="10.277095"
+     inkscape:cy="14.91816"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg2" />
-  <defs
-     id="defs4">
-    <filter
-       id="0"
-       filterUnits="objectBoundingBox"
-       x="0"
-       y="0"
-       width="24"
-       height="24">
-      <feColorMatrix
-         type="matrix"
-         in="SourceGraphic"
-         values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0"
-         id="feColorMatrix7" />
-    </filter>
-    <mask
-       id="1">
-      <g
-         filter="url(#0)"
-         id="g10">
-        <rect
-           width="24"
-           height="24"
-           fill-opacity="0.302"
-           id="rect12" />
-      </g>
-    </mask>
-    <clipPath
-       id="2">
-      <rect
-         width="24"
-         height="24"
-         id="rect15" />
-    </clipPath>
-    <g
-       id="3"
-       clip-path="url(#2)">
-      <path
-         d="M 12.5 5.332682 L 12.5 8.666341 "
-         transform="matrix(1.6,0,0,1.090909,-8,-1.090909)"
-         fill="none"
-         stroke="#dcdcdc"
-         stroke-linecap="round"
-         stroke-width="2"
-         id="path18" />
-      <path
-         d="M -16.450846 8.249512 L -7.549154 8.249512 C -6.277995 8.249512 -5.250326 9.726562 -5.250326 11.550293 L -5.250326 13.449707 C -5.250326 15.273438 -6.277995 16.750488 -7.549154 16.750488 L -16.450846 16.750488 C -17.722005 16.750488 -18.749674 15.273438 -18.749674 13.449707 L -18.749674 11.550293 C -18.749674 9.726562 -17.722005 8.249512 -16.450846 8.249512 Z "
-         transform="matrix(0,-1.090909,1.6,0,-8,-1.090909)"
-         fill="none"
-         stroke="#dcdcdc"
-         stroke-linecap="round"
-         stroke-width="0.5"
-         id="path20" />
-    </g>
-  </defs>
+     inkscape:current-layer="svg3003" />
   <path
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1.32115650000000007;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-     d="M 10.40625,3.15625 C 8.5439697,3.15625 6.8409613,3.5334286 5.5625,4.1875 4.2840387,4.8415714 3.34375,5.8406017 3.34375,7.09375 l 0,9.8125 c 0,1.253148 0.9402887,2.252179 2.21875,2.90625 1.2784613,0.654071 2.9814698,1.03125 4.84375,1.03125 l 3.1875,0 c 1.86228,0 3.565289,-0.377179 4.84375,-1.03125 1.278461,-0.654071 2.21875,-1.653101 2.21875,-2.90625 l 0,-9.8125 C 20.65625,5.8406016 19.715961,4.8415714 18.4375,4.1875 17.159039,3.5334286 15.45603,3.15625 13.59375,3.15625 l -1.40625,0 -0.25,0 -1.53125,0 z m 0,1.3125 1,0 0,3.71875 a 0.66064431,0.66064431 0 1 0 1.3125,0 l 0,-3.71875 0.875,0 c 1.680688,0 3.214985,0.3767277 4.25,0.90625 1.035015,0.5295223 1.5,1.1593989 1.5,1.71875 l 0,9.8125 c 0,0.559351 -0.464985,1.189228 -1.5,1.71875 -1.035015,0.529522 -2.569312,0.90625 -4.25,0.90625 l -3.1875,0 c -1.680688,0 -3.2149849,-0.376728 -4.25,-0.90625 -1.0350151,-0.529522 -1.5,-1.159398 -1.5,-1.71875 l 0,-9.8125 c 0,-0.5593512 0.4649849,-1.1892277 1.5,-1.71875 1.0350151,-0.5295223 2.5693121,-0.90625 4.25,-0.90625 z"
-     id="path28"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     d="M 11,4 C 9.7913682,4 8.6960802,4.3529398 7.875,4.96875 7.0539198,5.5845602 6.5,6.4900991 6.5,7.5 l 0,9 c 0,1.009901 0.5539198,1.91544 1.375,2.53125 C 8.6960802,19.64706 9.7913682,20 11,20 l 2,0 c 1.208632,0 2.30392,-0.35294 3.125,-0.96875 C 16.94608,18.41544 17.5,17.509901 17.5,16.5 l 0,-9 C 17.5,6.4900991 16.94608,5.5845602 16.125,4.96875 15.30392,4.3529398 14.208632,4 13,4 L 12.1875,4 11.9375,4 11,4 Z m 0,1 0.53125,0 0,3.5 a 0.50005,0.50005 0 1 0 1,0 l 0,-3.5 L 13,5 c 1.007368,0 1.90633,0.3125602 2.53125,0.78125 C 16.15617,6.2499398 16.5,6.8479009 16.5,7.5 l 0,9 c 0,0.652099 -0.34383,1.25006 -0.96875,1.71875 C 14.90633,18.68744 14.007368,19 13,19 l -2,0 C 9.9926318,19 9.0936698,18.68744 8.46875,18.21875 7.8438302,17.75006 7.5,17.152099 7.5,16.5 l 0,-9 C 7.5,6.8479009 7.8438302,6.2499398 8.46875,5.78125 9.0936698,5.3125602 9.9926318,5 11,5 Z"
+     id="path3019"
      inkscape:connector-curvature="0" />
-  <path
-     style="fill:#ef555c;fill-rule:evenodd;fill-opacity:1"
-     inkscape:connector-curvature="0"
-     id="path30"
-     d="m 6.855469,16.363281 c -1.132813,0 -2.082031,0.488281 -2.054688,1.089844 0.066407,1.574219 2.570313,2.183594 6.171875,2.183594 l 2.054688,0 c 3.246094,0 5.925781,-0.449219 6.171875,-2.183594 0.08203,-0.5625 -0.792969,-1.089844 -2.054688,-1.089844 z" />
+  <g
+     transform="matrix(1.2857143,0,0,1,2.3571428,8)"
+     id="g3021"
+     style="fill:#ef555c;fill-opacity:1">
+    <path
+       d="M 5,8 C 4.4484,8 3.9877082,8.4489371 4,9 c 0.032187,1.442998 1.249741,2 3,2 l 1,0 c 1.5780187,0 2.880255,-0.41302 3,-2 0.03892,-0.5158337 -0.386,-1 -1,-1 z"
+       id="path3023"
+       style="fill:#ef555c;fill-opacity:1;fill-rule:evenodd"
+       inkscape:connector-curvature="0" />
+  </g>
 </svg>

--- a/Numix/16x16/status/gpm-mouse-020.svg
+++ b/Numix/16x16/status/gpm-mouse-020.svg
@@ -7,24 +7,27 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 16 16"
    width="16"
    height="16"
-   viewBox="0 0 16 16"
-   id="svg3035"
+   id="svg3003"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
+   inkscape:version="0.91 r"
    sodipodi:docname="gpm-mouse-020.svg">
   <metadata
-     id="metadata3067">
+     id="metadata3029">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <defs
+     id="defs3027" />
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -34,80 +37,30 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
-     id="namedview3065"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview3025"
      showgrid="false"
-     inkscape:zoom="29.5"
-     inkscape:cx="2.0177611"
-     inkscape:cy="5.2356201"
+     inkscape:zoom="15.170655"
+     inkscape:cx="-18.133016"
+     inkscape:cy="14.91816"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg3035" />
-  <defs
-     id="defs3037">
-    <filter
-       id="0"
-       filterUnits="objectBoundingBox"
-       x="0"
-       y="0"
-       width="16"
-       height="16">
-      <feColorMatrix
-         type="matrix"
-         in="SourceGraphic"
-         values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0"
-         id="feColorMatrix3040" />
-    </filter>
-    <mask
-       id="1">
-      <g
-         filter="url(#0)"
-         id="g3043">
-        <rect
-           width="16"
-           height="16"
-           fill-opacity="0.302"
-           id="rect3045" />
-      </g>
-    </mask>
-    <clipPath
-       id="2">
-      <rect
-         width="16"
-         height="16"
-         id="rect3048" />
-    </clipPath>
-    <g
-       id="3"
-       clip-path="url(#2)">
-      <path
-         d="M 12.5 5.334473 L 12.5 8.664551 "
-         transform="matrix(1.066667,0,0,0.727273,-5.333333,-0.727273)"
-         fill="none"
-         stroke="#dcdcdc"
-         stroke-linecap="round"
-         stroke-width="2"
-         id="path3051" />
-      <path
-         d="M -16.452637 8.248291 L -7.547363 8.248291 C -6.279785 8.248291 -5.248535 9.727783 -5.248535 11.551514 L -5.248535 13.448486 C -5.248535 15.272217 -6.279785 16.751709 -7.547363 16.751709 L -16.452637 16.751709 C -17.720215 16.751709 -18.751465 15.272217 -18.751465 13.448486 L -18.751465 11.551514 C -18.751465 9.727783 -17.720215 8.248291 -16.452637 8.248291 Z "
-         transform="matrix(0,-0.727273,1.066667,0,-5.333333,-0.727273)"
-         fill="none"
-         stroke="#dcdcdc"
-         stroke-linecap="round"
-         stroke-width="0.5"
-         id="path3053" />
-    </g>
-  </defs>
+     inkscape:current-layer="svg3003" />
   <path
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:0.88077134000000001;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-     d="m 6.9375,2.09375 c -1.2420574,0 -2.3665991,0.2519802 -3.21875,0.6875 -0.8521509,0.4355198 -1.5,1.1026273 -1.5,1.9375 l 0,6.5625 c 0,0.834873 0.6478491,1.50198 1.5,1.9375 0.8521509,0.43552 1.9766926,0.6875 3.21875,0.6875 l 2.125,0 c 1.242057,0 2.366599,-0.25198 3.21875,-0.6875 0.852151,-0.43552 1.5,-1.102627 1.5,-1.9375 l 0,-6.5625 c 0,-0.8348727 -0.647849,-1.5019802 -1.5,-1.9375 C 11.429099,2.3457302 10.304557,2.09375 9.0625,2.09375 l -0.9375,0 -0.125,0 -1.0625,0 z m 0,0.90625 0.65625,0 0,2.46875 a 0.44042971,0.44042971 0 0 0 0.875,0 L 8.46875,3 9.0625,3 c 1.121224,0 2.122658,0.2099337 2.8125,0.5625 0.689842,0.3525663 1.03125,0.7840909 1.03125,1.15625 l 0,6.5625 c 0,0.372159 -0.341408,0.803684 -1.03125,1.15625 C 11.185158,12.790066 10.183724,13 9.0625,13 l -2.125,0 C 5.8162756,13 4.8148416,12.790066 4.125,12.4375 3.4351584,12.084934 3.09375,11.653409 3.09375,11.28125 l 0,-6.5625 C 3.09375,4.3465909 3.4351584,3.9150663 4.125,3.5625 4.8148416,3.2099337 5.8162756,3 6.9375,3 z"
-     id="path3061"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     d="M 7.2727273,2.1875 C 6.3937223,2.1875 5.5971492,2.4439328 5,2.8913574 4.4028508,3.338782 4,3.996713 4,4.730469 l 0,6.539062 c 0,0.733756 0.4028508,1.391687 1,1.839112 0.5971492,0.447424 1.3937223,0.703857 2.2727273,0.703857 l 1.4545457,0 c 0.879005,0 1.675578,-0.256433 2.272727,-0.703857 0.597149,-0.447425 1,-1.105356 1,-1.839112 L 12,4.730469 C 12,3.996713 11.597149,3.338782 11,2.8913574 10.402851,2.4439328 9.606278,2.1875 8.727273,2.1875 l -0.590909,0 -0.181819,0 -0.6818177,0 z m 0,0.7265625 0.3863637,0 0,2.5429685 a 0.36367273,0.36331758 0 1 0 0.727273,0 l 0,-2.5429685 0.340909,0 c 0.732631,0 1.386422,0.2270945 1.840909,0.567627 0.454487,0.3405325 0.704545,0.7749885 0.704545,1.2487795 l 0,6.539062 c 0,0.473791 -0.250058,0.908247 -0.704545,1.24878 -0.454487,0.340532 -1.108278,0.567626 -1.840909,0.567626 l -1.4545457,0 c -0.7326314,0 -1.386422,-0.227094 -1.8409091,-0.567626 -0.4544871,-0.340533 -0.7045455,-0.774989 -0.7045455,-1.24878 l 0,-6.539062 c 0,-0.473791 0.2500584,-0.908247 0.7045455,-1.2487795 0.4544871,-0.3405325 1.1082777,-0.567627 1.8409091,-0.567627 z"
+     id="path3019"
      inkscape:connector-curvature="0" />
-  <path
-     style="fill:#ef555c;fill-rule:evenodd;fill-opacity:1"
-     inkscape:connector-curvature="0"
-     id="path3063"
-     d="m 4.570312,10.910156 c -0.753906,0 -1.386718,0.324219 -1.371093,0.726563 0.046875,1.050781 1.714843,1.453125 4.113281,1.453125 l 1.375,0 c 2.164062,0 3.949219,-0.300782 4.113281,-1.453125 0.05078,-0.375 -0.53125,-0.726563 -1.371093,-0.726563 z" />
+  <g
+     transform="matrix(0.93506495,0,0,0.7265625,0.9870129,5.09375)"
+     id="g3021"
+     style="fill:#ef555c;fill-opacity:1">
+    <path
+       d="M 5,8 C 4.4484,8 3.9877082,8.4489371 4,9 c 0.032187,1.442998 1.249741,2 3,2 l 1,0 c 1.5780187,0 2.880255,-0.41302 3,-2 0.03892,-0.5158337 -0.386,-1 -1,-1 z"
+       id="path3023"
+       style="fill:#ef555c;fill-opacity:1;fill-rule:evenodd"
+       inkscape:connector-curvature="0" />
+  </g>
 </svg>

--- a/Numix/22x22/status/gpm-mouse-020.svg
+++ b/Numix/22x22/status/gpm-mouse-020.svg
@@ -7,12 +7,12 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   viewBox="0 0 15 22"
-   width="15"
+   viewBox="0 0 22 22"
+   width="22"
    height="22"
    id="svg3003"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
+   inkscape:version="0.91 r"
    sodipodi:docname="gpm-mouse-020.svg">
   <metadata
      id="metadata3029">
@@ -22,6 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -36,31 +37,30 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview3025"
      showgrid="false"
-     inkscape:zoom="30.341309"
-     inkscape:cx="5.6413952"
-     inkscape:cy="16.011888"
+     inkscape:zoom="15.170655"
+     inkscape:cx="4.1532324"
+     inkscape:cy="14.91816"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg3003" />
   <path
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-     d="M 6.5,3 C 5.2913682,3 4.1960802,3.3529398 3.375,3.96875 2.5539198,4.5845602 2,5.4900991 2,6.5 l 0,9 c 0,1.009901 0.5539198,1.91544 1.375,2.53125 C 4.1960802,18.64706 5.2913682,19 6.5,19 l 2,0 c 1.2086318,0 2.30392,-0.35294 3.125,-0.96875 C 12.44608,17.41544 13,16.509901 13,15.5 l 0,-9 C 13,5.4900991 12.44608,4.5845602 11.625,3.96875 10.80392,3.3529398 9.7086318,3 8.5,3 L 7.6875,3 7.4375,3 6.5,3 z m 0,1 0.53125,0 0,3.5 a 0.50005,0.50005 0 1 0 1,0 l 0,-3.5 L 8.5,4 C 9.5073682,4 10.40633,4.3125602 11.03125,4.78125 11.65617,5.2499398 12,5.8479009 12,6.5 l 0,9 c 0,0.652099 -0.34383,1.25006 -0.96875,1.71875 C 10.40633,17.68744 9.5073682,18 8.5,18 l -2,0 C 5.4926318,18 4.5936698,17.68744 3.96875,17.21875 3.3438302,16.75006 3,16.152099 3,15.5 l 0,-9 C 3,5.8479009 3.3438302,5.2499398 3.96875,4.78125 4.5936698,4.3125602 5.4926318,4 6.5,4 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     d="M 10,3 C 8.7913682,3 7.6960802,3.3529398 6.875,3.96875 6.0539198,4.5845602 5.5,5.4900991 5.5,6.5 l 0,9 c 0,1.009901 0.5539198,1.91544 1.375,2.53125 C 7.6960802,18.64706 8.7913682,19 10,19 l 2,0 c 1.208632,0 2.30392,-0.35294 3.125,-0.96875 C 15.94608,17.41544 16.5,16.509901 16.5,15.5 l 0,-9 C 16.5,5.4900991 15.94608,4.5845602 15.125,3.96875 14.30392,3.3529398 13.208632,3 12,3 L 11.1875,3 10.9375,3 10,3 Z m 0,1 0.53125,0 0,3.5 a 0.50005,0.50005 0 1 0 1,0 l 0,-3.5 L 12,4 c 1.007368,0 1.90633,0.3125602 2.53125,0.78125 C 15.15617,5.2499398 15.5,5.8479009 15.5,6.5 l 0,9 c 0,0.652099 -0.34383,1.25006 -0.96875,1.71875 C 13.90633,17.68744 13.007368,18 12,18 l -2,0 C 8.9926318,18 8.0936698,17.68744 7.46875,17.21875 6.8438302,16.75006 6.5,16.152099 6.5,15.5 l 0,-9 C 6.5,5.8479009 6.8438302,5.2499398 7.46875,4.78125 8.0936698,4.3125602 8.9926318,4 10,4 Z"
      id="path3019"
      inkscape:connector-curvature="0" />
   <g
-     transform="matrix(1.2857143,0,0,1,-2.1428572,7)"
+     transform="matrix(1.2857143,0,0,1,1.3571428,7)"
      id="g3021"
      style="fill:#ef555c;fill-opacity:1">
     <path
        d="M 5,8 C 4.4484,8 3.9877082,8.4489371 4,9 c 0.032187,1.442998 1.249741,2 3,2 l 1,0 c 1.5780187,0 2.880255,-0.41302 3,-2 0.03892,-0.5158337 -0.386,-1 -1,-1 z"
-       fill="#df382c"
-       fill-rule="evenodd"
        id="path3023"
-       style="fill:#ef555c;fill-opacity:1" />
+       style="fill:#ef555c;fill-opacity:1;fill-rule:evenodd"
+       inkscape:connector-curvature="0" />
   </g>
 </svg>

--- a/Numix/24x24/status/gpm-mouse-020.svg
+++ b/Numix/24x24/status/gpm-mouse-020.svg
@@ -7,24 +7,27 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 24 24"
    width="24"
    height="24"
-   viewBox="0 0 24 24"
-   id="svg2"
+   id="svg3003"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
+   inkscape:version="0.91 r"
    sodipodi:docname="gpm-mouse-020.svg">
   <metadata
-     id="metadata34">
+     id="metadata3029">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <defs
+     id="defs3027" />
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -34,80 +37,30 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
-     id="namedview32"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview3025"
      showgrid="false"
-     inkscape:zoom="27.812867"
-     inkscape:cx="7.3552517"
-     inkscape:cy="12.597544"
+     inkscape:zoom="15.170655"
+     inkscape:cx="10.277095"
+     inkscape:cy="14.91816"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg2" />
-  <defs
-     id="defs4">
-    <filter
-       id="0"
-       filterUnits="objectBoundingBox"
-       x="0"
-       y="0"
-       width="24"
-       height="24">
-      <feColorMatrix
-         type="matrix"
-         in="SourceGraphic"
-         values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0"
-         id="feColorMatrix7" />
-    </filter>
-    <mask
-       id="1">
-      <g
-         filter="url(#0)"
-         id="g10">
-        <rect
-           width="24"
-           height="24"
-           fill-opacity="0.302"
-           id="rect12" />
-      </g>
-    </mask>
-    <clipPath
-       id="2">
-      <rect
-         width="24"
-         height="24"
-         id="rect15" />
-    </clipPath>
-    <g
-       id="3"
-       clip-path="url(#2)">
-      <path
-         d="M 12.5 5.332682 L 12.5 8.666341 "
-         transform="matrix(1.6,0,0,1.090909,-8,-1.090909)"
-         fill="none"
-         stroke="#dcdcdc"
-         stroke-linecap="round"
-         stroke-width="2"
-         id="path18" />
-      <path
-         d="M -16.450846 8.249512 L -7.549154 8.249512 C -6.277995 8.249512 -5.250326 9.726562 -5.250326 11.550293 L -5.250326 13.449707 C -5.250326 15.273438 -6.277995 16.750488 -7.549154 16.750488 L -16.450846 16.750488 C -17.722005 16.750488 -18.749674 15.273438 -18.749674 13.449707 L -18.749674 11.550293 C -18.749674 9.726562 -17.722005 8.249512 -16.450846 8.249512 Z "
-         transform="matrix(0,-1.090909,1.6,0,-8,-1.090909)"
-         fill="none"
-         stroke="#dcdcdc"
-         stroke-linecap="round"
-         stroke-width="0.5"
-         id="path20" />
-    </g>
-  </defs>
+     inkscape:current-layer="svg3003" />
   <path
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1.32115650000000007;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-     d="M 10.40625,3.15625 C 8.5439697,3.15625 6.8409613,3.5334286 5.5625,4.1875 4.2840387,4.8415714 3.34375,5.8406017 3.34375,7.09375 l 0,9.8125 c 0,1.253148 0.9402887,2.252179 2.21875,2.90625 1.2784613,0.654071 2.9814698,1.03125 4.84375,1.03125 l 3.1875,0 c 1.86228,0 3.565289,-0.377179 4.84375,-1.03125 1.278461,-0.654071 2.21875,-1.653101 2.21875,-2.90625 l 0,-9.8125 C 20.65625,5.8406016 19.715961,4.8415714 18.4375,4.1875 17.159039,3.5334286 15.45603,3.15625 13.59375,3.15625 l -1.40625,0 -0.25,0 -1.53125,0 z m 0,1.3125 1,0 0,3.71875 a 0.66064431,0.66064431 0 1 0 1.3125,0 l 0,-3.71875 0.875,0 c 1.680688,0 3.214985,0.3767277 4.25,0.90625 1.035015,0.5295223 1.5,1.1593989 1.5,1.71875 l 0,9.8125 c 0,0.559351 -0.464985,1.189228 -1.5,1.71875 -1.035015,0.529522 -2.569312,0.90625 -4.25,0.90625 l -3.1875,0 c -1.680688,0 -3.2149849,-0.376728 -4.25,-0.90625 -1.0350151,-0.529522 -1.5,-1.159398 -1.5,-1.71875 l 0,-9.8125 c 0,-0.5593512 0.4649849,-1.1892277 1.5,-1.71875 1.0350151,-0.5295223 2.5693121,-0.90625 4.25,-0.90625 z"
-     id="path28"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     d="M 11,4 C 9.7913682,4 8.6960802,4.3529398 7.875,4.96875 7.0539198,5.5845602 6.5,6.4900991 6.5,7.5 l 0,9 c 0,1.009901 0.5539198,1.91544 1.375,2.53125 C 8.6960802,19.64706 9.7913682,20 11,20 l 2,0 c 1.208632,0 2.30392,-0.35294 3.125,-0.96875 C 16.94608,18.41544 17.5,17.509901 17.5,16.5 l 0,-9 C 17.5,6.4900991 16.94608,5.5845602 16.125,4.96875 15.30392,4.3529398 14.208632,4 13,4 L 12.1875,4 11.9375,4 11,4 Z m 0,1 0.53125,0 0,3.5 a 0.50005,0.50005 0 1 0 1,0 l 0,-3.5 L 13,5 c 1.007368,0 1.90633,0.3125602 2.53125,0.78125 C 16.15617,6.2499398 16.5,6.8479009 16.5,7.5 l 0,9 c 0,0.652099 -0.34383,1.25006 -0.96875,1.71875 C 14.90633,18.68744 14.007368,19 13,19 l -2,0 C 9.9926318,19 9.0936698,18.68744 8.46875,18.21875 7.8438302,17.75006 7.5,17.152099 7.5,16.5 l 0,-9 C 7.5,6.8479009 7.8438302,6.2499398 8.46875,5.78125 9.0936698,5.3125602 9.9926318,5 11,5 Z"
+     id="path3019"
      inkscape:connector-curvature="0" />
-  <path
-     style="fill:#ef555c;fill-rule:evenodd;fill-opacity:1"
-     inkscape:connector-curvature="0"
-     id="path30"
-     d="m 6.855469,16.363281 c -1.132813,0 -2.082031,0.488281 -2.054688,1.089844 0.066407,1.574219 2.570313,2.183594 6.171875,2.183594 l 2.054688,0 c 3.246094,0 5.925781,-0.449219 6.171875,-2.183594 0.08203,-0.5625 -0.792969,-1.089844 -2.054688,-1.089844 z" />
+  <g
+     transform="matrix(1.2857143,0,0,1,2.3571428,8)"
+     id="g3021"
+     style="fill:#ef555c;fill-opacity:1">
+    <path
+       d="M 5,8 C 4.4484,8 3.9877082,8.4489371 4,9 c 0.032187,1.442998 1.249741,2 3,2 l 1,0 c 1.5780187,0 2.880255,-0.41302 3,-2 0.03892,-0.5158337 -0.386,-1 -1,-1 z"
+       id="path3023"
+       style="fill:#ef555c;fill-opacity:1;fill-rule:evenodd"
+       inkscape:connector-curvature="0" />
+  </g>
 </svg>


### PR DESCRIPTION
gpm-mouse-020.svg in 16x16/status 22x22/status and 24x24/status in Light and Dark theme was wrong (different size than all the other gpm-mouse-*.svg)