### PR TITLE
Removed blueman-tray.svg

### DIFF
--- a/Numix-Light/16x16/status/blueman-tray.svg
+++ b/Numix-Light/16x16/status/blueman-tray.svg
@@ -1,1 +1,0 @@
-bluetooth-active.svg

--- a/Numix-Light/22x22/status/blueman-tray.svg
+++ b/Numix-Light/22x22/status/blueman-tray.svg
@@ -1,1 +1,0 @@
-bluetooth-active.svg

--- a/Numix-Light/24x24/status/blueman-tray.svg
+++ b/Numix-Light/24x24/status/blueman-tray.svg
@@ -1,1 +1,0 @@
-bluetooth-active.svg

--- a/Numix/16x16/status/blueman-tray.svg
+++ b/Numix/16x16/status/blueman-tray.svg
@@ -1,1 +1,0 @@
-bluetooth-active.svg

--- a/Numix/22x22/status/blueman-tray.svg
+++ b/Numix/22x22/status/blueman-tray.svg
@@ -1,1 +1,0 @@
-bluetooth-active.svg

--- a/Numix/24x24/status/blueman-tray.svg
+++ b/Numix/24x24/status/blueman-tray.svg
@@ -1,1 +1,0 @@
-bluetooth-active.svg


### PR DESCRIPTION
Removed blueman-tray.svg (symlink). Fixes https://github.com/numixproject/numix-icon-theme/issues/439.