### PR TITLE
Removed unnecessary symlinks in Numix-Light

### DIFF
--- a/Numix-Light/16x16/status/touchpad-indicator-dark-disabled.svg
+++ b/Numix-Light/16x16/status/touchpad-indicator-dark-disabled.svg
@@ -1,1 +1,0 @@
-../../../Numix/16x16/status/touchpad-indicator-dark-disabled.svg

--- a/Numix-Light/16x16/status/touchpad-indicator-dark-enabled.svg
+++ b/Numix-Light/16x16/status/touchpad-indicator-dark-enabled.svg
@@ -1,1 +1,0 @@
-../../../Numix/16x16/status/touchpad-indicator-dark-enabled.svg

--- a/Numix-Light/16x16/status/touchpad-indicator-dark.svg
+++ b/Numix-Light/16x16/status/touchpad-indicator-dark.svg
@@ -1,1 +1,0 @@
-../../../Numix/16x16/status/touchpad-indicator-dark-enabled.svg

--- a/Numix-Light/16x16/status/touchpad-indicator-light-disabled.svg
+++ b/Numix-Light/16x16/status/touchpad-indicator-light-disabled.svg
@@ -1,1 +1,0 @@
-../../../Numix/16x16/status/touchpad-indicator-light-disabled.svg

--- a/Numix-Light/16x16/status/touchpad-indicator-light-enabled.svg
+++ b/Numix-Light/16x16/status/touchpad-indicator-light-enabled.svg
@@ -1,1 +1,0 @@
-../../../Numix/16x16/status/touchpad-indicator-light-enabled.svg

--- a/Numix-Light/16x16/status/touchpad-indicator-light.svg
+++ b/Numix-Light/16x16/status/touchpad-indicator-light.svg
@@ -1,1 +1,0 @@
-../../../Numix/16x16/status/touchpad-indicator-light-enabled.svg

--- a/Numix-Light/16x16/status/variety-indicator-dark.svg
+++ b/Numix-Light/16x16/status/variety-indicator-dark.svg
@@ -1,1 +1,0 @@
-../../../Numix/16x16/status/variety-indicator-dark.svg

--- a/Numix-Light/16x16/status/variety-indicator.svg
+++ b/Numix-Light/16x16/status/variety-indicator.svg
@@ -1,1 +1,0 @@
-../../../Numix/16x16/status/variety-indicator.svg

--- a/Numix-Light/22x22/status/touchpad-indicator-dark-disabled.svg
+++ b/Numix-Light/22x22/status/touchpad-indicator-dark-disabled.svg
@@ -1,1 +1,0 @@
-../../../Numix/22x22/status/touchpad-indicator-dark-disabled.svg

--- a/Numix-Light/22x22/status/touchpad-indicator-dark-enabled.svg
+++ b/Numix-Light/22x22/status/touchpad-indicator-dark-enabled.svg
@@ -1,1 +1,0 @@
-../../../Numix/22x22/status/touchpad-indicator-dark-enabled.svg

--- a/Numix-Light/22x22/status/touchpad-indicator-dark.svg
+++ b/Numix-Light/22x22/status/touchpad-indicator-dark.svg
@@ -1,1 +1,0 @@
-../../../Numix/22x22/status/touchpad-indicator-dark-enabled.svg

--- a/Numix-Light/22x22/status/touchpad-indicator-light-disabled.svg
+++ b/Numix-Light/22x22/status/touchpad-indicator-light-disabled.svg
@@ -1,1 +1,0 @@
-../../../Numix/22x22/status/touchpad-indicator-light-disabled.svg

--- a/Numix-Light/22x22/status/touchpad-indicator-light-enabled.svg
+++ b/Numix-Light/22x22/status/touchpad-indicator-light-enabled.svg
@@ -1,1 +1,0 @@
-../../../Numix/22x22/status/touchpad-indicator-light-enabled.svg

--- a/Numix-Light/22x22/status/touchpad-indicator-light.svg
+++ b/Numix-Light/22x22/status/touchpad-indicator-light.svg
@@ -1,1 +1,0 @@
-../../../Numix/22x22/status/touchpad-indicator-light-enabled.svg

--- a/Numix-Light/22x22/status/variety-indicator-dark.svg
+++ b/Numix-Light/22x22/status/variety-indicator-dark.svg
@@ -1,1 +1,0 @@
-../../../Numix/22x22/status/variety-indicator-dark.svg

--- a/Numix-Light/22x22/status/variety-indicator.svg
+++ b/Numix-Light/22x22/status/variety-indicator.svg
@@ -1,1 +1,0 @@
-../../../Numix/22x22/status/variety-indicator.svg

--- a/Numix-Light/24x24/status/touchpad-indicator-dark-disabled.svg
+++ b/Numix-Light/24x24/status/touchpad-indicator-dark-disabled.svg
@@ -1,1 +1,0 @@
-../../../Numix/24x24/status/touchpad-indicator-dark-disabled.svg

--- a/Numix-Light/24x24/status/touchpad-indicator-dark-enabled.svg
+++ b/Numix-Light/24x24/status/touchpad-indicator-dark-enabled.svg
@@ -1,1 +1,0 @@
-../../../Numix/24x24/status/touchpad-indicator-dark-enabled.svg

--- a/Numix-Light/24x24/status/touchpad-indicator-dark.svg
+++ b/Numix-Light/24x24/status/touchpad-indicator-dark.svg
@@ -1,1 +1,0 @@
-../../../Numix/24x24/status/touchpad-indicator-dark-enabled.svg

--- a/Numix-Light/24x24/status/touchpad-indicator-light-disabled.svg
+++ b/Numix-Light/24x24/status/touchpad-indicator-light-disabled.svg
@@ -1,1 +1,0 @@
-../../../Numix/24x24/status/touchpad-indicator-light-disabled.svg

--- a/Numix-Light/24x24/status/touchpad-indicator-light-enabled.svg
+++ b/Numix-Light/24x24/status/touchpad-indicator-light-enabled.svg
@@ -1,1 +1,0 @@
-../../../Numix/24x24/status/touchpad-indicator-light-enabled.svg

--- a/Numix-Light/24x24/status/touchpad-indicator-light.svg
+++ b/Numix-Light/24x24/status/touchpad-indicator-light.svg
@@ -1,1 +1,0 @@
-../../../Numix/24x24/status/touchpad-indicator-light-enabled.svg

--- a/Numix-Light/24x24/status/variety-indicator-dark.svg
+++ b/Numix-Light/24x24/status/variety-indicator-dark.svg
@@ -1,1 +1,0 @@
-../../../Numix/24x24/status/variety-indicator-dark.svg

--- a/Numix-Light/24x24/status/variety-indicator.svg
+++ b/Numix-Light/24x24/status/variety-indicator.svg
@@ -1,1 +1,0 @@
-../../../Numix/24x24/status/variety-indicator.svg


### PR DESCRIPTION
Please cf. conversation at https://github.com/numixproject/numix-icon-theme/pull/457.

These icons are of the same name and of the same design as in Numix base, and since Numix-Light inherits from Numix base, they are unnecessary in Numix-Light.

Such identical icons in Numix base and Numix-Light should only be included in Numix-Light if the inheritance from Numix base for some reason does not work, as e.g. for the red battery status icons.