### PR TITLE
Fixes truly invisible user-invisible-panel.svg in 16 and 24

### DIFF
--- a/Numix-Light/16x16/status/user-invisible-panel.svg
+++ b/Numix-Light/16x16/status/user-invisible-panel.svg
@@ -5,17 +5,13 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   viewBox="-290.9 0 0 22"
-   id="svg3008"
    version="1.1"
-   inkscape:version="0.91 r"
-   width="14.545"
+   id="svg2"
    height="16"
-   sodipodi:docname="user-invisible-panel.svg">
+   viewBox="0 0 14.545 16"
+   width="14.545">
   <metadata
-     id="metadata3022">
+     id="metadata14">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -27,30 +23,9 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs3020" />
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1366"
-     inkscape:window-height="747"
-     id="namedview3018"
-     showgrid="false"
-     inkscape:zoom="7.5853273"
-     inkscape:cx="-22.70014"
-     inkscape:cy="18.79542"
-     inkscape:window-x="0"
-     inkscape:window-y="21"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg3008" />
+     id="defs12" />
   <path
-     style="opacity:0.4;fill:#353535;fill-opacity:1;fill-rule:evenodd"
+     style="fill:#353535;fill-opacity:1;fill-rule:evenodd;opacity:0.4"
      d="m 6.908644,2.9087121 c -3.0109634,0 -5.4546439,2.4436805 -5.4546439,5.454644 0,3.0109639 2.4436805,5.4546439 5.4546439,5.4546439 1.4289713,0 2.7317581,-0.554352 3.704649,-1.454572 l 3.931707,0 -2.432044,-2.4318982 c 0.151276,-0.5000817 0.250186,-1.0189275 0.250186,-1.5681737 0,-3.0109635 -2.4436799,-5.454644 -5.4546434,-5.454644 z"
-     id="path3016"
-     inkscape:connector-curvature="0" />
+     id="path8" />
 </svg>

--- a/Numix-Light/24x24/status/user-invisible-panel.svg
+++ b/Numix-Light/24x24/status/user-invisible-panel.svg
@@ -5,17 +5,13 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   viewBox="-436.36002 0 0 22"
-   id="svg3008"
    version="1.1"
-   inkscape:version="0.91 r"
-   width="21.818001"
+   id="svg2"
    height="24"
-   sodipodi:docname="user-invisible-panel.svg">
+   viewBox="0 0 21.818001 24"
+   width="21.818001">
   <metadata
-     id="metadata3022">
+     id="metadata14">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -27,30 +23,9 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs3020" />
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1366"
-     inkscape:window-height="747"
-     id="namedview3018"
-     showgrid="false"
-     inkscape:zoom="15.170655"
-     inkscape:cx="10.118204"
-     inkscape:cy="8.6578493"
-     inkscape:window-x="0"
-     inkscape:window-y="21"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg3008" />
+     id="defs12" />
   <path
-     style="opacity:0.4;fill:#353535;fill-opacity:1;fill-rule:evenodd"
+     style="fill:#353535;fill-opacity:1;fill-rule:evenodd;opacity:0.4"
      d="m 10.409,5 c -4.14,0 -7.5,3.36 -7.5,7.5 0,4.14 3.36,7.5 7.5,7.5 1.9648,0 3.7561,-0.76222 5.0938,-2 l 5.406,0 -3.344,-3.3438 c 0.208,-0.6876 0.344,-1.401 0.344,-2.1562 0,-4.14 -3.36,-7.5 -7.5,-7.5 z"
-     id="path3016"
-     inkscape:connector-curvature="0" />
+     id="path8" />
 </svg>

--- a/Numix/16x16/status/user-invisible-panel.svg
+++ b/Numix/16x16/status/user-invisible-panel.svg
@@ -5,17 +5,13 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   viewBox="-290.9 0 0 22"
-   id="svg3008"
    version="1.1"
-   inkscape:version="0.91 r"
-   width="14.545"
+   id="svg2"
    height="16"
-   sodipodi:docname="user-invisible-panel.svg">
+   viewBox="0 0 14.545 16"
+   width="14.545">
   <metadata
-     id="metadata3022">
+     id="metadata14">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -27,30 +23,9 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs3020" />
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1366"
-     inkscape:window-height="747"
-     id="namedview3018"
-     showgrid="false"
-     inkscape:zoom="7.5853273"
-     inkscape:cx="-22.70014"
-     inkscape:cy="18.79542"
-     inkscape:window-x="0"
-     inkscape:window-y="21"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg3008" />
+     id="defs12" />
   <path
-     style="opacity:0.4;fill:#ececec;fill-opacity:1;fill-rule:evenodd"
+     style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;opacity:0.4"
      d="m 6.908644,2.9087121 c -3.0109634,0 -5.4546439,2.4436805 -5.4546439,5.454644 0,3.0109639 2.4436805,5.4546439 5.4546439,5.4546439 1.4289713,0 2.7317581,-0.554352 3.704649,-1.454572 l 3.931707,0 -2.432044,-2.4318982 c 0.151276,-0.5000817 0.250186,-1.0189275 0.250186,-1.5681737 0,-3.0109635 -2.4436799,-5.454644 -5.4546434,-5.454644 z"
-     id="path3016"
-     inkscape:connector-curvature="0" />
+     id="path8" />
 </svg>

--- a/Numix/24x24/status/user-invisible-panel.svg
+++ b/Numix/24x24/status/user-invisible-panel.svg
@@ -5,17 +5,13 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   viewBox="-436.36002 0 0 22"
-   id="svg3008"
    version="1.1"
-   inkscape:version="0.91 r"
-   width="21.818001"
+   id="svg2"
    height="24"
-   sodipodi:docname="user-invisible-panel.svg">
+   viewBox="0 0 21.818001 24"
+   width="21.818001">
   <metadata
-     id="metadata3022">
+     id="metadata14">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -27,30 +23,9 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs3020" />
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1366"
-     inkscape:window-height="747"
-     id="namedview3018"
-     showgrid="false"
-     inkscape:zoom="15.170655"
-     inkscape:cx="10.118204"
-     inkscape:cy="8.6578493"
-     inkscape:window-x="0"
-     inkscape:window-y="21"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg3008" />
+     id="defs12" />
   <path
-     style="opacity:0.4;fill:#ececec;fill-opacity:1;fill-rule:evenodd"
+     style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;opacity:0.4"
      d="m 10.409,5 c -4.14,0 -7.5,3.36 -7.5,7.5 0,4.14 3.36,7.5 7.5,7.5 1.9648,0 3.7561,-0.76222 5.0938,-2 l 5.406,0 -3.344,-3.3438 c 0.208,-0.6876 0.344,-1.401 0.344,-2.1562 0,-4.14 -3.36,-7.5 -7.5,-7.5 z"
-     id="path3016"
-     inkscape:connector-curvature="0" />
+     id="path8" />
 </svg>


### PR DESCRIPTION
The icons were completely invisible in 16x16/status and 24x24/status (I'm afraid there are more, Inkscape strikes again...)