### PR TITLE
Added mimetype for Octave files

### DIFF
--- a/Numix/128x128/mimetypes/text-x-matlab.svg
+++ b/Numix/128x128/mimetypes/text-x-matlab.svg
@@ -1,0 +1,1 @@
+text-x-octave.svg

--- a/Numix/128x128/mimetypes/text-x-octave.svg
+++ b/Numix/128x128/mimetypes/text-x-octave.svg
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="128px"
+   height="128px"
+   viewBox="0 0 128 128"
+   version="1.1"
+   id="svg2"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="application-audio.svg">
+  <metadata
+     id="metadata17">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs15">
+    <clipPath
+       id="clipPath-883211809-3">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17-2">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19-9" />
+      </g>
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview13"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="46.5"
+     inkscape:cy="48.659378"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3369" />
+  </sodipodi:namedview>
+  <g
+     id="surface1">
+    <path
+       style="stroke:none;fill-rule:nonzero;fill:#795a8b;fill-opacity:1"
+       d="M 21.34375 0 C 18.59375 0 16 2.710938 16 5.578125 L 16 122.421875 C 16 125.132812 18.75 128 21.34375 128 L 106.65625 128 C 109.25 128 112 125.132812 112 122.421875 L 112 36 L 76 0 Z M 21.34375 0 "
+       id="path5" />
+    <path
+       style=" stroke:none;fill-rule:nonzero;fill:rgb(0%,0%,0%);fill-opacity:0.196078;"
+       d="M 84 36 L 112 64 L 112 36 Z M 84 36 "
+       id="path7" />
+    <path
+       style=" stroke:none;fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:0.392157;"
+       d="M 76 0 L 111.96875 36 L 81.515625 36 C 78.820312 36 76 33.148438 76 30.453125 Z M 76 0 "
+       id="path9" />
+  </g>
+  <g
+     id="g64"
+     style="fill:#ffffff"
+     transform="matrix(2.3332361,0,0,2.3335733,8.0011668,21.997845)">
+    <g
+       clip-path="url(#clipPath-883211809-3)"
+       id="g66"
+       style="fill:#ffffff">
+      <!-- color: #eeeeee -->
+      <g
+         id="g68"
+         style="fill:#ffffff">
+        <path
+           d="m 15.988,14.492 c -3.766,4.04 -2.852,11.574 2.031,16.828 4.887,5.25 11.898,6.227 15.66,2.184 3.762,-4.04 2.852,-11.578 -2.035,-16.824 -4.887,-5.254 -11.898,-6.23 -15.66,-2.187 m 3.414,1.68 c 2.957,-3.18 8.219948,-2.488 11.969948,1.543 3.75,4.03 4.479921,9.875 1.518921,13.05 -2.953,3.18 -8.308869,2.488 -12.054869,-1.539 -3.75,-4.03 -4.391,-9.871 -1.438,-13.05"
+           id="path70"
+           style="fill:#ffffff;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccccc" />
+        <path
+           d="m 30.606276,15.427414 2.216162,0 c 0.334537,0 0.606276,0.271739 0.606276,0.606276 l 0,2.216162 c 0,0.334536 -0.271739,0.606276 -0.606276,0.606276 l -2.216162,0 C 30.27174,18.856128 30,18.584388 30,18.249852 l 0,-2.216162 c 0,-0.334537 0.27174,-0.606276 0.606276,-0.606276 m 0,0"
+           id="path72"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 13.216009,20.574141 4.425411,0 c 0.673602,0 1.216009,0.543385 1.216009,1.212092 l 0,4.428348 c 0,0.669686 -0.543386,1.212093 -1.216009,1.212093 l -4.425411,0 C 12.542407,27.426674 12,26.883288 12,26.214581 l 0,-4.428348 c 0,-0.669686 0.543386,-1.212092 1.216009,-1.212092 m 0,0"
+           id="path74"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 31.770127,29.145183 3.318675,0 c 0.501863,0 0.912198,0.406221 0.912198,0.908084 l 0,3.32176 c 0,0.501864 -0.409306,0.908085 -0.912198,0.908085 l -3.318675,0 c -0.501863,0 -0.912198,-0.406221 -0.912198,-0.908085 l 0,-3.32176 c 0,-0.501863 0.409307,-0.908084 0.912198,-0.908084 m 0,0"
+           id="path76"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/Numix/128x128/mimetypes/text-x-octave.svg
+++ b/Numix/128x128/mimetypes/text-x-octave.svg
@@ -13,7 +13,7 @@
    version="1.1"
    id="svg2"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="application-audio.svg">
+   sodipodi:docname="text-x-octave.svg">
   <metadata
      id="metadata17">
     <rdf:RDF>
@@ -55,7 +55,7 @@
      id="namedview13"
      showgrid="false"
      inkscape:zoom="1"
-     inkscape:cx="46.5"
+     inkscape:cx="29"
      inkscape:cy="48.659378"
      inkscape:window-x="0"
      inkscape:window-y="28"
@@ -68,7 +68,7 @@
   <g
      id="surface1">
     <path
-       style="stroke:none;fill-rule:nonzero;fill:#795a8b;fill-opacity:1"
+       style="stroke:none;fill-rule:nonzero;fill:#ef6f29;fill-opacity:1"
        d="M 21.34375 0 C 18.59375 0 16 2.710938 16 5.578125 L 16 122.421875 C 16 125.132812 18.75 128 21.34375 128 L 106.65625 128 C 109.25 128 112 125.132812 112 122.421875 L 112 36 L 76 0 Z M 21.34375 0 "
        id="path5" />
     <path

--- a/Numix/16x16/mimetypes/text-x-matlab.svg
+++ b/Numix/16x16/mimetypes/text-x-matlab.svg
@@ -1,0 +1,1 @@
+text-x-octave.svg

--- a/Numix/16x16/mimetypes/text-x-octave.svg
+++ b/Numix/16x16/mimetypes/text-x-octave.svg
@@ -13,7 +13,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="application-json4.svg">
+   sodipodi:docname="text-x-octave.svg">
   <metadata
      id="metadata20">
     <rdf:RDF>
@@ -56,7 +56,7 @@
      id="namedview16"
      showgrid="true"
      inkscape:zoom="32"
-     inkscape:cx="4.9387218"
+     inkscape:cx="-0.2956532"
      inkscape:cy="6.6038615"
      inkscape:window-x="0"
      inkscape:window-y="28"
@@ -68,7 +68,7 @@
        id="grid3008" />
   </sodipodi:namedview>
   <path
-     style="fill:#795a8b;fill-opacity:1"
+     style="fill:#ef6f29;fill-opacity:1"
      d="M 2.667969,-4.461e-4 C 2.324219,-4.461e-4 2,0.3378119 2,0.6964466 L 2,15.303108 C 2,15.641365 2.34375,16 2.667969,16 l 10.664062,0 C 13.65625,16 14,15.641365 14,15.303108 L 14,3.9995537 9.9999996,-4.461e-4 z"
      id="path4-5"
      inkscape:connector-curvature="0"

--- a/Numix/16x16/mimetypes/text-x-octave.svg
+++ b/Numix/16x16/mimetypes/text-x-octave.svg
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="application-json4.svg">
+  <metadata
+     id="metadata20">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs18">
+    <clipPath
+       id="clipPath-883211809">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19" />
+      </g>
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview16"
+     showgrid="true"
+     inkscape:zoom="32"
+     inkscape:cx="4.9387218"
+     inkscape:cy="6.6038615"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     showguides="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3008" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#795a8b;fill-opacity:1"
+     d="M 2.667969,-4.461e-4 C 2.324219,-4.461e-4 2,0.3378119 2,0.6964466 L 2,15.303108 C 2,15.641365 2.34375,16 2.667969,16 l 10.664062,0 C 13.65625,16 14,15.641365 14,15.303108 L 14,3.9995537 9.9999996,-4.461e-4 z"
+     id="path4-5"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssssccs" />
+  <path
+     style="fill:#000000;fill-opacity:0.19599998"
+     d="m 10.583223,3.3315847 0.0154,0.01953 0.04005,-0.01953 z m 0.02978,0.667969 3.387,3.664062 0,-3.664062 z"
+     id="path6"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccc" />
+  <path
+     style="fill:#ffffff;fill-opacity:0.39200003"
+     d="m 9.9999996,-4.461e-4 3.9963964,3.9999998 -3.383784,0 c -0.299099,0 -0.6126124,-0.317117 -0.6126124,-0.616216 z"
+     id="path8"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccssc" />
+  <g
+     transform="matrix(0.33331945,0,0,0.33331945,1.666e-4,1.501426)"
+     id="g3469">
+    <g
+       id="g3471"
+       clip-path="url(#clipPath-883211809)">
+      <!-- color: #eeeeee -->
+      <g
+         id="g3473">
+        <path
+           style="fill:#ffffff;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           id="path3475"
+           d="m 15.988,14.492 c -3.766,4.04 -2.852,11.574 2.031,16.828 4.887,5.25 11.898,6.227 15.66,2.184 3.762,-4.04 2.852,-11.578 -2.035,-16.824 -4.887,-5.254 -11.898,-6.23 -15.66,-2.187 m 3.414,1.68 c 2.957,-3.18 7.791789,-2.488 11.541789,1.543 3.75,4.03 4.395466,9.875 1.434466,13.05 -2.953,3.18 -7.796255,2.488 -11.542255,-1.539 -3.75,-4.03 -4.391,-9.871 -1.438,-13.05"
+           sodipodi:nodetypes="cccccccccc" />
+        <path
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           id="path3477"
+           d="m 29.049461,13.496284 3.102629,0 c 0.468351,0 0.848785,0.380434 0.848785,0.848785 l 0,3.102629 c 0,0.468351 -0.380434,0.848786 -0.848785,0.848786 l -3.102629,0 c -0.468351,0 -0.848786,-0.380435 -0.848786,-0.848786 l 0,-3.102629 c 0,-0.468351 0.380435,-0.848785 0.848786,-0.848785 m 0,0" />
+        <path
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           id="path3479"
+           d="m 13.436409,19.502534 5.227518,0 c 0.795693,0 1.43641,0.641857 1.43641,1.431746 l 0,5.230845 c 0,0.791046 -0.641874,1.431746 -1.43641,1.431746 l -5.227518,0 C 12.640717,27.596871 12,26.955014 12,26.165125 l 0,-5.230845 c 0,-0.791046 0.641874,-1.431746 1.436409,-1.431746 m 0,0" />
+        <path
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           id="path3481"
+           d="m 31.064983,28.502909 3.871786,0 c 0.585508,0 1.064231,0.473924 1.064231,1.059432 l 0,3.875385 c 0,0.585509 -0.477524,1.059433 -1.064231,1.059433 l -3.871786,0 c -0.58551,0 -1.064233,-0.473924 -1.064233,-1.059433 l 0,-3.875385 c 0,-0.585508 0.477524,-1.059432 1.064233,-1.059432 m 0,0" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/Numix/22x22/mimetypes/text-x-matlab.svg
+++ b/Numix/22x22/mimetypes/text-x-matlab.svg
@@ -1,0 +1,1 @@
+text-x-octave.svg

--- a/Numix/22x22/mimetypes/text-x-octave.svg
+++ b/Numix/22x22/mimetypes/text-x-octave.svg
@@ -13,7 +13,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="application-json2.svg">
+   sodipodi:docname="text-x-octave.svg">
   <metadata
      id="metadata20">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -55,8 +55,8 @@
      inkscape:window-height="713"
      id="namedview16"
      showgrid="false"
-     inkscape:zoom="1"
-     inkscape:cx="9.424365"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="6.3307728"
      inkscape:cy="9.109097"
      inkscape:window-x="0"
      inkscape:window-y="28"
@@ -71,7 +71,7 @@
        snapvisiblegridlinesonly="true" />
   </sodipodi:namedview>
   <path
-     style="fill:#795a8b;fill-opacity:1"
+     style="fill:#ef6f29;fill-opacity:1"
      d="M 4,0 C 3.527343,0 3,0.527344 3,1 l 0,20 c 0,0.445312 0.554687,1 1,1 l 14,0 c 0.445313,0 0.992367,-0.554753 1,-1 L 19,6 13,0 z"
      id="path4"
      inkscape:connector-curvature="0"

--- a/Numix/22x22/mimetypes/text-x-octave.svg
+++ b/Numix/22x22/mimetypes/text-x-octave.svg
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   viewBox="0 0 22 22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="application-json2.svg">
+  <metadata
+     id="metadata20">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs18">
+    <clipPath
+       id="clipPath-883211809">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19" />
+      </g>
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview16"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="9.424365"
+     inkscape:cy="9.109097"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3008"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#795a8b;fill-opacity:1"
+     d="M 4,0 C 3.527343,0 3,0.527344 3,1 l 0,20 c 0,0.445312 0.554687,1 1,1 l 14,0 c 0.445313,0 0.992367,-0.554753 1,-1 L 19,6 13,0 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssssccs" />
+  <path
+     style="fill:#000000;fill-opacity:0.19599998"
+     d="m 14,6 5,5 0,-5 z"
+     id="path6-5"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccc" />
+  <path
+     style="fill:#ffffff;fill-opacity:0.39200003"
+     d="m 13,0 6,6 -5,0 C 13.554688,6 13,5.445312 13,5 z"
+     id="path8-8"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccssc" />
+  <g
+     transform="matrix(0.41664931,0,0,0.41664931,1.0002083,3.0017826)"
+     id="g3469">
+    <g
+       id="g3471"
+       clip-path="url(#clipPath-883211809)">
+      <!-- color: #eeeeee -->
+      <g
+         id="g3473">
+        <path
+           style="fill:#ffffff;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           id="path3475"
+           d="m 15.988,14.492 c -3.766,4.04 -2.852,11.574 2.031,16.828 4.887,5.25 11.898,6.227 15.66,2.184 3.762,-4.04 2.852,-11.578 -2.035,-16.824 -4.887,-5.254 -11.898,-6.23 -15.66,-2.187 m 3.414,1.68 c 2.957,-3.18 8.391,-2.488 12.141,1.543 3.75,4.03 4.395,9.875 1.434,13.05 -2.953,3.18 -8.395,2.488 -12.141,-1.539 -3.75,-4.03 -4.391,-9.871 -1.438,-13.05 m 0.004,0" />
+        <path
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           id="path3477"
+           d="m 30.242198,15.116351 2.637234,0 c 0.398097,0 0.721468,0.323371 0.721468,0.721468 l 0,2.637234 c 0,0.398097 -0.323371,0.721468 -0.721468,0.721468 l -2.637234,0 c -0.398097,0 -0.721468,-0.323371 -0.721468,-0.721468 l 0,-2.637234 c 0,-0.398097 0.323371,-0.721468 0.721468,-0.721468 m 0,0" />
+        <path
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           id="path3479"
+           d="m 13.276809,19.201661 4.646682,0 c 0.707282,0 1.276809,0.570555 1.276809,1.272697 l 0,4.649766 c 0,0.70317 -0.570555,1.272697 -1.276809,1.272697 l -4.646682,0 C 12.569527,26.396821 12,25.826266 12,25.124124 l 0,-4.649766 c 0,-0.70317 0.570555,-1.272697 1.276809,-1.272697 m 0,0" />
+        <path
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           id="path3481"
+           d="m 32.052185,28.80172 3.09743,0 c 0.468406,0 0.851385,0.37914 0.851385,0.847546 l 0,3.100309 c 0,0.468406 -0.38202,0.847546 -0.851385,0.847546 l -3.09743,0 c -0.468406,0 -0.851385,-0.37914 -0.851385,-0.847546 l 0,-3.100309 c 0,-0.468406 0.38202,-0.847546 0.851385,-0.847546 m 0,0" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/Numix/24x24/mimetypes/text-x-matlab.svg
+++ b/Numix/24x24/mimetypes/text-x-matlab.svg
@@ -1,0 +1,1 @@
+text-x-octave.svg

--- a/Numix/24x24/mimetypes/text-x-octave.svg
+++ b/Numix/24x24/mimetypes/text-x-octave.svg
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="application-json.svg">
+  <metadata
+     id="metadata20">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs18">
+    <clipPath
+       id="clipPath-883211809">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19" />
+      </g>
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview16"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="19.89005"
+     inkscape:cy="10.760761"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3008"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#795a8b;fill-opacity:1"
+     d="M 5,1 C 4.527343,1 4,1.527344 4,2 l 0,20 c 0,0.445312 0.554687,1 1,1 l 14,0 c 0.445313,0 0.992367,-0.554753 1,-1 L 20,7 14,1 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssssccs" />
+  <path
+     style="fill:#000000;fill-opacity:0.19599998"
+     d="m 15,7 5,5 0,-5 z"
+     id="path6-5"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccc" />
+  <path
+     style="fill:#ffffff;fill-opacity:0.39200003"
+     d="m 14,1 6,6 -5,0 C 14.554688,7 14,6.445312 14,6 z"
+     id="path8-8"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccssc" />
+  <g
+     transform="matrix(0.41664931,0,0,0.41664931,2.0002083,4.0017826)"
+     id="g3469">
+    <g
+       id="g3471"
+       clip-path="url(#clipPath-883211809)">
+      <!-- color: #eeeeee -->
+      <g
+         id="g3473">
+        <path
+           style="fill:#ffffff;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           id="path3475"
+           d="m 15.988,14.492 c -3.766,4.04 -2.852,11.574 2.031,16.828 4.887,5.25 11.898,6.227 15.66,2.184 3.762,-4.04 2.852,-11.578 -2.035,-16.824 -4.887,-5.254 -11.898,-6.23 -15.66,-2.187 m 3.414,1.68 c 2.957,-3.18 8.391,-2.488 12.141,1.543 3.75,4.03 4.395,9.875 1.434,13.05 -2.953,3.18 -8.395,2.488 -12.141,-1.539 -3.75,-4.03 -4.391,-9.871 -1.438,-13.05 m 0.004,0" />
+        <path
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           id="path3477"
+           d="m 30.242198,15.116351 2.637234,0 c 0.398097,0 0.721468,0.323371 0.721468,0.721468 l 0,2.637234 c 0,0.398097 -0.323371,0.721468 -0.721468,0.721468 l -2.637234,0 c -0.398097,0 -0.721468,-0.323371 -0.721468,-0.721468 l 0,-2.637234 c 0,-0.398097 0.323371,-0.721468 0.721468,-0.721468 m 0,0" />
+        <path
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           id="path3479"
+           d="m 13.276809,19.201661 4.646682,0 c 0.707282,0 1.276809,0.570555 1.276809,1.272697 l 0,4.649766 c 0,0.70317 -0.570555,1.272697 -1.276809,1.272697 l -4.646682,0 C 12.569527,26.396821 12,25.826266 12,25.124124 l 0,-4.649766 c 0,-0.70317 0.570555,-1.272697 1.276809,-1.272697 m 0,0" />
+        <path
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           id="path3481"
+           d="m 32.052185,28.80172 3.09743,0 c 0.468406,0 0.851385,0.37914 0.851385,0.847546 l 0,3.100309 c 0,0.468406 -0.38202,0.847546 -0.851385,0.847546 l -3.09743,0 c -0.468406,0 -0.851385,-0.37914 -0.851385,-0.847546 l 0,-3.100309 c 0,-0.468406 0.38202,-0.847546 0.851385,-0.847546 m 0,0" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/Numix/24x24/mimetypes/text-x-octave.svg
+++ b/Numix/24x24/mimetypes/text-x-octave.svg
@@ -13,7 +13,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="application-json.svg">
+   sodipodi:docname="text-x-octave.svg">
   <metadata
      id="metadata20">
     <rdf:RDF>
@@ -56,7 +56,7 @@
      id="namedview16"
      showgrid="false"
      inkscape:zoom="1"
-     inkscape:cx="19.89005"
+     inkscape:cx="18.343254"
      inkscape:cy="10.760761"
      inkscape:window-x="0"
      inkscape:window-y="28"
@@ -71,7 +71,7 @@
        snapvisiblegridlinesonly="true" />
   </sodipodi:namedview>
   <path
-     style="fill:#795a8b;fill-opacity:1"
+     style="fill:#ef6f29;fill-opacity:1"
      d="M 5,1 C 4.527343,1 4,1.527344 4,2 l 0,20 c 0,0.445312 0.554687,1 1,1 l 14,0 c 0.445313,0 0.992367,-0.554753 1,-1 L 20,7 14,1 z"
      id="path4"
      inkscape:connector-curvature="0"

--- a/Numix/256x256/mimetypes/text-x-matlab.svg
+++ b/Numix/256x256/mimetypes/text-x-matlab.svg
@@ -1,0 +1,1 @@
+text-x-octave.svg

--- a/Numix/256x256/mimetypes/text-x-octave.svg
+++ b/Numix/256x256/mimetypes/text-x-octave.svg
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="256px"
+   height="256px"
+   viewBox="0 0 256 256"
+   version="1.1"
+   id="svg2"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="application-json.svg">
+  <metadata
+     id="metadata19">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs17">
+    <clipPath
+       id="clipPath-883211809-3">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17-2">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19-9" />
+      </g>
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview15"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="110.5"
+     inkscape:cy="92.852814"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4163" />
+  </sodipodi:namedview>
+  <g
+     id="surface1">
+    <path
+       style="stroke:none;fill-rule:nonzero;fill:#795a8b;fill-opacity:1"
+       d="M 42.6875 0 C 37.1875 0 32 5.421875 32 11.15625 L 32 244.84375 C 32 250.265625 37.5 256 42.6875 256 L 213.3125 256 C 218.5 256 224 250.265625 224 244.84375 L 224 72 L 152 0 Z M 42.6875 0 "
+       id="path5" />
+    <path
+       style=" stroke:none;fill-rule:nonzero;fill:rgb(0%,0%,0%);fill-opacity:0.196078;"
+       d="M 168 72 L 224 128 L 224 72 Z M 168 72 "
+       id="path7" />
+    <path
+       style=" stroke:none;fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:0.392157;"
+       d="M 152 0 L 223.9375 72 L 163.03125 72 C 157.640625 72 152 66.296875 152 60.90625 Z M 152 0 "
+       id="path9" />
+  </g>
+  <g
+     id="g64"
+     style="fill:#ffffff"
+     transform="matrix(4.6664722,0,0,4.6671466,17.002335,43.995689)">
+    <g
+       clip-path="url(#clipPath-883211809-3)"
+       id="g66"
+       style="fill:#ffffff">
+      <!-- color: #eeeeee -->
+      <g
+         id="g68"
+         style="fill:#ffffff">
+        <path
+           d="m 15.988,14.492 c -3.766,4.04 -2.852,11.574 2.031,16.828 4.887,5.25 11.898,6.227 15.66,2.184 3.762,-4.04 2.852,-11.578 -2.035,-16.824 -4.887,-5.254 -11.898,-6.23 -15.66,-2.187 m 3.414,1.68 c 2.957,-3.18 8.219948,-2.488 11.969948,1.543 3.75,4.03 4.479921,9.875 1.518921,13.05 -2.953,3.18 -8.308869,2.488 -12.054869,-1.539 -3.75,-4.03 -4.391,-9.871 -1.438,-13.05"
+           id="path70"
+           style="fill:#ffffff;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccccc" />
+        <path
+           d="m 30.606276,15.427414 2.216162,0 c 0.334537,0 0.606276,0.271739 0.606276,0.606276 l 0,2.216162 c 0,0.334536 -0.271739,0.606276 -0.606276,0.606276 l -2.216162,0 C 30.27174,18.856128 30,18.584388 30,18.249852 l 0,-2.216162 c 0,-0.334537 0.27174,-0.606276 0.606276,-0.606276 m 0,0"
+           id="path72"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 13.644598,20.574141 4.425411,0 c 0.673602,0 1.216009,0.543385 1.216009,1.212092 l 0,4.428348 c 0,0.669686 -0.543386,1.212093 -1.216009,1.212093 l -4.425411,0 c -0.673602,0 -1.216009,-0.543386 -1.216009,-1.212093 l 0,-4.428348 c 0,-0.669686 0.543386,-1.212092 1.216009,-1.212092 m 0,0"
+           id="path74"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 31.770127,29.145183 3.318675,0 c 0.501863,0 0.912198,0.406221 0.912198,0.908084 l 0,3.32176 c 0,0.501864 -0.409306,0.908085 -0.912198,0.908085 l -3.318675,0 c -0.501863,0 -0.912198,-0.406221 -0.912198,-0.908085 l 0,-3.32176 c 0,-0.501863 0.409307,-0.908084 0.912198,-0.908084 m 0,0"
+           id="path76"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/Numix/256x256/mimetypes/text-x-octave.svg
+++ b/Numix/256x256/mimetypes/text-x-octave.svg
@@ -13,7 +13,7 @@
    version="1.1"
    id="svg2"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="application-json.svg">
+   sodipodi:docname="text-x-octave.svg">
   <metadata
      id="metadata19">
     <rdf:RDF>
@@ -55,7 +55,7 @@
      id="namedview15"
      showgrid="false"
      inkscape:zoom="1"
-     inkscape:cx="110.5"
+     inkscape:cx="93"
      inkscape:cy="92.852814"
      inkscape:window-x="0"
      inkscape:window-y="28"
@@ -68,7 +68,7 @@
   <g
      id="surface1">
     <path
-       style="stroke:none;fill-rule:nonzero;fill:#795a8b;fill-opacity:1"
+       style="stroke:none;fill-rule:nonzero;fill:#ef6f29;fill-opacity:1"
        d="M 42.6875 0 C 37.1875 0 32 5.421875 32 11.15625 L 32 244.84375 C 32 250.265625 37.5 256 42.6875 256 L 213.3125 256 C 218.5 256 224 250.265625 224 244.84375 L 224 72 L 152 0 Z M 42.6875 0 "
        id="path5" />
     <path

--- a/Numix/32x32/mimetypes/text-x-matlab.svg
+++ b/Numix/32x32/mimetypes/text-x-matlab.svg
@@ -1,0 +1,1 @@
+text-x-octave.svg

--- a/Numix/32x32/mimetypes/text-x-octave.svg
+++ b/Numix/32x32/mimetypes/text-x-octave.svg
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   height="32"
+   viewBox="0 0 32 32"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="test4b-32.svg">
+  <metadata
+     id="metadata20">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs18">
+    <clipPath
+       id="clipPath-883211809">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-883211809-6">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17-4">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19-1" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-883211809-3">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17-2">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19-9" />
+      </g>
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview16"
+     showgrid="true"
+     inkscape:zoom="32"
+     inkscape:cx="16"
+     inkscape:cy="14.464466"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3008" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#795a8b;fill-opacity:1"
+     d="M 5.335888,2.977e-4 C 4.648414,3.127e-4 4,0.6767877 4,1.3940317 L 4,30.606268 C 4,31.282757 4.687474,32 5.335888,32 l 21.327332,0 c 0.648414,0 1.335888,-0.717243 1.335888,-1.393732 L 28,8.9999997 l -9,-9 z"
+     id="path4-1"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssssccs" />
+  <path
+     style="fill:#000000;fill-opacity:0.19599998"
+     d="M 21,8.9999997 28,16 28,8.9999997 z"
+     id="path6-4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccc" />
+  <path
+     style="fill:#ffffff;fill-opacity:0.39200003"
+     d="m 19.000306,2.977e-4 8.991594,8.999702 -7.613262,0 c -0.672951,0 -1.378332,-0.713489 -1.378332,-1.38644 z"
+     id="path8-6"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccssc" />
+  <g
+     id="g64"
+     style="fill:#ffffff"
+     transform="matrix(0.58330903,0,0,0.58339335,2.0002916,4.9994605)">
+    <g
+       clip-path="url(#clipPath-883211809-3)"
+       id="g66"
+       style="fill:#ffffff">
+      <!-- color: #eeeeee -->
+      <g
+         id="g68"
+         style="fill:#ffffff">
+        <path
+           d="m 15.988,14.492 c -3.766,4.04 -2.852,11.574 2.031,16.828 4.887,5.25 11.898,6.227 15.66,2.184 3.762,-4.04 2.852,-11.578 -2.035,-16.824 -4.887,-5.254 -11.898,-6.23 -15.66,-2.187 m 3.414,1.68 c 2.957,-3.18 8.047657,-2.488 11.797657,1.543 3.75,4.03 4.567353,9.875 1.606353,13.05 -2.953,3.18 -8.22401,2.488 -11.97001,-1.539 -3.75,-4.03 -4.391,-9.871 -1.438,-13.05"
+           id="path70"
+           style="fill:#ffffff;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccccc" />
+        <path
+           d="m 29.749847,15.427414 2.216162,0 c 0.334537,0 0.606276,0.271739 0.606276,0.606276 l 0,2.216162 c 0,0.334536 -0.271739,0.606276 -0.606276,0.606276 l -2.216162,0 c -0.334536,0 -0.606276,-0.27174 -0.606276,-0.606276 l 0,-2.216162 c 0,-0.334537 0.27174,-0.606276 0.606276,-0.606276 m 0,0"
+           id="path72"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 13.216009,20.574141 4.425411,0 c 0.673602,0 1.216009,0.543385 1.216009,1.212092 l 0,4.428348 c 0,0.669686 -0.543386,1.212093 -1.216009,1.212093 l -4.425411,0 C 12.542407,27.426674 12,26.883288 12,26.214581 l 0,-4.428348 c 0,-0.669686 0.543386,-1.212092 1.216009,-1.212092 m 0,0"
+           id="path74"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 31.770127,29.145183 3.318675,0 c 0.501863,0 0.912198,0.406221 0.912198,0.908084 l 0,3.32176 c 0,0.501864 -0.409306,0.908085 -0.912198,0.908085 l -3.318675,0 c -0.501863,0 -0.912198,-0.406221 -0.912198,-0.908085 l 0,-3.32176 c 0,-0.501863 0.409307,-0.908084 0.912198,-0.908084 m 0,0"
+           id="path76"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/Numix/32x32/mimetypes/text-x-octave.svg
+++ b/Numix/32x32/mimetypes/text-x-octave.svg
@@ -13,7 +13,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="test4b-32.svg">
+   sodipodi:docname="text-x-octave.svg">
   <metadata
      id="metadata20">
     <rdf:RDF>
@@ -80,9 +80,9 @@
      inkscape:window-width="1366"
      inkscape:window-height="713"
      id="namedview16"
-     showgrid="true"
-     inkscape:zoom="32"
-     inkscape:cx="16"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="15.453125"
      inkscape:cy="14.464466"
      inkscape:window-x="0"
      inkscape:window-y="28"
@@ -93,7 +93,7 @@
        id="grid3008" />
   </sodipodi:namedview>
   <path
-     style="fill:#795a8b;fill-opacity:1"
+     style="fill:#ef6f29;fill-opacity:1"
      d="M 5.335888,2.977e-4 C 4.648414,3.127e-4 4,0.6767877 4,1.3940317 L 4,30.606268 C 4,31.282757 4.687474,32 5.335888,32 l 21.327332,0 c 0.648414,0 1.335888,-0.717243 1.335888,-1.393732 L 28,8.9999997 l -9,-9 z"
      id="path4-1"
      inkscape:connector-curvature="0"

--- a/Numix/48x48/mimetypes/text-x-matlab.svg
+++ b/Numix/48x48/mimetypes/text-x-matlab.svg
@@ -1,0 +1,1 @@
+text-x-octave.svg

--- a/Numix/48x48/mimetypes/text-x-octave.svg
+++ b/Numix/48x48/mimetypes/text-x-octave.svg
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   viewBox="0 0 48 48"
+   height="48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="octave-test1.svg">
+  <metadata
+     id="metadata28">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs26">
+    <clipPath
+       id="clipPath-883211809">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19" />
+      </g>
+    </clipPath>
+    <radialGradient
+       id="radial0"
+       gradientUnits="userSpaceOnUse"
+       cx="182.98"
+       cy="395.04999"
+       r="148.95"
+       gradientTransform="matrix(0.165918,-0.178305,0.553456,0.594776,-229.68345,-169.66171)">
+      <stop
+         stop-color="#008cbe"
+         stop-opacity="1"
+         id="stop22" />
+      <stop
+         offset="1"
+         stop-color="#b2ffff"
+         stop-opacity="1"
+         id="stop24" />
+    </radialGradient>
+    <radialGradient
+       id="radialGradient3505"
+       gradientUnits="userSpaceOnUse"
+       cx="182.98"
+       cy="395.04999"
+       r="148.95"
+       gradientTransform="matrix(0.165918,-0.178305,0.553456,0.594776,-229.68345,-169.66171)">
+      <stop
+         stop-color="#008cbe"
+         stop-opacity="1"
+         id="stop3507" />
+      <stop
+         offset="1"
+         stop-color="#b2ffff"
+         stop-opacity="1"
+         id="stop3509" />
+    </radialGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview24"
+     showgrid="true"
+     inkscape:zoom="16"
+     inkscape:cx="14.132032"
+     inkscape:cy="14.385445"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3405" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#795a8b"
+     d="M 8,1 C 6.9714285,1 6,1.9714285 6,3 l 0,42 c 0,0.971429 1.0285714,2 2,2 l 32,0 c 0.971429,0 2,-1.028571 2,-2 L 42,14 29,1 z"
+     id="path4" />
+  <path
+     style="fill-opacity:.196"
+     d="M 29,12 29.0625,12.0625 29.21875,12 29,12 z m 2,2 11,11 0,-11 -11,0 z"
+     id="path6" />
+  <path
+     style="fill:#fff;fill-opacity:.392"
+     d="m 29,1 13,13 -11,0 c -0.971429,0 -2,-1.028571 -2,-2 L 29,1 z"
+     id="path8" />
+  <g
+     style="fill:#fff"
+     id="g12">
+    <g
+       style="word-spacing:0;line-height:125%;letter-spacing:0"
+       transform="matrix(1.00959 0 0 .88456 -4.86228 8.04713)"
+       id="g16" />
+  </g>
+  <g
+     transform="matrix(0.83329861,0,0,0.83329861,4.0004167,8.0035656)"
+     id="g3469">
+    <g
+       id="g3471"
+       clip-path="url(#clipPath-883211809)">
+      <!-- color: #eeeeee -->
+      <g
+         id="g3473">
+        <path
+           style="fill:#ffffff;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           id="path3475"
+           d="m 15.988,14.492 c -3.766,4.04 -2.852,11.574 2.031,16.828 4.887,5.25 11.898,6.227 15.66,2.184 3.762,-4.04 2.852,-11.578 -2.035,-16.824 -4.887,-5.254 -11.898,-6.23 -15.66,-2.187 m 3.414,1.68 c 2.957,-3.18 8.031199,-2.488 11.781199,1.543 3.75,4.03 4.63507,9.875 1.67407,13.05 -2.953,3.18 -8.275269,2.488 -12.021269,-1.539 -3.75,-4.03 -4.391,-9.871 -1.438,-13.05"
+           sodipodi:nodetypes="cccccccccc" />
+        <path
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           id="path3477"
+           d="m 30.63659,15.596371 2.32697,0 c 0.351263,0 0.63659,0.285327 0.63659,0.63659 l 0,2.32697 c 0,0.351263 -0.285327,0.63659 -0.63659,0.63659 l -2.32697,0 C 30.285327,19.196521 30,18.911194 30,18.559931 l 0,-2.32697 c 0,-0.351263 0.285327,-0.63659 0.63659,-0.63659 m 0,0" />
+        <path
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           id="path3479"
+           d="m 13.276809,20.401711 4.646682,0 c 0.707282,0 1.276809,0.570555 1.276809,1.272697 l 0,4.649766 c 0,0.70317 -0.570555,1.272697 -1.276809,1.272697 l -4.646682,0 C 12.569527,27.596871 12,27.026316 12,26.324174 l 0,-4.649766 c 0,-0.70317 0.570555,-1.272697 1.276809,-1.272697 m 0,0" />
+        <path
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           id="path3481"
+           d="m 32.052185,28.80172 3.09743,0 c 0.468406,0 0.851385,0.37914 0.851385,0.847546 l 0,3.100309 c 0,0.468406 -0.38202,0.847546 -0.851385,0.847546 l -3.09743,0 c -0.468406,0 -0.851385,-0.37914 -0.851385,-0.847546 l 0,-3.100309 c 0,-0.468406 0.38202,-0.847546 0.851385,-0.847546 m 0,0" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/Numix/48x48/mimetypes/text-x-octave.svg
+++ b/Numix/48x48/mimetypes/text-x-octave.svg
@@ -13,7 +13,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="octave-test1.svg">
+   sodipodi:docname="text-x-octave.svg">
   <metadata
      id="metadata28">
     <rdf:RDF>
@@ -88,9 +88,9 @@
      inkscape:window-width="1366"
      inkscape:window-height="713"
      id="namedview24"
-     showgrid="true"
-     inkscape:zoom="16"
-     inkscape:cx="14.132032"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="13.038282"
      inkscape:cy="14.385445"
      inkscape:window-x="0"
      inkscape:window-y="28"
@@ -101,7 +101,7 @@
        id="grid3405" />
   </sodipodi:namedview>
   <path
-     style="fill:#795a8b"
+     style="fill:#ef6f29;fill-opacity:1"
      d="M 8,1 C 6.9714285,1 6,1.9714285 6,3 l 0,42 c 0,0.971429 1.0285714,2 2,2 l 32,0 c 0.971429,0 2,-1.028571 2,-2 L 42,14 29,1 z"
      id="path4" />
   <path

--- a/Numix/64x64/mimetypes/text-x-matlab.svg
+++ b/Numix/64x64/mimetypes/text-x-matlab.svg
@@ -1,0 +1,1 @@
+text-x-octave.svg

--- a/Numix/64x64/mimetypes/text-x-octave.svg
+++ b/Numix/64x64/mimetypes/text-x-octave.svg
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   viewBox="0 0 64 64"
+   version="1.1"
+   id="svg2"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="application-json.svg">
+  <metadata
+     id="metadata19">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs17">
+    <clipPath
+       id="clipPath-883211809-3">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17-2">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19-9" />
+      </g>
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview15"
+     showgrid="false"
+     inkscape:zoom="4"
+     inkscape:cx="28.906408"
+     inkscape:cy="17.428932"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3363" />
+  </sodipodi:namedview>
+  <g
+     id="surface1">
+    <path
+       style="stroke:none;fill-rule:nonzero;fill:#795a8b;fill-opacity:1"
+       d="M 10.671875 0 C 9.296875 0 8 1.355469 8 2.789062 L 8 61.210938 C 8 62.566406 9.375 64 10.671875 64 L 53.328125 64 C 54.625 64 56 62.566406 56 61.210938 L 56 18 L 38 0 Z M 10.671875 0 "
+       id="path5" />
+    <path
+       style=" stroke:none;fill-rule:nonzero;fill:rgb(0%,0%,0%);fill-opacity:0.196078;"
+       d="M 42 18 L 56 32 L 56 18 Z M 42 18 "
+       id="path7" />
+    <path
+       style=" stroke:none;fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:0.392157;"
+       d="M 38 0 L 55.984375 18 L 40.757812 18 C 39.410156 18 38 16.574219 38 15.226562 Z M 38 0 "
+       id="path9" />
+  </g>
+  <g
+     id="g64"
+     style="fill:#ffffff"
+     transform="matrix(1.1666181,0,0,1.1667867,4.0005837,10.998921)">
+    <g
+       clip-path="url(#clipPath-883211809-3)"
+       id="g66"
+       style="fill:#ffffff">
+      <!-- color: #eeeeee -->
+      <g
+         id="g68"
+         style="fill:#ffffff">
+        <path
+           d="m 15.988,14.492 c -3.766,4.04 -2.852,11.574 2.031,16.828 4.887,5.25 11.898,6.227 15.66,2.184 3.762,-4.04 2.852,-11.578 -2.035,-16.824 -4.887,-5.254 -11.898,-6.23 -15.66,-2.187 m 3.414,1.68 c 2.957,-3.18 8.219948,-2.488 11.969948,1.543 3.75,4.03 4.479921,9.875 1.518921,13.05 -2.953,3.18 -8.308869,2.488 -12.054869,-1.539 -3.75,-4.03 -4.391,-9.871 -1.438,-13.05"
+           id="path70"
+           style="fill:#ffffff;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccccc" />
+        <path
+           d="m 30.606276,15.427414 2.216162,0 c 0.334537,0 0.606276,0.271739 0.606276,0.606276 l 0,2.216162 c 0,0.334536 -0.271739,0.606276 -0.606276,0.606276 l -2.216162,0 C 30.27174,18.856128 30,18.584388 30,18.249852 l 0,-2.216162 c 0,-0.334537 0.27174,-0.606276 0.606276,-0.606276 m 0,0"
+           id="path72"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 13.216009,20.574141 4.425411,0 c 0.673602,0 1.216009,0.543385 1.216009,1.212092 l 0,4.428348 c 0,0.669686 -0.543386,1.212093 -1.216009,1.212093 l -4.425411,0 C 12.542407,27.426674 12,26.883288 12,26.214581 l 0,-4.428348 c 0,-0.669686 0.543386,-1.212092 1.216009,-1.212092 m 0,0"
+           id="path74"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 31.770127,29.145183 3.318675,0 c 0.501863,0 0.912198,0.406221 0.912198,0.908084 l 0,3.32176 c 0,0.501864 -0.409306,0.908085 -0.912198,0.908085 l -3.318675,0 c -0.501863,0 -0.912198,-0.406221 -0.912198,-0.908085 l 0,-3.32176 c 0,-0.501863 0.409307,-0.908084 0.912198,-0.908084 m 0,0"
+           id="path76"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/Numix/64x64/mimetypes/text-x-octave.svg
+++ b/Numix/64x64/mimetypes/text-x-octave.svg
@@ -13,7 +13,7 @@
    version="1.1"
    id="svg2"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="application-json.svg">
+   sodipodi:docname="text-x-octave.svg">
   <metadata
      id="metadata19">
     <rdf:RDF>
@@ -55,8 +55,8 @@
      inkscape:window-height="713"
      id="namedview15"
      showgrid="false"
-     inkscape:zoom="4"
-     inkscape:cx="28.906408"
+     inkscape:zoom="1"
+     inkscape:cx="24.531408"
      inkscape:cy="17.428932"
      inkscape:window-x="0"
      inkscape:window-y="28"
@@ -69,7 +69,7 @@
   <g
      id="surface1">
     <path
-       style="stroke:none;fill-rule:nonzero;fill:#795a8b;fill-opacity:1"
+       style="stroke:none;fill-rule:nonzero;fill:#ef6f29;fill-opacity:1"
        d="M 10.671875 0 C 9.296875 0 8 1.355469 8 2.789062 L 8 61.210938 C 8 62.566406 9.375 64 10.671875 64 L 53.328125 64 C 54.625 64 56 62.566406 56 61.210938 L 56 18 L 38 0 Z M 10.671875 0 "
        id="path5" />
     <path


### PR DESCRIPTION
Pushed design, same colour as formula mimetype:
![octave](https://cloud.githubusercontent.com/assets/7050624/6920595/a7efffae-d7bf-11e4-8179-3bb89c1c09d4.png)
Alternative colour (from cubes in Octave logo):
![octave2](https://cloud.githubusercontent.com/assets/7050624/6920605/b74b87ac-d7bf-11e4-9a4c-ef8c5d0789d5.png)


