### PR TITLE
Removed bluetooth.svg

### DIFF
--- a/Numix-Light/16x16/status/bluetooth.svg
+++ b/Numix-Light/16x16/status/bluetooth.svg
@@ -1,1 +1,0 @@
-bluetooth-active.svg

--- a/Numix-Light/22x22/status/bluetooth.svg
+++ b/Numix-Light/22x22/status/bluetooth.svg
@@ -1,1 +1,0 @@
-bluetooth-active.svg

--- a/Numix-Light/24x24/status/bluetooth.svg
+++ b/Numix-Light/24x24/status/bluetooth.svg
@@ -1,1 +1,0 @@
-bluetooth-active.svg

--- a/Numix/16x16/status/bluetooth.svg
+++ b/Numix/16x16/status/bluetooth.svg
@@ -1,1 +1,0 @@
-bluetooth-active.svg

--- a/Numix/22x22/status/bluetooth.svg
+++ b/Numix/22x22/status/bluetooth.svg
@@ -1,1 +1,0 @@
-bluetooth-active.svg

--- a/Numix/24x24/status/bluetooth.svg
+++ b/Numix/24x24/status/bluetooth.svg
@@ -1,1 +1,0 @@
-bluetooth-active.svg


### PR DESCRIPTION
Removed `bluetooth.svg` (symlink). Fixes https://github.com/numixproject/numix-icon-theme/issues/438.

Alternative, cf. discussion over at https://github.com/numixproject/numix-icon-theme/issues/438: rename `bluetooth.svg`.