### PR TITLE
Symlinks for image-loading.svg fixes #138

### DIFF
--- a/Numix/128x128/actions/image-loading.svg
+++ b/Numix/128x128/actions/image-loading.svg
@@ -1,0 +1,1 @@
+../places/gnome-fs-loading-icon.svg

--- a/Numix/16x16/actions/image-loading.svg
+++ b/Numix/16x16/actions/image-loading.svg
@@ -1,0 +1,1 @@
+../places/gnome-fs-loading-icon.svg

--- a/Numix/22x22/actions/image-loading.svg
+++ b/Numix/22x22/actions/image-loading.svg
@@ -1,0 +1,1 @@
+../places/gnome-fs-loading-icon.svg

--- a/Numix/24x24/actions/image-loading.svg
+++ b/Numix/24x24/actions/image-loading.svg
@@ -1,0 +1,1 @@
+../places/gnome-fs-loading-icon.svg

--- a/Numix/256x256/actions/image-loading.svg
+++ b/Numix/256x256/actions/image-loading.svg
@@ -1,0 +1,1 @@
+../places/gnome-fs-loading-icon.svg

--- a/Numix/32x32/actions/image-loading.svg
+++ b/Numix/32x32/actions/image-loading.svg
@@ -1,0 +1,1 @@
+../places/gnome-fs-loading-icon.svg

--- a/Numix/48x48/actions/image-loading.svg
+++ b/Numix/48x48/actions/image-loading.svg
@@ -1,0 +1,1 @@
+../places/gnome-fs-loading-icon.svg

--- a/Numix/64x64/actions/image-loading.svg
+++ b/Numix/64x64/actions/image-loading.svg
@@ -1,0 +1,1 @@
+../places/gnome-fs-loading-icon.svg

--- a/Numix/96x96/actions/image-loading.svg
+++ b/Numix/96x96/actions/image-loading.svg
@@ -1,0 +1,1 @@
+../places/gnome-fs-loading-icon.svg


### PR DESCRIPTION
Image loading (used for preview thumbnails) icons were missing but loading icon (similar to elementary icon theme) was already present. -> Symlinks