### PR TITLE
Btsync-gui status icons

### DIFF
--- a/Numix-Light/16x16/status/btsync-gui-0.svg
+++ b/Numix-Light/16x16/status/btsync-gui-0.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-0.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="15.170655"
+     inkscape:cx="-1.680296"
+     inkscape:cy="11.313813"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.25296443,0,0,0.25296443,1.922611,1.9241134)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,1.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/16x16/status/btsync-gui-1.svg
+++ b/Numix-Light/16x16/status/btsync-gui-1.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-1.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="15.170655"
+     inkscape:cx="-1.878046"
+     inkscape:cy="11.313813"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.2442826,0.06545533,-0.06545533,0.2442826,3.7033436,0.56009675)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,1.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/16x16/status/btsync-gui-10.svg
+++ b/Numix-Light/16x16/status/btsync-gui-10.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-10.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.21902844,0.12645612,-0.12645612,-0.21902844,16.299404,10.222719)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/16x16/status/btsync-gui-11.svg
+++ b/Numix-Light/16x16/status/btsync-gui-11.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-11.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.24427588,0.06545353,-0.06545353,-0.24427588,15.440761,12.294699)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/16x16/status/btsync-gui-2.svg
+++ b/Numix-Light/16x16/status/btsync-gui-2.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-2.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="55.25"
+     inkscape:cx="8"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.21903446,0.12645961,-0.12645961,0.21903446,5.7751679,-0.29908297)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/16x16/status/btsync-gui-3.svg
+++ b/Numix-Light/16x16/status/btsync-gui-3.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-3.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.17886541,0.17886541,-0.17886541,0.17886541,7.9989377,-0.59330552)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/16x16/status/btsync-gui-4.svg
+++ b/Numix-Light/16x16/status/btsync-gui-4.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-4.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+  <g
+     transform="matrix(0.12645612,0.21902844,-0.21902844,0.12645612,10.222719,-0.29940434)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/Numix-Light/16x16/status/btsync-gui-5.svg
+++ b/Numix-Light/16x16/status/btsync-gui-5.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-5.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.06545352,0.24427588,-0.24427588,0.06545352,12.294699,0.55923957)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/16x16/status/btsync-gui-6.svg
+++ b/Numix-Light/16x16/status/btsync-gui-6.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-6.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0,0.25295652,-0.25295652,0,14.075697,1.922801)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/16x16/status/btsync-gui-7.svg
+++ b/Numix-Light/16x16/status/btsync-gui-7.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-7.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.06545353,0.24427588,-0.24427588,-0.06545353,15.439699,3.7034618)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/16x16/status/btsync-gui-8.svg
+++ b/Numix-Light/16x16/status/btsync-gui-8.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-8.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.12645613,0.21902843,-0.21902843,-0.12645613,16.298855,5.7752292)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/16x16/status/btsync-gui-9.svg
+++ b/Numix-Light/16x16/status/btsync-gui-9.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-9.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.17886541,0.17886541,-0.17886541,-0.17886541,16.593306,7.9989377)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/16x16/status/btsync-gui-connecting.svg
+++ b/Numix-Light/16x16/status/btsync-gui-connecting.svg
@@ -1,0 +1,1 @@
+btsync-gui-0.svg

--- a/Numix-Light/16x16/status/btsync-gui-disconnected.svg
+++ b/Numix-Light/16x16/status/btsync-gui-disconnected.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-disconnected.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="15.170655"
+     inkscape:cx="-14.072642"
+     inkscape:cy="11.313813"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.25295652,0,0,0.25295652,1.922801,1.9243034)"
+     id="g3628"
+     style="opacity:0.4;fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/16x16/status/btsync-gui-paused.svg
+++ b/Numix-Light/16x16/status/btsync-gui-paused.svg
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-paused.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="15.170655"
+     inkscape:cx="16.882693"
+     inkscape:cy="4.7628212"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.25295652,0,0,0.25295652,1.9228009,1.9243033)"
+     id="g3628"
+     style="opacity:0.4;fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m 11,3 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m -3.75,2 3,0 A 1.0001,1.0001 0 0 1 11,5.3417969 1.0001,1.0001 0 0 1 11.75,5 l 3,0 a 1.0001,1.0001 0 0 1 1,1 l 0,1.9140625 C 15.95092,8.1962057 16.135328,8.4915993 16.28125,8.8125 L 17.5,8.34375 l -1,3.46875 -0.75,-0.417969 0,1.408203 0.59375,0.228516 C 16.187037,13.407129 15.979607,13.749392 15.75,14.074219 L 15.75,16 a 1.0001,1.0001 0 0 1 -1,1 l -3,0 A 1.0001,1.0001 0 0 1 11,16.660156 1.0001,1.0001 0 0 1 10.25,17 l -3,0 a 1.0001,1.0001 0 0 1 -1,-1 l 0,-1.939453 C 6.0482982,13.775425 5.8625527,13.47858 5.71875,13.15625 L 4.5,13.59375 l 1,-3.375 0.75,0.402344 0,-1.3925784 L 5.65625,9 C 5.8095088,8.6183946 6.0179158,8.2704044 6.25,7.9394531 L 6.25,6 a 1.0001,1.0001 0 0 1 1,-1 z m 5.5,2.75 0,6.492188 c 0.37158,-0.181025 0.708486,-0.420122 1,-0.707032 l 0,-3.253906 L 13.1875,9.96875 13.75,9.75 l 0,-1.2851562 C 13.458677,8.1743867 13.124004,7.9308058 12.75,7.75 Z m -3.5,0.00977 c -0.3730305,0.185668 -0.7082387,0.4313045 -1,0.7226519 l 0,3.2148441 L 8.8125,12 8.25,12.21875 l 0,1.292969 c 0.2907393,0.293992 0.626965,0.539867 1,0.726562 l 0,-6.4785154 z"
+       transform="matrix(2.875,0,0,2.875,-7.6003215,-7.6062606)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+  <g
+     id="g3179"
+     transform="matrix(0.6630485,0,0,0.6630485,0.7541,-0.8298046)"
+     style="fill:#353535;fill-opacity:1" />
+  <g
+     id="g3037-6"
+     transform="matrix(0.72724999,0,0,0.72724999,0.18206253,2.5006659e-4)"
+     style="fill:#353535;fill-opacity:1">
+    <rect
+       y="6"
+       x="11.5"
+       height="10"
+       width="3"
+       id="rect3017-1"
+       style="fill:#353535;fill-opacity:1;stroke:none" />
+    <rect
+       y="6"
+       x="7"
+       height="10"
+       width="3"
+       id="rect3017-7-4"
+       style="fill:#353535;fill-opacity:1;stroke:none" />
+  </g>
+</svg>

--- a/Numix-Light/22x22/status/btsync-gui-0.svg
+++ b/Numix-Light/22x22/status/btsync-gui-0.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-0.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="15.170655"
+     inkscape:cx="9.4596317"
+     inkscape:cy="11.313813"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.34782609,0,0,0.34782609,2.6435901,2.6456559)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/22x22/status/btsync-gui-1.svg
+++ b/Numix-Light/22x22/status/btsync-gui-1.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-1.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="15.170655"
+     inkscape:cx="9.2618817"
+     inkscape:cy="11.313813"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.33588983,0.09000141,-0.09000141,0.33588983,5.0920754,0.77009492)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/22x22/status/btsync-gui-10.svg
+++ b/Numix-Light/22x22/status/btsync-gui-10.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-10.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="0.39303325"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.30117351,0.1738826,-0.1738826,-0.30117351,22.412037,14.056333)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/22x22/status/btsync-gui-11.svg
+++ b/Numix-Light/22x22/status/btsync-gui-11.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-11.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="0.39303325"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.33588983,0.09000141,-0.09000141,-0.33588983,21.231365,16.905471)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/22x22/status/btsync-gui-2.svg
+++ b/Numix-Light/22x22/status/btsync-gui-2.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-2.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="0.39303325"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.30117351,0.17388261,-0.17388261,0.30117351,7.9408444,-0.41128175)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/22x22/status/btsync-gui-3.svg
+++ b/Numix-Light/22x22/status/btsync-gui-3.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-3.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="0.39303325"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.24594762,0.24594762,-0.24594762,0.24594762,10.99854,-0.81616437)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/22x22/status/btsync-gui-4.svg
+++ b/Numix-Light/22x22/status/btsync-gui-4.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-4.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="0.39303325"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+  <g
+     transform="matrix(0.1738826,0.30117351,-0.30117351,0.1738826,14.056334,-0.41203741)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/Numix-Light/22x22/status/btsync-gui-5.svg
+++ b/Numix-Light/22x22/status/btsync-gui-5.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-5.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="0.39303325"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.0900014,0.33588983,-0.33588983,0.0900014,16.905395,0.76871107)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/22x22/status/btsync-gui-6.svg
+++ b/Numix-Light/22x22/status/btsync-gui-6.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-6.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="0.39303325"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0,0.34782609,-0.34782609,0,19.354344,2.6434153)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/22x22/status/btsync-gui-7.svg
+++ b/Numix-Light/22x22/status/btsync-gui-7.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-7.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="0.39303325"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.09000141,0.33588983,-0.33588983,-0.09000141,21.229905,5.0921518)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/22x22/status/btsync-gui-8.svg
+++ b/Numix-Light/22x22/status/btsync-gui-8.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-8.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="0.39303325"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.17388261,0.30117351,-0.30117351,-0.17388261,22.411282,7.9408446)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/22x22/status/btsync-gui-9.svg
+++ b/Numix-Light/22x22/status/btsync-gui-9.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-9.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="0.39303325"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.24594762,0.24594762,-0.24594762,-0.24594762,22.816164,10.998374)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/22x22/status/btsync-gui-connecting.svg
+++ b/Numix-Light/22x22/status/btsync-gui-connecting.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-0.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="15.170655"
+     inkscape:cx="9.4596317"
+     inkscape:cy="11.313813"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.34782609,0,0,0.34782609,2.6435901,2.6456559)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/22x22/status/btsync-gui-disconnected.svg
+++ b/Numix-Light/22x22/status/btsync-gui-disconnected.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-disconnected.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="15.170655"
+     inkscape:cx="-2.9327139"
+     inkscape:cy="11.313813"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.34782609,0,0,0.34782609,2.6435901,2.6456559)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1;opacity:0.4">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/22x22/status/btsync-gui-paused.svg
+++ b/Numix-Light/22x22/status/btsync-gui-paused.svg
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-paused.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="15.170655"
+     inkscape:cx="-3.460047"
+     inkscape:cy="16.587152"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.34782609,0,0,0.34782609,2.6435901,2.6456559)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1;opacity:0.4">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="M 11 3 C 6.581565 3 3 6.581565 3 11 C 3 15.418435 6.581565 19 11 19 C 15.418435 19 19 15.418435 19 11 C 19 6.581565 15.418435 3 11 3 z M 7.25 5 L 10.25 5 A 1.0001 1.0001 0 0 1 11 5.3417969 A 1.0001 1.0001 0 0 1 11.75 5 L 14.75 5 A 1.0001 1.0001 0 0 1 15.75 6 L 15.75 7.9140625 C 15.95092 8.1962057 16.135328 8.4915993 16.28125 8.8125 L 17.5 8.34375 L 16.5 11.8125 L 15.75 11.394531 L 15.75 12.802734 L 16.34375 13.03125 C 16.187037 13.407129 15.979607 13.749392 15.75 14.074219 L 15.75 16 A 1.0001 1.0001 0 0 1 14.75 17 L 11.75 17 A 1.0001 1.0001 0 0 1 11 16.660156 A 1.0001 1.0001 0 0 1 10.25 17 L 7.25 17 A 1.0001 1.0001 0 0 1 6.25 16 L 6.25 14.060547 C 6.0482982 13.775425 5.8625527 13.47858 5.71875 13.15625 L 4.5 13.59375 L 5.5 10.21875 L 6.25 10.621094 L 6.25 9.2285156 L 5.65625 9 C 5.8095088 8.6183946 6.0179158 8.2704044 6.25 7.9394531 L 6.25 6 A 1.0001 1.0001 0 0 1 7.25 5 z M 12.75 7.75 L 12.75 14.242188 C 13.12158 14.061163 13.458486 13.822066 13.75 13.535156 L 13.75 10.28125 L 13.1875 9.96875 L 13.75 9.75 L 13.75 8.4648438 C 13.458677 8.1743867 13.124004 7.9308058 12.75 7.75 z M 9.25 7.7597656 C 8.8769695 7.945438 8.5417613 8.1910745 8.25 8.4824219 L 8.25 11.697266 L 8.8125 12 L 8.25 12.21875 L 8.25 13.511719 C 8.5407393 13.805711 8.876965 14.051586 9.25 14.238281 L 9.25 7.7597656 z "
+       transform="matrix(2.875,0,0,2.875,-7.6003215,-7.6062606)"
+       id="path3630" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+  <g
+     id="g3179"
+     transform="matrix(0.6630485,0,0,0.6630485,0.7541,-0.8298046)"
+     style="fill:#353535;fill-opacity:1" />
+  <g
+     id="g3037-6"
+     transform="translate(0.25,0)"
+     style="fill:#353535;fill-opacity:1">
+    <rect
+       y="6"
+       x="11.5"
+       height="10"
+       width="3"
+       id="rect3017-1"
+       style="fill:#353535;fill-opacity:1;stroke:none" />
+    <rect
+       y="6"
+       x="7"
+       height="10"
+       width="3"
+       id="rect3017-7-4"
+       style="fill:#353535;fill-opacity:1;stroke:none" />
+  </g>
+</svg>

--- a/Numix-Light/24x24/status/btsync-gui-0.svg
+++ b/Numix-Light/24x24/status/btsync-gui-0.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-0.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="15.170655"
+     inkscape:cx="-1.680296"
+     inkscape:cy="11.313813"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.34782609,0,0,0.34782609,3.6435901,3.6456559)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/24x24/status/btsync-gui-1.svg
+++ b/Numix-Light/24x24/status/btsync-gui-1.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-1.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="15.170655"
+     inkscape:cx="-1.878046"
+     inkscape:cy="11.313813"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.33588983,0.09000141,-0.09000141,0.33588983,6.0920753,1.7700949)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/24x24/status/btsync-gui-10.svg
+++ b/Numix-Light/24x24/status/btsync-gui-10.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-10.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.30117351,0.1738826,-0.1738826,-0.30117351,23.412037,15.056334)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/24x24/status/btsync-gui-11.svg
+++ b/Numix-Light/24x24/status/btsync-gui-11.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-11.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.33588983,0.09000141,-0.09000141,-0.33588983,22.231365,17.905395)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/24x24/status/btsync-gui-2.svg
+++ b/Numix-Light/24x24/status/btsync-gui-2.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-2.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.30117351,0.17388261,-0.17388261,0.30117351,8.9408444,0.58871831)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/24x24/status/btsync-gui-3.svg
+++ b/Numix-Light/24x24/status/btsync-gui-3.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-3.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.24594762,0.24594762,-0.24594762,0.24594762,11.998539,0.18383587)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/24x24/status/btsync-gui-4.svg
+++ b/Numix-Light/24x24/status/btsync-gui-4.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-4.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+  <g
+     transform="matrix(0.1738826,0.30117351,-0.30117351,0.1738826,15.056334,0.58796254)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/Numix-Light/24x24/status/btsync-gui-5.svg
+++ b/Numix-Light/24x24/status/btsync-gui-5.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-5.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.0900014,0.33588983,-0.33588983,0.0900014,17.905395,1.7686348)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/24x24/status/btsync-gui-6.svg
+++ b/Numix-Light/24x24/status/btsync-gui-6.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-6.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0,0.34782609,-0.34782609,0,20.354344,3.6435901)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/24x24/status/btsync-gui-7.svg
+++ b/Numix-Light/24x24/status/btsync-gui-7.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-7.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.09000141,0.33588983,-0.33588983,-0.09000141,22.229905,6.0920753)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/24x24/status/btsync-gui-8.svg
+++ b/Numix-Light/24x24/status/btsync-gui-8.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-8.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.17388261,0.30117351,-0.30117351,-0.17388261,23.411282,8.9408444)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/24x24/status/btsync-gui-9.svg
+++ b/Numix-Light/24x24/status/btsync-gui-9.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-9.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.24594762,0.24594762,-0.24594762,-0.24594762,23.816164,11.998539)"
+     id="g3628"
+     style="fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/24x24/status/btsync-gui-connecting.svg
+++ b/Numix-Light/24x24/status/btsync-gui-connecting.svg
@@ -1,0 +1,1 @@
+btsync-gui-0.svg

--- a/Numix-Light/24x24/status/btsync-gui-disconnected.svg
+++ b/Numix-Light/24x24/status/btsync-gui-disconnected.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-disconnected.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="15.170655"
+     inkscape:cx="-14.072642"
+     inkscape:cy="11.313813"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.34782609,0,0,0.34782609,3.6435901,3.6456559)"
+     id="g3628"
+     style="opacity:0.4;fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix-Light/24x24/status/btsync-gui-paused.svg
+++ b/Numix-Light/24x24/status/btsync-gui-paused.svg
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-paused.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="15.170655"
+     inkscape:cx="-14.599975"
+     inkscape:cy="16.587152"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.34782609,0,0,0.34782609,3.6435901,3.6456557)"
+     id="g3628"
+     style="opacity:0.4;fill:#353535;fill-opacity:1">
+    <path
+       style="fill:#353535;fill-opacity:1"
+       d="m 11,3 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m -3.75,2 3,0 A 1.0001,1.0001 0 0 1 11,5.3417969 1.0001,1.0001 0 0 1 11.75,5 l 3,0 a 1.0001,1.0001 0 0 1 1,1 l 0,1.9140625 C 15.95092,8.1962057 16.135328,8.4915993 16.28125,8.8125 L 17.5,8.34375 l -1,3.46875 -0.75,-0.417969 0,1.408203 0.59375,0.228516 C 16.187037,13.407129 15.979607,13.749392 15.75,14.074219 L 15.75,16 a 1.0001,1.0001 0 0 1 -1,1 l -3,0 A 1.0001,1.0001 0 0 1 11,16.660156 1.0001,1.0001 0 0 1 10.25,17 l -3,0 a 1.0001,1.0001 0 0 1 -1,-1 l 0,-1.939453 C 6.0482982,13.775425 5.8625527,13.47858 5.71875,13.15625 L 4.5,13.59375 l 1,-3.375 0.75,0.402344 0,-1.3925784 L 5.65625,9 C 5.8095088,8.6183946 6.0179158,8.2704044 6.25,7.9394531 L 6.25,6 a 1.0001,1.0001 0 0 1 1,-1 z m 5.5,2.75 0,6.492188 c 0.37158,-0.181025 0.708486,-0.420122 1,-0.707032 l 0,-3.253906 L 13.1875,9.96875 13.75,9.75 l 0,-1.2851562 C 13.458677,8.1743867 13.124004,7.9308058 12.75,7.75 Z m -3.5,0.00977 c -0.3730305,0.185668 -0.7082387,0.4313045 -1,0.7226519 l 0,3.2148441 L 8.8125,12 8.25,12.21875 l 0,1.292969 c 0.2907393,0.293992 0.626965,0.539867 1,0.726562 l 0,-6.4785154 z"
+       transform="matrix(2.875,0,0,2.875,-7.6003215,-7.6062606)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-36.411065,8.9950009)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+  <g
+     id="g3179"
+     transform="matrix(0.6630485,0,0,0.6630485,1.7541,0.1701952)"
+     style="fill:#353535;fill-opacity:1" />
+  <g
+     id="g3037-6"
+     transform="translate(1.25,0.9999998)"
+     style="fill:#353535;fill-opacity:1">
+    <rect
+       y="6"
+       x="11.5"
+       height="10"
+       width="3"
+       id="rect3017-1"
+       style="fill:#353535;fill-opacity:1;stroke:none" />
+    <rect
+       y="6"
+       x="7"
+       height="10"
+       width="3"
+       id="rect3017-7-4"
+       style="fill:#353535;fill-opacity:1;stroke:none" />
+  </g>
+</svg>

--- a/Numix/16x16/status/btsync-gui-0.svg
+++ b/Numix/16x16/status/btsync-gui-0.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-0.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="15.170655"
+     inkscape:cx="-1.680296"
+     inkscape:cy="11.313813"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.25296443,0,0,0.25296443,1.922611,1.9241134)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,1.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/16x16/status/btsync-gui-1.svg
+++ b/Numix/16x16/status/btsync-gui-1.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-1.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="15.170655"
+     inkscape:cx="-1.878046"
+     inkscape:cy="11.313813"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.2442826,0.06545533,-0.06545533,0.2442826,3.7033436,0.56009675)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,1.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/16x16/status/btsync-gui-10.svg
+++ b/Numix/16x16/status/btsync-gui-10.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-10.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.21902844,0.12645612,-0.12645612,-0.21902844,16.299404,10.222719)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/16x16/status/btsync-gui-11.svg
+++ b/Numix/16x16/status/btsync-gui-11.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-11.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.24427588,0.06545353,-0.06545353,-0.24427588,15.440761,12.294699)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/16x16/status/btsync-gui-2.svg
+++ b/Numix/16x16/status/btsync-gui-2.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-2.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="55.25"
+     inkscape:cx="8"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.21903446,0.12645961,-0.12645961,0.21903446,5.7751679,-0.29908297)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/16x16/status/btsync-gui-3.svg
+++ b/Numix/16x16/status/btsync-gui-3.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-3.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.17886541,0.17886541,-0.17886541,0.17886541,7.9989377,-0.59330552)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/16x16/status/btsync-gui-4.svg
+++ b/Numix/16x16/status/btsync-gui-4.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-4.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+  <g
+     transform="matrix(0.12645612,0.21902844,-0.21902844,0.12645612,10.222719,-0.29940434)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/Numix/16x16/status/btsync-gui-5.svg
+++ b/Numix/16x16/status/btsync-gui-5.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-5.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.06545352,0.24427588,-0.24427588,0.06545352,12.294699,0.55923957)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/16x16/status/btsync-gui-6.svg
+++ b/Numix/16x16/status/btsync-gui-6.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-6.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0,0.25295652,-0.25295652,0,14.075697,1.922801)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/16x16/status/btsync-gui-7.svg
+++ b/Numix/16x16/status/btsync-gui-7.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-7.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.06545353,0.24427588,-0.24427588,-0.06545353,15.439699,3.7034618)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/16x16/status/btsync-gui-8.svg
+++ b/Numix/16x16/status/btsync-gui-8.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-8.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.12645613,0.21902843,-0.21902843,-0.12645613,16.298855,5.7752292)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/16x16/status/btsync-gui-9.svg
+++ b/Numix/16x16/status/btsync-gui-9.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-9.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.17886541,0.17886541,-0.17886541,-0.17886541,16.593306,7.9989377)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/16x16/status/btsync-gui-connecting.svg
+++ b/Numix/16x16/status/btsync-gui-connecting.svg
@@ -1,0 +1,1 @@
+btsync-gui-0.svg

--- a/Numix/16x16/status/btsync-gui-disconnected.svg
+++ b/Numix/16x16/status/btsync-gui-disconnected.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-disconnected.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="15.170655"
+     inkscape:cx="-14.072642"
+     inkscape:cy="11.313813"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.25295652,0,0,0.25295652,1.922801,1.9243034)"
+     id="g3628"
+     style="opacity:0.4;fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/16x16/status/btsync-gui-paused.svg
+++ b/Numix/16x16/status/btsync-gui-paused.svg
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="16"
+   height="16"
+   sodipodi:docname="btsync-gui-paused.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="15.170655"
+     inkscape:cx="16.882693"
+     inkscape:cy="4.7628212"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.25295652,0,0,0.25295652,1.9228009,1.9243033)"
+     id="g3628"
+     style="opacity:0.4;fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m 11,3 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m -3.75,2 3,0 A 1.0001,1.0001 0 0 1 11,5.3417969 1.0001,1.0001 0 0 1 11.75,5 l 3,0 a 1.0001,1.0001 0 0 1 1,1 l 0,1.9140625 C 15.95092,8.1962057 16.135328,8.4915993 16.28125,8.8125 L 17.5,8.34375 l -1,3.46875 -0.75,-0.417969 0,1.408203 0.59375,0.228516 C 16.187037,13.407129 15.979607,13.749392 15.75,14.074219 L 15.75,16 a 1.0001,1.0001 0 0 1 -1,1 l -3,0 A 1.0001,1.0001 0 0 1 11,16.660156 1.0001,1.0001 0 0 1 10.25,17 l -3,0 a 1.0001,1.0001 0 0 1 -1,-1 l 0,-1.939453 C 6.0482982,13.775425 5.8625527,13.47858 5.71875,13.15625 L 4.5,13.59375 l 1,-3.375 0.75,0.402344 0,-1.3925784 L 5.65625,9 C 5.8095088,8.6183946 6.0179158,8.2704044 6.25,7.9394531 L 6.25,6 a 1.0001,1.0001 0 0 1 1,-1 z m 5.5,2.75 0,6.492188 c 0.37158,-0.181025 0.708486,-0.420122 1,-0.707032 l 0,-3.253906 L 13.1875,9.96875 13.75,9.75 l 0,-1.2851562 C 13.458677,8.1743867 13.124004,7.9308058 12.75,7.75 Z m -3.5,0.00977 c -0.3730305,0.185668 -0.7082387,0.4313045 -1,0.7226519 l 0,3.2148441 L 8.8125,12 8.25,12.21875 l 0,1.292969 c 0.2907393,0.293992 0.626965,0.539867 1,0.726562 l 0,-6.4785154 z"
+       transform="matrix(2.875,0,0,2.875,-7.6003215,-7.6062606)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+  <g
+     id="g3179"
+     transform="matrix(0.6630485,0,0,0.6630485,0.7541,-0.8298046)"
+     style="fill:#ececec;fill-opacity:1" />
+  <g
+     id="g3037-6"
+     transform="matrix(0.72724999,0,0,0.72724999,0.18206253,2.5006659e-4)"
+     style="fill:#ececec;fill-opacity:1">
+    <rect
+       y="6"
+       x="11.5"
+       height="10"
+       width="3"
+       id="rect3017-1"
+       style="fill:#ececec;fill-opacity:1;stroke:none" />
+    <rect
+       y="6"
+       x="7"
+       height="10"
+       width="3"
+       id="rect3017-7-4"
+       style="fill:#ececec;fill-opacity:1;stroke:none" />
+  </g>
+</svg>

--- a/Numix/22x22/status/btsync-gui-0.svg
+++ b/Numix/22x22/status/btsync-gui-0.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-0.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="15.170655"
+     inkscape:cx="9.4596317"
+     inkscape:cy="11.313813"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.34782609,0,0,0.34782609,2.6435901,2.6456559)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/22x22/status/btsync-gui-1.svg
+++ b/Numix/22x22/status/btsync-gui-1.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-1.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="15.170655"
+     inkscape:cx="9.2618817"
+     inkscape:cy="11.313813"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.33588983,0.09000141,-0.09000141,0.33588983,5.0920754,0.77009492)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/22x22/status/btsync-gui-10.svg
+++ b/Numix/22x22/status/btsync-gui-10.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-10.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="0.39303325"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.30117351,0.1738826,-0.1738826,-0.30117351,22.412037,14.056333)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/22x22/status/btsync-gui-11.svg
+++ b/Numix/22x22/status/btsync-gui-11.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-11.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="0.39303325"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.33588983,0.09000141,-0.09000141,-0.33588983,21.231365,16.905471)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/22x22/status/btsync-gui-2.svg
+++ b/Numix/22x22/status/btsync-gui-2.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-2.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="0.39303325"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.30117351,0.17388261,-0.17388261,0.30117351,7.9408444,-0.41128175)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/22x22/status/btsync-gui-3.svg
+++ b/Numix/22x22/status/btsync-gui-3.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-3.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="0.39303325"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.24594762,0.24594762,-0.24594762,0.24594762,10.99854,-0.81616437)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/22x22/status/btsync-gui-4.svg
+++ b/Numix/22x22/status/btsync-gui-4.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-4.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="0.39303325"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+  <g
+     transform="matrix(0.1738826,0.30117351,-0.30117351,0.1738826,14.056334,-0.41203741)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/Numix/22x22/status/btsync-gui-5.svg
+++ b/Numix/22x22/status/btsync-gui-5.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-5.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="0.39303325"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.0900014,0.33588983,-0.33588983,0.0900014,16.905395,0.76871107)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/22x22/status/btsync-gui-6.svg
+++ b/Numix/22x22/status/btsync-gui-6.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-6.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="0.39303325"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0,0.34782609,-0.34782609,0,19.354344,2.6434153)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/22x22/status/btsync-gui-7.svg
+++ b/Numix/22x22/status/btsync-gui-7.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-7.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="0.39303325"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.09000141,0.33588983,-0.33588983,-0.09000141,21.229905,5.0921518)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/22x22/status/btsync-gui-8.svg
+++ b/Numix/22x22/status/btsync-gui-8.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-8.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="0.39303325"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.17388261,0.30117351,-0.30117351,-0.17388261,22.411282,7.9408446)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/22x22/status/btsync-gui-9.svg
+++ b/Numix/22x22/status/btsync-gui-9.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-9.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="0.39303325"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.24594762,0.24594762,-0.24594762,-0.24594762,22.816164,10.998374)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/22x22/status/btsync-gui-connecting.svg
+++ b/Numix/22x22/status/btsync-gui-connecting.svg
@@ -1,0 +1,1 @@
+btsync-gui-0.svg

--- a/Numix/22x22/status/btsync-gui-disconnected.svg
+++ b/Numix/22x22/status/btsync-gui-disconnected.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-disconnected.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="15.170655"
+     inkscape:cx="-2.9327139"
+     inkscape:cy="11.313813"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.34782609,0,0,0.34782609,2.6435901,2.6456559)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1;opacity:0.4">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/22x22/status/btsync-gui-paused.svg
+++ b/Numix/22x22/status/btsync-gui-paused.svg
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="22"
+   height="22"
+   sodipodi:docname="btsync-gui-paused.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="15.170655"
+     inkscape:cx="-3.460047"
+     inkscape:cy="16.587152"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.34782609,0,0,0.34782609,2.6435901,2.6456559)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1;opacity:0.4">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="M 11 3 C 6.581565 3 3 6.581565 3 11 C 3 15.418435 6.581565 19 11 19 C 15.418435 19 19 15.418435 19 11 C 19 6.581565 15.418435 3 11 3 z M 7.25 5 L 10.25 5 A 1.0001 1.0001 0 0 1 11 5.3417969 A 1.0001 1.0001 0 0 1 11.75 5 L 14.75 5 A 1.0001 1.0001 0 0 1 15.75 6 L 15.75 7.9140625 C 15.95092 8.1962057 16.135328 8.4915993 16.28125 8.8125 L 17.5 8.34375 L 16.5 11.8125 L 15.75 11.394531 L 15.75 12.802734 L 16.34375 13.03125 C 16.187037 13.407129 15.979607 13.749392 15.75 14.074219 L 15.75 16 A 1.0001 1.0001 0 0 1 14.75 17 L 11.75 17 A 1.0001 1.0001 0 0 1 11 16.660156 A 1.0001 1.0001 0 0 1 10.25 17 L 7.25 17 A 1.0001 1.0001 0 0 1 6.25 16 L 6.25 14.060547 C 6.0482982 13.775425 5.8625527 13.47858 5.71875 13.15625 L 4.5 13.59375 L 5.5 10.21875 L 6.25 10.621094 L 6.25 9.2285156 L 5.65625 9 C 5.8095088 8.6183946 6.0179158 8.2704044 6.25 7.9394531 L 6.25 6 A 1.0001 1.0001 0 0 1 7.25 5 z M 12.75 7.75 L 12.75 14.242188 C 13.12158 14.061163 13.458486 13.822066 13.75 13.535156 L 13.75 10.28125 L 13.1875 9.96875 L 13.75 9.75 L 13.75 8.4648438 C 13.458677 8.1743867 13.124004 7.9308058 12.75 7.75 z M 9.25 7.7597656 C 8.8769695 7.945438 8.5417613 8.1910745 8.25 8.4824219 L 8.25 11.697266 L 8.8125 12 L 8.25 12.21875 L 8.25 13.511719 C 8.5407393 13.805711 8.876965 14.051586 9.25 14.238281 L 9.25 7.7597656 z "
+       transform="matrix(2.875,0,0,2.875,-7.6003215,-7.6062606)"
+       id="path3630" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,7.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+  <g
+     id="g3179"
+     transform="matrix(0.6630485,0,0,0.6630485,0.7541,-0.8298046)"
+     style="fill:#ececec;fill-opacity:1" />
+  <g
+     id="g3037-6"
+     transform="translate(0.25,0)"
+     style="fill:#ececec;fill-opacity:1">
+    <rect
+       y="6"
+       x="11.5"
+       height="10"
+       width="3"
+       id="rect3017-1"
+       style="fill:#ececec;fill-opacity:1;stroke:none" />
+    <rect
+       y="6"
+       x="7"
+       height="10"
+       width="3"
+       id="rect3017-7-4"
+       style="fill:#ececec;fill-opacity:1;stroke:none" />
+  </g>
+</svg>

--- a/Numix/24x24/status/btsync-gui-0.svg
+++ b/Numix/24x24/status/btsync-gui-0.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-0.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="15.170655"
+     inkscape:cx="-1.680296"
+     inkscape:cy="11.313813"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.34782609,0,0,0.34782609,3.6435901,3.6456559)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/24x24/status/btsync-gui-1.svg
+++ b/Numix/24x24/status/btsync-gui-1.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-1.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="15.170655"
+     inkscape:cx="-1.878046"
+     inkscape:cy="11.313813"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.33588983,0.09000141,-0.09000141,0.33588983,6.0920753,1.7700949)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/24x24/status/btsync-gui-10.svg
+++ b/Numix/24x24/status/btsync-gui-10.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-10.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.30117351,0.1738826,-0.1738826,-0.30117351,23.412037,15.056334)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/24x24/status/btsync-gui-11.svg
+++ b/Numix/24x24/status/btsync-gui-11.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-11.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.33588983,0.09000141,-0.09000141,-0.33588983,22.231365,17.905395)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/24x24/status/btsync-gui-2.svg
+++ b/Numix/24x24/status/btsync-gui-2.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-2.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.30117351,0.17388261,-0.17388261,0.30117351,8.9408444,0.58871831)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/24x24/status/btsync-gui-3.svg
+++ b/Numix/24x24/status/btsync-gui-3.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-3.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.24594762,0.24594762,-0.24594762,0.24594762,11.998539,0.18383587)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/24x24/status/btsync-gui-4.svg
+++ b/Numix/24x24/status/btsync-gui-4.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-4.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+  <g
+     transform="matrix(0.1738826,0.30117351,-0.30117351,0.1738826,15.056334,0.58796254)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/Numix/24x24/status/btsync-gui-5.svg
+++ b/Numix/24x24/status/btsync-gui-5.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-5.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.0900014,0.33588983,-0.33588983,0.0900014,17.905395,1.7686348)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/24x24/status/btsync-gui-6.svg
+++ b/Numix/24x24/status/btsync-gui-6.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-6.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0,0.34782609,-0.34782609,0,20.354344,3.6435901)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/24x24/status/btsync-gui-7.svg
+++ b/Numix/24x24/status/btsync-gui-7.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-7.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.09000141,0.33588983,-0.33588983,-0.09000141,22.229905,6.0920753)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/24x24/status/btsync-gui-8.svg
+++ b/Numix/24x24/status/btsync-gui-8.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-8.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.17388261,0.30117351,-0.30117351,-0.17388261,23.411282,8.9408444)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/24x24/status/btsync-gui-9.svg
+++ b/Numix/24x24/status/btsync-gui-9.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-9.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="18.625"
+     inkscape:cx="-8.6807923"
+     inkscape:cy="11.336496"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(-0.24594762,0.24594762,-0.24594762,-0.24594762,23.816164,11.998539)"
+     id="g3628"
+     style="fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/24x24/status/btsync-gui-connecting.svg
+++ b/Numix/24x24/status/btsync-gui-connecting.svg
@@ -1,0 +1,1 @@
+btsync-gui-0.svg

--- a/Numix/24x24/status/btsync-gui-disconnected.svg
+++ b/Numix/24x24/status/btsync-gui-disconnected.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-disconnected.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="15.170655"
+     inkscape:cx="-14.072642"
+     inkscape:cy="11.313813"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.34782609,0,0,0.34782609,3.6435901,3.6456559)"
+     id="g3628"
+     style="opacity:0.4;fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m -25.40625,12 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m 0,2.5 c 2.303968,0 4.367461,1.302964 5.28125,3.3125 l 1.21875,-0.46875 -1,3.46875 -3.3125,-1.84375 1.28125,-0.5 c -0.620857,-1.310198 -1.9541,-2.125 -3.46875,-2.125 -1.572637,0 -2.996131,0.939574 -3.5625,2.34375 L -30.75,18 c 0.844805,-2.103515 2.984794,-3.5 5.34375,-3.5 z m -5.5,4.71875 3.3125,1.78125 -1.28125,0.5 c 0.613358,1.304699 1.964097,2.15625 3.46875,2.15625 1.575636,0 2.978635,-0.910324 3.5625,-2.3125 l 1.78125,0.6875 c -0.876798,2.103015 -2.979296,3.46875 -5.34375,3.46875 -2.292471,0 -4.386956,-1.339213 -5.28125,-3.34375 l -1.21875,0.4375 1,-3.375 z"
+       transform="matrix(2.875,0,0,2.875,97.067647,-33.481261)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-37.411065,9.9950011)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+</svg>

--- a/Numix/24x24/status/btsync-gui-paused.svg
+++ b/Numix/24x24/status/btsync-gui-paused.svg
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="24"
+   height="24"
+   sodipodi:docname="btsync-gui-paused.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6">
+    <clipPath
+       id="clipPath-408241621">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3616">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3618" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-401820784">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3611">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3613" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#003c80"
+         stop-opacity="1"
+         id="stop3606" />
+      <stop
+         offset="1"
+         stop-color="#004794"
+         stop-opacity="1"
+         id="stop3608" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="15.170655"
+     inkscape:cx="-14.599975"
+     inkscape:cy="16.587152"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="matrix(0.34782609,0,0,0.34782609,3.6435901,3.6456557)"
+     id="g3628"
+     style="opacity:0.4;fill:#ececec;fill-opacity:1">
+    <path
+       style="fill:#ececec;fill-opacity:1"
+       d="m 11,3 c -4.418435,0 -8,3.581565 -8,8 0,4.418435 3.581565,8 8,8 4.418435,0 8,-3.581565 8,-8 0,-4.418435 -3.581565,-8 -8,-8 z m -3.75,2 3,0 A 1.0001,1.0001 0 0 1 11,5.3417969 1.0001,1.0001 0 0 1 11.75,5 l 3,0 a 1.0001,1.0001 0 0 1 1,1 l 0,1.9140625 C 15.95092,8.1962057 16.135328,8.4915993 16.28125,8.8125 L 17.5,8.34375 l -1,3.46875 -0.75,-0.417969 0,1.408203 0.59375,0.228516 C 16.187037,13.407129 15.979607,13.749392 15.75,14.074219 L 15.75,16 a 1.0001,1.0001 0 0 1 -1,1 l -3,0 A 1.0001,1.0001 0 0 1 11,16.660156 1.0001,1.0001 0 0 1 10.25,17 l -3,0 a 1.0001,1.0001 0 0 1 -1,-1 l 0,-1.939453 C 6.0482982,13.775425 5.8625527,13.47858 5.71875,13.15625 L 4.5,13.59375 l 1,-3.375 0.75,0.402344 0,-1.3925784 L 5.65625,9 C 5.8095088,8.6183946 6.0179158,8.2704044 6.25,7.9394531 L 6.25,6 a 1.0001,1.0001 0 0 1 1,-1 z m 5.5,2.75 0,6.492188 c 0.37158,-0.181025 0.708486,-0.420122 1,-0.707032 l 0,-3.253906 L 13.1875,9.96875 13.75,9.75 l 0,-1.2851562 C 13.458677,8.1743867 13.124004,7.9308058 12.75,7.75 Z m -3.5,0.00977 c -0.3730305,0.185668 -0.7082387,0.4313045 -1,0.7226519 l 0,3.2148441 L 8.8125,12 8.25,12.21875 l 0,1.292969 c 0.2907393,0.293992 0.626965,0.539867 1,0.726562 l 0,-6.4785154 z"
+       transform="matrix(2.875,0,0,2.875,-7.6003215,-7.6062606)"
+       id="path3630"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g3650"
+     clip-path="url(#clipPath-408241621)"
+     transform="matrix(0.49988464,0,0,0.49988464,-36.411065,8.9950009)">
+    <!-- color: #004794 -->
+    <g
+       id="g3652" />
+  </g>
+  <g
+     id="g3179"
+     transform="matrix(0.6630485,0,0,0.6630485,1.7541,0.1701952)"
+     style="fill:#ececec;fill-opacity:1" />
+  <g
+     id="g3037-6"
+     transform="translate(1.25,0.9999998)"
+     style="fill:#ececec;fill-opacity:1">
+    <rect
+       y="6"
+       x="11.5"
+       height="10"
+       width="3"
+       id="rect3017-1"
+       style="fill:#ececec;fill-opacity:1;stroke:none" />
+    <rect
+       y="6"
+       x="7"
+       height="10"
+       width="3"
+       id="rect3017-7-4"
+       style="fill:#ececec;fill-opacity:1;stroke:none" />
+  </g>
+</svg>


### PR DESCRIPTION
The 22x22/status part of #292. The other ones are not necessary imo (44x44/status wtf?) and the 48x48/apps icon should be covered in circle.