### PR TITLE
Removes network wired from status. Adds symlinks in devices

### DIFF
--- a/Numix-Light/16x16/status/network-wired.svg
+++ b/Numix-Light/16x16/status/network-wired.svg
@@ -1,1 +1,0 @@
-network-transmit-receive.svg

--- a/Numix-Light/22x22/status/network-wired.svg
+++ b/Numix-Light/22x22/status/network-wired.svg
@@ -1,1 +1,0 @@
-network-transmit-receive.svg

--- a/Numix-Light/24x24/status/network-wired.svg
+++ b/Numix-Light/24x24/status/network-wired.svg
@@ -1,1 +1,0 @@
-network-transmit-receive.svg

--- a/Numix/128x128/devices/network-wired.svg
+++ b/Numix/128x128/devices/network-wired.svg
@@ -1,0 +1,1 @@
+nm-device-wired.svg

--- a/Numix/16x16/devices/network-wired.svg
+++ b/Numix/16x16/devices/network-wired.svg
@@ -1,0 +1,1 @@
+nm-device-wired.svg

--- a/Numix/16x16/status/network-wired.svg
+++ b/Numix/16x16/status/network-wired.svg
@@ -1,1 +1,0 @@
-network-transmit-receive.svg

--- a/Numix/22x22/devices/network-wired.svg
+++ b/Numix/22x22/devices/network-wired.svg
@@ -1,0 +1,1 @@
+nm-device-wired.svg

--- a/Numix/22x22/status/network-wired.svg
+++ b/Numix/22x22/status/network-wired.svg
@@ -1,1 +1,0 @@
-network-transmit-receive.svg

--- a/Numix/24x24/devices/network-wired.svg
+++ b/Numix/24x24/devices/network-wired.svg
@@ -1,0 +1,1 @@
+nm-device-wired.svg

--- a/Numix/24x24/status/network-wired.svg
+++ b/Numix/24x24/status/network-wired.svg
@@ -1,1 +1,0 @@
-network-transmit-receive.svg

--- a/Numix/256x256/devices/network-wired.svg
+++ b/Numix/256x256/devices/network-wired.svg
@@ -1,0 +1,1 @@
+nm-device-wired.svg

--- a/Numix/32x32/devices/network-wired.svg
+++ b/Numix/32x32/devices/network-wired.svg
@@ -1,0 +1,1 @@
+nm-device-wired.svg

--- a/Numix/48x48/devices/network-wired.svg
+++ b/Numix/48x48/devices/network-wired.svg
@@ -1,0 +1,1 @@
+nm-device-wired.svg

--- a/Numix/64x64/devices/network-wired.svg
+++ b/Numix/64x64/devices/network-wired.svg
@@ -1,0 +1,1 @@
+nm-device-wired.svg


### PR DESCRIPTION
As discussed in #458, removes unnecessary `network-wired.svg` in `status` and adds symlinks to `nm-device-wired.svg` in `devices`