### PR TITLE
Deleted glow

### DIFF
--- a/Numix/22x22/status/redshift-status-off.svg
+++ b/Numix/22x22/status/redshift-status-off.svg
@@ -13,7 +13,7 @@
    height="22"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
+   inkscape:version="0.91 r"
    sodipodi:docname="redshift-status-off.svg">
   <metadata
      id="metadata34">
@@ -36,15 +36,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1215"
+     inkscape:window-height="776"
      id="namedview32"
      showgrid="false"
-     inkscape:zoom="23.70222"
-     inkscape:cx="0.68585697"
-     inkscape:cy="8.3837667"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:zoom="26.818182"
+     inkscape:cx="11"
+     inkscape:cy="11"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2" />
   <defs
@@ -107,11 +107,6 @@
          offset="1" />
     </linearGradient>
   </defs>
-  <path
-     style="opacity:0.15;fill:#f9f9f9;fill-opacity:1;stroke:none"
-     d="M 3.2672979,1.0632952 4.4305758,1.4834772 4.4558645,2.440558 3.9753802,3.1642047 3.6466277,3.7711342 3.4443186,3.9345382 2.7362364,4.0045686 2.4833499,3.6310734 1.901711,2.7206794 1.6235358,2.0437196 1.8511336,1.4834772 2.5592159,1.1566689 z"
-     id="path3840"
-     inkscape:connector-curvature="0" />
   <g
      style="fill:#ececec;fill-opacity:1;opacity:0.4"
      transform="matrix(0.00330729,0,0,-0.00293981,1.4111111,4.9859266)"


### PR DESCRIPTION
Deleted "glow" in the light bulb in the new `redshift-status-off.svg` for consistency with the new `redshift-status-on.svg`. Fixes https://github.com/numixproject/numix-icon-theme/issues/382.