### PR TITLE
Fixes inconsistent icon audio-output-none-panel.svg in 16 22 and 24

### DIFF
--- a/Numix-Light/16x16/status/audio-output-none-panel.svg
+++ b/Numix-Light/16x16/status/audio-output-none-panel.svg
@@ -12,7 +12,7 @@
    viewBox="0 0 16 16"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
+   inkscape:version="0.91 r"
    sodipodi:docname="audio-output-none-panel.svg">
   <metadata
      id="metadata79">
@@ -34,15 +34,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview77"
      showgrid="true"
-     inkscape:zoom="10.429825"
-     inkscape:cx="-13.182766"
-     inkscape:cy="21.645325"
+     inkscape:zoom="29.5"
+     inkscape:cx="8.3301549"
+     inkscape:cy="8.1988502"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
@@ -198,38 +198,38 @@
      style="fill:#353535;fill-opacity:1"
      inkscape:connector-curvature="0"
      id="path3342"
-     d="m 4.9999997,2.9999998 -1.9999997,2 0,5 L 4.9999997,12 l 3e-6,-3.0030214 1.499997,-1.4969788 -1.5,-1.5 z"
+     d="m 5.9999997,2.9999998 -1.9999997,2 0,5 L 5.9999997,12 l 3e-6,-3.0030214 1.499997,-1.4969788 -1.5,-1.5 z"
      sodipodi:nodetypes="cccccccc" />
   <path
      style="fill:#353535;fill-opacity:1"
      inkscape:connector-curvature="0"
      id="path3344"
-     d="M 0.7499995,4.9999998 C 0.3588707,4.9999998 0,5.4159219 0,5.8363148 l 0,3.32737 c 0,0.4830053 0.3266127,0.836315 0.7499995,0.836315 l 2.2500005,0 0,-5 z"
+     d="M 1.7499995,4.9999998 C 1.3588707,4.9999998 1,5.4159219 1,5.8363148 l 0,3.32737 c 0,0.4830053 0.3266127,0.836315 0.7499995,0.836315 l 2.2500005,0 0,-5 z"
      sodipodi:nodetypes="ssssccs" />
   <rect
      style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none"
      id="rect3102"
-     width="2"
+     width="1.75"
      height="1"
-     x="7"
+     x="8"
      y="7"
      rx="0.255"
      ry="0.20999999" />
   <rect
      style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none"
      id="rect3104"
-     width="2"
+     width="1.75"
      height="1"
-     x="10"
+     x="10.625"
      y="7"
      rx="0.255"
      ry="0.20999999" />
   <rect
      style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none"
      id="rect3106"
-     width="2"
+     width="1.75"
      height="1"
-     x="13"
+     x="13.25"
      y="7"
      rx="0.255"
      ry="0.20999999" />

--- a/Numix-Light/22x22/status/audio-output-none-panel.svg
+++ b/Numix-Light/22x22/status/audio-output-none-panel.svg
@@ -12,7 +12,7 @@
    height="22"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
+   inkscape:version="0.91 r"
    sodipodi:docname="audio-output-none-panel.svg">
   <metadata
      id="metadata46">
@@ -35,15 +35,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview44"
      showgrid="true"
-     inkscape:zoom="40.424161"
-     inkscape:cx="10.793399"
-     inkscape:cy="9.6470285"
+     inkscape:zoom="14.292099"
+     inkscape:cx="6.4485518"
+     inkscape:cy="16.608873"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
@@ -122,13 +122,13 @@
   <g
      style="fill:#353535;fill-opacity:1"
      id="g3101"
-     transform="matrix(1.0001112,0,0,1,-8.8989898e-4,0)">
+     transform="matrix(1.0001112,0,0,1,0.9991101,0)">
     <path
        sodipodi:nodetypes="cccccccc"
        style="fill:#353535;fill-opacity:1"
        inkscape:connector-curvature="0"
        id="path40"
-       d="M 6.0010672,5 3,8 l 0,6 3.0010672,3 0,-4 L 8,11 6.0010672,9 z" />
+       d="M 6.0010672,5 3,8 l 0,6 3.0010672,3 0,-4 L 8,11 6.0010672,9 Z" />
     <path
        sodipodi:nodetypes="ssssccs"
        style="fill:#353535;fill-opacity:1"
@@ -138,10 +138,10 @@
   </g>
   <rect
      style="fill:#353535;fill-opacity:1"
-     width="4"
-     height="2"
-     x="8"
-     y="10"
+     width="3.1428573"
+     height="1.4"
+     x="10"
+     y="10.3"
      rx="0.255"
      ry="0.20999999"
      id="rect3031" />
@@ -149,17 +149,17 @@
      style="fill:#353535;fill-opacity:1"
      ry="0.20999999"
      rx="0.255"
-     y="10"
-     x="13"
-     height="2"
-     width="4"
+     y="10.3"
+     x="13.928572"
+     height="1.4"
+     width="3.1428573"
      id="rect3035" />
   <rect
      style="fill:#353535;fill-opacity:1"
-     width="4"
-     height="2"
-     x="18"
-     y="10"
+     width="3.1428573"
+     height="1.4"
+     x="17.857143"
+     y="10.3"
      rx="0.255"
      ry="0.20999999"
      id="rect3039" />

--- a/Numix-Light/24x24/status/audio-output-none-panel.svg
+++ b/Numix-Light/24x24/status/audio-output-none-panel.svg
@@ -12,7 +12,7 @@
    viewBox="0 0 24 24"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
+   inkscape:version="0.91 r"
    sodipodi:docname="audio-output-none-panel.svg">
   <metadata
      id="metadata79">
@@ -34,15 +34,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview77"
      showgrid="true"
-     inkscape:zoom="27.812867"
-     inkscape:cx="7.0699578"
-     inkscape:cy="10.684724"
+     inkscape:zoom="13.906434"
+     inkscape:cx="15.567452"
+     inkscape:cy="13.734282"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
@@ -193,49 +193,115 @@
            id="rect53" />
       </g>
     </mask>
+    <clipPath
+       id="clipPath6">
+      <rect
+         id="rect8"
+         color="#bebebe"
+         fill="#bebebe"
+         x="26.85"
+         y="220.75"
+         width="3.825"
+         height="6.375" />
+    </clipPath>
+    <clipPath
+       id="clipPath10">
+      <rect
+         id="rect12"
+         color="#bebebe"
+         fill="#bebebe"
+         x="26.966"
+         y="221.33"
+         width="2.898"
+         height="5.216" />
+    </clipPath>
+    <clipPath
+       id="clipPath14">
+      <rect
+         id="rect16-5"
+         color="#bebebe"
+         fill="#bebebe"
+         x="26.999"
+         y="221.5"
+         width="1.876"
+         height="4.874" />
+    </clipPath>
+    <clipPath
+       id="clipPath3025">
+      <rect
+         height="4.874"
+         width="1.876"
+         y="221.5"
+         x="26.999"
+         fill="#bebebe"
+         color="#bebebe"
+         id="rect3027" />
+    </clipPath>
+    <clipPath
+       id="clipPath3021">
+      <rect
+         height="5.216"
+         width="2.898"
+         y="221.33"
+         x="26.966"
+         fill="#bebebe"
+         color="#bebebe"
+         id="rect3023" />
+    </clipPath>
+    <clipPath
+       id="clipPath3017">
+      <rect
+         height="6.375"
+         width="3.825"
+         y="220.75"
+         x="26.85"
+         fill="#bebebe"
+         color="#bebebe"
+         id="rect3019" />
+    </clipPath>
   </defs>
   <g
-     id="g3101"
-     transform="matrix(1.0001112,0,0,1,0.9991101,1)"
-     style="fill:#353535;fill-opacity:1">
+     style="fill:#353535;fill-opacity:1"
+     id="g3101-3"
+     transform="matrix(1.0001112,0,0,1,1.9991101,1)">
     <path
        sodipodi:nodetypes="cccccccc"
        style="fill:#353535;fill-opacity:1"
        inkscape:connector-curvature="0"
-       id="path40"
-       d="M 6.0010672,5 3,8 l 0,6 3.0010672,3 0,-4 L 8,11 6.0010672,9 z" />
+       id="path40-7"
+       d="M 6.0010672,5 3,8 l 0,6 3.0010672,3 0,-4 L 8,11 6.0010672,9 Z" />
     <path
        sodipodi:nodetypes="ssssccs"
        style="fill:#353535;fill-opacity:1"
        inkscape:connector-curvature="0"
-       id="path42"
+       id="path42-0"
        d="M 1,8 C 0.4769561,8 8.898e-4,8.4981434 8.898e-4,9 l 0,4 c 0,0.579702 0.432648,1 0.9991102,1 l 3.9964407,0 0,-6 z" />
   </g>
   <rect
      style="fill:#353535;fill-opacity:1"
-     width="4"
-     height="2"
-     x="9"
-     y="11"
+     width="3.1428573"
+     height="1.4"
+     x="11"
+     y="11.3"
      rx="0.255"
      ry="0.20999999"
-     id="rect3031" />
+     id="rect3031-3" />
   <rect
      style="fill:#353535;fill-opacity:1"
      ry="0.20999999"
      rx="0.255"
-     y="11"
-     x="14"
-     height="2"
-     width="4"
-     id="rect3035" />
+     y="11.3"
+     x="14.928572"
+     height="1.4"
+     width="3.1428573"
+     id="rect3035-6" />
   <rect
      style="fill:#353535;fill-opacity:1"
-     width="4"
-     height="2"
-     x="19"
-     y="11"
+     width="3.1428573"
+     height="1.4"
+     x="18.857143"
+     y="11.3"
      rx="0.255"
      ry="0.20999999"
-     id="rect3039" />
+     id="rect3039-7" />
 </svg>

--- a/Numix/16x16/status/audio-output-none-panel.svg
+++ b/Numix/16x16/status/audio-output-none-panel.svg
@@ -12,7 +12,7 @@
    viewBox="0 0 16 16"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
+   inkscape:version="0.91 r"
    sodipodi:docname="audio-output-none-panel.svg">
   <metadata
      id="metadata79">
@@ -34,15 +34,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview77"
      showgrid="true"
-     inkscape:zoom="10.429825"
-     inkscape:cx="-13.182766"
-     inkscape:cy="21.645325"
+     inkscape:zoom="29.5"
+     inkscape:cx="8.3301549"
+     inkscape:cy="8.1988502"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
@@ -198,38 +198,38 @@
      style="fill:#ececec;fill-opacity:1"
      inkscape:connector-curvature="0"
      id="path3342"
-     d="m 4.9999997,2.9999998 -1.9999997,2 0,5 L 4.9999997,12 l 3e-6,-3.0030214 1.499997,-1.4969788 -1.5,-1.5 z"
+     d="m 5.9999997,2.9999998 -1.9999997,2 0,5 L 5.9999997,12 l 3e-6,-3.0030214 1.499997,-1.4969788 -1.5,-1.5 z"
      sodipodi:nodetypes="cccccccc" />
   <path
      style="fill:#ececec;fill-opacity:1"
      inkscape:connector-curvature="0"
      id="path3344"
-     d="M 0.7499995,4.9999998 C 0.3588707,4.9999998 0,5.4159219 0,5.8363148 l 0,3.32737 c 0,0.4830053 0.3266127,0.836315 0.7499995,0.836315 l 2.2500005,0 0,-5 z"
+     d="M 1.7499995,4.9999998 C 1.3588707,4.9999998 1,5.4159219 1,5.8363148 l 0,3.32737 c 0,0.4830053 0.3266127,0.836315 0.7499995,0.836315 l 2.2500005,0 0,-5 z"
      sodipodi:nodetypes="ssssccs" />
   <rect
      style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none"
      id="rect3102"
-     width="2"
+     width="1.75"
      height="1"
-     x="7"
+     x="8"
      y="7"
      rx="0.255"
      ry="0.20999999" />
   <rect
      style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none"
      id="rect3104"
-     width="2"
+     width="1.75"
      height="1"
-     x="10"
+     x="10.625"
      y="7"
      rx="0.255"
      ry="0.20999999" />
   <rect
      style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none"
      id="rect3106"
-     width="2"
+     width="1.75"
      height="1"
-     x="13"
+     x="13.25"
      y="7"
      rx="0.255"
      ry="0.20999999" />

--- a/Numix/22x22/status/audio-output-none-panel.svg
+++ b/Numix/22x22/status/audio-output-none-panel.svg
@@ -12,7 +12,7 @@
    height="22"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
+   inkscape:version="0.91 r"
    sodipodi:docname="audio-output-none-panel.svg">
   <metadata
      id="metadata46">
@@ -35,15 +35,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview44"
      showgrid="true"
-     inkscape:zoom="40.424161"
-     inkscape:cx="10.793399"
-     inkscape:cy="9.6470285"
+     inkscape:zoom="14.292099"
+     inkscape:cx="6.4485518"
+     inkscape:cy="16.608873"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
@@ -122,13 +122,13 @@
   <g
      style="fill:#ececec;fill-opacity:1"
      id="g3101"
-     transform="matrix(1.0001112,0,0,1,-8.8989898e-4,0)">
+     transform="matrix(1.0001112,0,0,1,0.9991101,0)">
     <path
        sodipodi:nodetypes="cccccccc"
        style="fill:#ececec;fill-opacity:1"
        inkscape:connector-curvature="0"
        id="path40"
-       d="M 6.0010672,5 3,8 l 0,6 3.0010672,3 0,-4 L 8,11 6.0010672,9 z" />
+       d="M 6.0010672,5 3,8 l 0,6 3.0010672,3 0,-4 L 8,11 6.0010672,9 Z" />
     <path
        sodipodi:nodetypes="ssssccs"
        style="fill:#ececec;fill-opacity:1"
@@ -138,10 +138,10 @@
   </g>
   <rect
      style="fill:#ececec;fill-opacity:1"
-     width="4"
-     height="2"
-     x="8"
-     y="10"
+     width="3.1428573"
+     height="1.4"
+     x="10"
+     y="10.3"
      rx="0.255"
      ry="0.20999999"
      id="rect3031" />
@@ -149,17 +149,17 @@
      style="fill:#ececec;fill-opacity:1"
      ry="0.20999999"
      rx="0.255"
-     y="10"
-     x="13"
-     height="2"
-     width="4"
+     y="10.3"
+     x="13.928572"
+     height="1.4"
+     width="3.1428573"
      id="rect3035" />
   <rect
      style="fill:#ececec;fill-opacity:1"
-     width="4"
-     height="2"
-     x="18"
-     y="10"
+     width="3.1428573"
+     height="1.4"
+     x="17.857143"
+     y="10.3"
      rx="0.255"
      ry="0.20999999"
      id="rect3039" />

--- a/Numix/24x24/status/audio-output-none-panel.svg
+++ b/Numix/24x24/status/audio-output-none-panel.svg
@@ -12,7 +12,7 @@
    viewBox="0 0 24 24"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
+   inkscape:version="0.91 r"
    sodipodi:docname="audio-output-none-panel.svg">
   <metadata
      id="metadata79">
@@ -34,15 +34,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
      id="namedview77"
      showgrid="true"
-     inkscape:zoom="27.812867"
-     inkscape:cx="7.0699578"
-     inkscape:cy="10.684724"
+     inkscape:zoom="19.666668"
+     inkscape:cx="7.5524029"
+     inkscape:cy="12.323353"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
@@ -193,49 +193,115 @@
            id="rect53" />
       </g>
     </mask>
+    <clipPath
+       id="clipPath6">
+      <rect
+         id="rect8"
+         color="#bebebe"
+         fill="#bebebe"
+         x="26.85"
+         y="220.75"
+         width="3.825"
+         height="6.375" />
+    </clipPath>
+    <clipPath
+       id="clipPath10">
+      <rect
+         id="rect12"
+         color="#bebebe"
+         fill="#bebebe"
+         x="26.966"
+         y="221.33"
+         width="2.898"
+         height="5.216" />
+    </clipPath>
+    <clipPath
+       id="clipPath14">
+      <rect
+         id="rect16-5"
+         color="#bebebe"
+         fill="#bebebe"
+         x="26.999"
+         y="221.5"
+         width="1.876"
+         height="4.874" />
+    </clipPath>
+    <clipPath
+       id="clipPath3025">
+      <rect
+         height="4.874"
+         width="1.876"
+         y="221.5"
+         x="26.999"
+         fill="#bebebe"
+         color="#bebebe"
+         id="rect3027" />
+    </clipPath>
+    <clipPath
+       id="clipPath3021">
+      <rect
+         height="5.216"
+         width="2.898"
+         y="221.33"
+         x="26.966"
+         fill="#bebebe"
+         color="#bebebe"
+         id="rect3023" />
+    </clipPath>
+    <clipPath
+       id="clipPath3017">
+      <rect
+         height="6.375"
+         width="3.825"
+         y="220.75"
+         x="26.85"
+         fill="#bebebe"
+         color="#bebebe"
+         id="rect3019" />
+    </clipPath>
   </defs>
   <g
-     id="g3101"
-     transform="matrix(1.0001112,0,0,1,0.9991101,1)"
-     style="fill:#ececec;fill-opacity:1">
+     style="fill:#ececec;fill-opacity:1"
+     id="g3101-3"
+     transform="matrix(1.0001112,0,0,1,1.9991101,1)">
     <path
        sodipodi:nodetypes="cccccccc"
        style="fill:#ececec;fill-opacity:1"
        inkscape:connector-curvature="0"
-       id="path40"
-       d="M 6.0010672,5 3,8 l 0,6 3.0010672,3 0,-4 L 8,11 6.0010672,9 z" />
+       id="path40-7"
+       d="M 6.0010672,5 3,8 l 0,6 3.0010672,3 0,-4 L 8,11 6.0010672,9 Z" />
     <path
        sodipodi:nodetypes="ssssccs"
        style="fill:#ececec;fill-opacity:1"
        inkscape:connector-curvature="0"
-       id="path42"
+       id="path42-0"
        d="M 1,8 C 0.4769561,8 8.898e-4,8.4981434 8.898e-4,9 l 0,4 c 0,0.579702 0.432648,1 0.9991102,1 l 3.9964407,0 0,-6 z" />
   </g>
   <rect
      style="fill:#ececec;fill-opacity:1"
-     width="4"
-     height="2"
-     x="9"
-     y="11"
+     width="3.1428573"
+     height="1.4"
+     x="11"
+     y="11.3"
      rx="0.255"
      ry="0.20999999"
-     id="rect3031" />
+     id="rect3031-3" />
   <rect
      style="fill:#ececec;fill-opacity:1"
      ry="0.20999999"
      rx="0.255"
-     y="11"
-     x="14"
-     height="2"
-     width="4"
-     id="rect3035" />
+     y="11.3"
+     x="14.928572"
+     height="1.4"
+     width="3.1428573"
+     id="rect3035-6" />
   <rect
      style="fill:#ececec;fill-opacity:1"
-     width="4"
-     height="2"
-     x="19"
-     y="11"
+     width="3.1428573"
+     height="1.4"
+     x="18.857143"
+     y="11.3"
      rx="0.255"
      ry="0.20999999"
-     id="rect3039" />
+     id="rect3039-7" />
 </svg>


### PR DESCRIPTION
The icon `audio-output-none-panel.svg` seemed off when compared to the other audio icons (position of the speaker was different) I changed that and made it consistent with the other audio icons