### PR TITLE
Enhanced network-wired-symbolic.svg

### DIFF
--- a/Numix-Light/scalable/status/network-wired-symbolic.svg
+++ b/Numix-Light/scalable/status/network-wired-symbolic.svg
@@ -1,3 +1,61 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" viewBox="0 0 16 16" height="16">
- <path d="m 0,1 0,9.999909 3,1.82e-4 L 3,13 l 2,0 0,2 6,0 0,-2 2,0 0,-2.000091 3,0 L 16,1 z M 3,3 13,3 13,6 3,6 z" fill="#353535"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   viewBox="0 0 16 16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="network-wired-symbolic_LIGHT.svg">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1215"
+     inkscape:window-height="776"
+     id="namedview6"
+     showgrid="true"
+     inkscape:zoom="36.875"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4138" />
+  </sodipodi:namedview>
+  <path
+     style="color:#bebebe;fill:#353535;fill-opacity:1"
+     d="M 3,16 C 1.7952973,16 1,15.202426 1,14 L 1,3 C 1,1.7966102 1.7966102,1 3,1 l 10,0 c 1.20339,0 2,0.7966102 2,2 l 0,11 c 0,1.198056 -0.799552,2 -2,2 z m 2,-4 1.0000001,0 -1e-7,2 4,0 0,-2 1,0 0,-2 2,0 0,-5 C 13,3.2 13,3 12,3 L 4,3 C 3,3 3,3.2033898 3,5 l 0,5 2,0 z"
+     id="path6104"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="scccccccsccccccccccccccc" />
 </svg>

--- a/Numix-Light/scalable/status/network-wired-symbolic.svg
+++ b/Numix-Light/scalable/status/network-wired-symbolic.svg
@@ -13,7 +13,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r"
-   sodipodi:docname="network-wired-symbolic_LIGHT.svg">
+   sodipodi:docname="network-wired-symbolic_16x14_NEU_LIGHT.svg">
   <metadata
      id="metadata10">
     <rdf:RDF>
@@ -54,7 +54,7 @@
   </sodipodi:namedview>
   <path
      style="color:#bebebe;fill:#353535;fill-opacity:1"
-     d="M 3,16 C 1.7952973,16 1,15.202426 1,14 L 1,3 C 1,1.7966102 1.7966102,1 3,1 l 10,0 c 1.20339,0 2,0.7966102 2,2 l 0,11 c 0,1.198056 -0.799552,2 -2,2 z m 2,-4 1.0000001,0 -1e-7,2 4,0 0,-2 1,0 0,-2 2,0 0,-5 C 13,3.2 13,3 12,3 L 4,3 C 3,3 3,3.2033898 3,5 l 0,5 2,0 z"
+     d="M 1.9999999,15 C 0.79529725,15 0,14.202426 0,13 L 0,3 C 0,1.7966102 0.79661015,1 1.9999999,1 L 14,1 c 1.20339,0 2,0.7966102 2,2 l 0,10 c 0,1.198056 -0.799552,2 -2,2 z m 2,-4 L 5,11 l -1e-7,2 L 11,13 l 0,-2 1,0 0,-2 2,0 0,-4 C 14,3.2 14,3 13,3 L 2.9999999,3 c -1,0 -1,0.2033898 -1,2 l 0,4 2,0 z"
      id="path6104"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="scccccccsccccccccccccccc" />

--- a/Numix/scalable/status/network-wired-symbolic.svg
+++ b/Numix/scalable/status/network-wired-symbolic.svg
@@ -13,7 +13,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r"
-   sodipodi:docname="network-wired-symbolic_TEST6.svg">
+   sodipodi:docname="network-wired-symbolic_16x14_NEU.svg">
   <metadata
      id="metadata10">
     <rdf:RDF>
@@ -54,7 +54,7 @@
   </sodipodi:namedview>
   <path
      style="color:#bebebe;fill:#bebebe;fill-opacity:1"
-     d="M 3,16 C 1.7952973,16 1,15.202426 1,14 L 1,3 C 1,1.7966102 1.7966102,1 3,1 l 10,0 c 1.20339,0 2,0.7966102 2,2 l 0,11 c 0,1.198056 -0.799552,2 -2,2 z m 2,-4 1.0000001,0 -1e-7,2 4,0 0,-2 1,0 0,-2 2,0 0,-5 C 13,3.2 13,3 12,3 L 4,3 C 3,3 3,3.2033898 3,5 l 0,5 2,0 z"
+     d="M 1.9999999,15 C 0.79529725,15 0,14.202426 0,13 L 0,3 C 0,1.7966102 0.79661015,1 1.9999999,1 L 14,1 c 1.20339,0 2,0.7966102 2,2 l 0,10 c 0,1.198056 -0.799552,2 -2,2 z m 2,-4 L 5,11 l -1e-7,2 L 11,13 l 0,-2 1,0 0,-2 2,0 0,-4 C 14,3.2 14,3 13,3 L 2.9999999,3 c -1,0 -1,0.2033898 -1,2 l 0,4 2,0 z"
      id="path6104"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="scccccccsccccccccccccccc" />

--- a/Numix/scalable/status/network-wired-symbolic.svg
+++ b/Numix/scalable/status/network-wired-symbolic.svg
@@ -13,7 +13,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r"
-   sodipodi:docname="network-wired-symbolic.svg">
+   sodipodi:docname="network-wired-symbolic_TEST6.svg">
   <metadata
      id="metadata10">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,43 +37,25 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1366"
-     inkscape:window-height="747"
+     inkscape:window-width="1215"
+     inkscape:window-height="776"
      id="namedview6"
      showgrid="true"
-     inkscape:zoom="14.75"
-     inkscape:cx="-2.6295718"
-     inkscape:cy="8.3824468"
-     inkscape:window-x="0"
-     inkscape:window-y="21"
+     inkscape:zoom="36.875"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
        type="xygrid"
        id="grid4138" />
   </sodipodi:namedview>
-  <rect
-     transform="scale(1,-1)"
-     id="rect6106-8-61-2"
-     style="color:#bebebe;opacity:1;fill:#bebebe;fill-opacity:1"
-     ry="0"
-     height="3"
-     width="1"
-     y="-7"
-     x="6" />
   <path
      style="color:#bebebe;fill:#bebebe;fill-opacity:1"
-     d="M 2.5,14 C 1,14 1,14 1,13 L 1,3 C 1,2 1,2 2.5,2 l 11,0 C 15,2 15,2 15,3 l 0,10 c 0,1 0,1 -1.5,1 z m 2.5,-3 1,0 0,2 4,0 0,-2 1,0 0,-2 2,0 0,-5 C 13,3 13,3 12.5,3 l -9,0 C 3,3 3,3 3,4 l 0,5 2,0 z"
+     d="M 3,16 C 1.7952973,16 1,15.202426 1,14 L 1,3 C 1,1.7966102 1.7966102,1 3,1 l 10,0 c 1.20339,0 2,0.7966102 2,2 l 0,11 c 0,1.198056 -0.799552,2 -2,2 z m 2,-4 1.0000001,0 -1e-7,2 4,0 0,-2 1,0 0,-2 2,0 0,-5 C 13,3.2 13,3 12,3 L 4,3 C 3,3 3,3.2033898 3,5 l 0,5 2,0 z"
      id="path6104"
      inkscape:connector-curvature="0"
-     sodipodi:nodetypes="sccccccssccccccccccccccc" />
-  <rect
-     transform="scale(1,-1)"
-     id="rect6106-8-61-1-3"
-     style="color:#bebebe;opacity:1;fill:#bebebe;fill-opacity:1"
-     ry="0"
-     height="3"
-     width="1"
-     y="-7"
-     x="9" />
+     sodipodi:nodetypes="scccccccsccccccccccccccc" />
 </svg>


### PR DESCRIPTION
In continuation of https://github.com/numixproject/numix-icon-theme/pull/478 and https://github.com/numixproject/numix-icon-theme/pull/480, this is an enhanced version of `network-wired-symbolic.svg` for Numix and for Numix-Light.

This icon is consistent with the other "wired" icons in Numix base, and it is consistent with the other Numix icons in GNOME Shell.

Icon:
![proposed](https://cloud.githubusercontent.com/assets/7164227/7445425/c215faca-f1b2-11e4-957f-cad265eb823f.png)

In GNOME Shell (3.16):

![1_proposed](https://cloud.githubusercontent.com/assets/7164227/7445427/d444d018-f1b2-11e4-92db-6b982709552d.png)
![2_proposed](https://cloud.githubusercontent.com/assets/7164227/7445428/d762e6e0-f1b2-11e4-8fef-66ece4ce7df6.png)
