### PR TITLE
Added usb alternative icon

### DIFF
--- a/Numix/16x16/devices/drive-harddisk-usb_alternative.svg
+++ b/Numix/16x16/devices/drive-harddisk-usb_alternative.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="drive-harddisk-usb_alternative.svg">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1215"
+     inkscape:window-height="776"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="38.125"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2993" />
+  </sodipodi:namedview>
+  <rect
+     style="fill:#dc4946;fill-opacity:1;stroke:none"
+     id="rect3011"
+     width="12"
+     height="16"
+     x="2"
+     y="0"
+     ry="1" />
+  <rect
+     style="opacity:0.46366781;fill:#fdf6e3;fill-opacity:1;stroke:none"
+     id="rect3781"
+     width="2"
+     height="16"
+     x="10.979818"
+     y="0" />
+  <path
+     style="fill:#073642;fill-opacity:1"
+     d="M 8.02336,2.9799084 C 7.378086,2.9731684 6.723942,3.11991 6.113719,3.4432779 4.1610007,4.4780535 3.4361226,6.896589 4.4708695,8.849251 5.328511,10.4677 7.130738,11.249926 8.837767,10.885269 l -0.7442,-2.625761 c -0.02441,0.0013 -0.04547,0.01405 -0.07022,0.01405 -0.744471,0 -1.347983,-0.603514 -1.347983,-1.347984 0,-0.744467 0.603512,-1.3479797 1.347983,-1.3479797 0.744472,0 1.347985,0.6035127 1.347985,1.3479797 0,0.332822 -0.123046,0.635423 -0.322955,0.870573 l 1.727105,2.064101 C 12.027761,8.651803 12.389125,6.714387 11.533727,5.1001768 10.822345,3.7577186 9.442956,2.9946427 8.023355,2.9799084 z"
+     id="path6"
+     inkscape:connector-curvature="0" />
+  <path
+     style="fill:#073642;fill-opacity:1;stroke:none"
+     d="m 8.957317,9.493274 1.5,4.5 1.5,0 0,-1 z"
+     id="path3879"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     style="opacity:0.49480968;fill:#93a1a1;fill-opacity:1"
+     d="m 4.2184096,8.160832 c 0.358384,1.12383 1.2171335,2.056293 2.3637974,2.504793 L 7.523375,8.157564 C 7.387334,8.103434 7.265083,8.0273 7.148026,7.926228 6.959082,7.763087 6.82101,7.55896 6.746552,7.338411 L 4.2184096,8.160832 z"
+     id="path6-5"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.24567476;fill:#268bd2;fill-opacity:1"
+     d="M 4.1036435,6.103531 C 3.8520989,7.255984 4.1295655,8.492896 4.8983638,9.454645 L 6.967461,7.753185 C 6.876711,7.638292 6.808905,7.511227 6.758066,7.365167 6.676006,7.129411 6.658496,6.883597 6.704286,6.655369 L 4.1036435,6.103531 z"
+     id="path6-5-8"
+     inkscape:transform-center-x="2.5095619"
+     inkscape:transform-center-y="0.86106179" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.49480968;fill:#93a1a1;fill-opacity:1"
+     d="M 11.772636,5.6482718 C 11.406242,4.5270276 10.540862,3.6007144 9.391018,3.160408 L 8.467767,5.6751191 C 8.604191,5.7282741 8.726984,5.8035371 8.844759,5.9037714 9.034862,6.06556 9.174386,6.268696 9.250416,6.488709 l 2.52222,-0.8404372 z"
+     id="path6-5-9" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.19031145;fill:#268bd2;fill-opacity:1"
+     d="M 11.902077,7.704701 C 12.145392,6.550483 11.859107,5.3155822 11.083468,4.3593419 L 9.026553,6.075521 c 0.09157,0.114243 0.160279,0.240821 0.212159,0.386514 0.08374,0.235165 0.103003,0.480844 0.05885,0.709395 l 2.604523,0.533271 z"
+     id="path6-5-8-1"
+     inkscape:transform-center-x="-2.5064827"
+     inkscape:transform-center-y="-0.88600496" />
+</svg>

--- a/Numix/22x22/devices/drive-harddisk-usb_alternative.svg
+++ b/Numix/22x22/devices/drive-harddisk-usb_alternative.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   viewBox="0 0 22 22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="drive-harddisk-usb_alternative.svg">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1215"
+     inkscape:window-height="776"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="27.727273"
+     inkscape:cx="11"
+     inkscape:cy="11"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3014" />
+  </sodipodi:namedview>
+  <rect
+     style="fill:#dc4946;fill-opacity:1;stroke:none"
+     id="rect3011"
+     width="12"
+     height="16"
+     x="5"
+     y="3"
+     ry="1" />
+  <rect
+     style="opacity:0.46366781;fill:#fdf6e3;fill-opacity:1;stroke:none"
+     id="rect3781"
+     width="2"
+     height="16"
+     x="13.979818"
+     y="3" />
+  <path
+     style="fill:#073642;fill-opacity:1"
+     d="M 11.02336,5.9799084 C 10.378086,5.9731684 9.7239423,6.11991 9.1137193,6.4432779 7.1610007,7.4780535 6.4361226,9.8965885 7.4708695,11.84925 c 0.8576415,1.618449 2.6598685,2.400675 4.3668975,2.036018 l -0.7442,-2.625761 c -0.02441,0.0013 -0.04547,0.01405 -0.07022,0.01405 -0.744471,0 -1.3479827,-0.603514 -1.3479827,-1.3479835 0,-0.744467 0.6035117,-1.347979 1.3479827,-1.347979 0.744472,0 1.347985,0.603512 1.347985,1.347979 0,0.3328215 -0.123046,0.6354225 -0.322955,0.8705725 l 1.727105,2.064101 C 15.027761,11.651802 15.389125,9.7143865 14.533727,8.1001765 13.822345,6.7577186 12.442956,5.9946427 11.023355,5.9799084 z"
+     id="path6"
+     inkscape:connector-curvature="0" />
+  <path
+     style="fill:#073642;fill-opacity:1;stroke:none"
+     d="m 11.957317,12.493273 1.5,4.5 1.5,0 0,-1 z"
+     id="path3879"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     style="opacity:0.49480968;fill:#93a1a1;fill-opacity:1"
+     d="m 7.2184096,11.160831 c 0.358384,1.12383 1.2171335,2.056293 2.3637977,2.504793 L 10.523375,11.157563 C 10.387334,11.103433 10.265083,11.027299 10.148026,10.926227 9.9590823,10.763086 9.8210103,10.558959 9.7465523,10.33841 l -2.5281427,0.822421 z"
+     id="path6-5"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.24567476;fill:#268bd2;fill-opacity:1"
+     d="m 7.1036435,9.1035305 c -0.2515446,1.1524525 0.025922,2.3893645 0.7947203,3.3511135 l 2.0690975,-1.70146 c -0.09075,-0.114893 -0.158556,-0.241958 -0.209395,-0.388018 -0.08206,-0.235756 -0.09957,-0.4815695 -0.05378,-0.7097975 L 7.1036435,9.1035305 z"
+     id="path6-5-8"
+     inkscape:transform-center-x="2.5095619"
+     inkscape:transform-center-y="0.86106179" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.49480968;fill:#93a1a1;fill-opacity:1"
+     d="M 14.772636,8.6482715 C 14.406242,7.5270276 13.540862,6.6007144 12.391018,6.160408 l -0.923251,2.5147115 c 0.136424,0.05315 0.259217,0.128418 0.376992,0.228652 0.190103,0.161788 0.329627,0.364924 0.405657,0.584937 l 2.52222,-0.840437 z"
+     id="path6-5-9" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.19031145;fill:#268bd2;fill-opacity:1"
+     d="M 14.902077,10.7047 C 15.145392,9.5504825 14.859107,8.3155825 14.083468,7.3593419 l -2.056915,1.7161786 c 0.09157,0.114243 0.160279,0.240821 0.212159,0.386514 0.08374,0.235165 0.103003,0.480844 0.05885,0.7093945 l 2.604523,0.533271 z"
+     id="path6-5-8-1"
+     inkscape:transform-center-x="-2.5064827"
+     inkscape:transform-center-y="-0.88600496" />
+</svg>

--- a/Numix/24x24/devices/drive-harddisk-usb_alternative.svg
+++ b/Numix/24x24/devices/drive-harddisk-usb_alternative.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="drive-harddisk-usb_alternative.svg">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1215"
+     inkscape:window-height="776"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="25.416667"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2993" />
+  </sodipodi:namedview>
+  <rect
+     style="fill:#dc4946;fill-opacity:1;stroke:none"
+     id="rect3011"
+     width="12"
+     height="16"
+     x="6"
+     y="4"
+     ry="1" />
+  <rect
+     style="opacity:0.46366781;fill:#fdf6e3;fill-opacity:1;stroke:none"
+     id="rect3781"
+     width="2"
+     height="16"
+     x="14.979818"
+     y="4" />
+  <path
+     style="fill:#073642;fill-opacity:1"
+     d="M 12.02336,6.9799084 C 11.378086,6.9731684 10.723942,7.11991 10.113719,7.4432779 8.1610007,8.4780535 7.4361226,10.896589 8.4708695,12.849251 9.328511,14.4677 11.130738,15.249926 12.837767,14.885269 l -0.7442,-2.625761 c -0.02441,0.0013 -0.04547,0.01405 -0.07022,0.01405 -0.744471,0 -1.347983,-0.603514 -1.347983,-1.347984 0,-0.744467 0.603512,-1.3479797 1.347983,-1.3479797 0.744472,0 1.347985,0.6035127 1.347985,1.3479797 0,0.332822 -0.123046,0.635423 -0.322955,0.870573 l 1.727105,2.064101 C 16.027761,12.651803 16.389125,10.714387 15.533727,9.1001768 14.822345,7.7577186 13.442956,6.9946427 12.023355,6.9799084 z"
+     id="path6"
+     inkscape:connector-curvature="0" />
+  <path
+     style="fill:#073642;fill-opacity:1;stroke:none"
+     d="m 12.957317,13.493274 1.5,4.5 1.5,0 0,-1 z"
+     id="path3879"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     style="opacity:0.49480968;fill:#93a1a1;fill-opacity:1"
+     d="m 8.2184096,12.160832 c 0.358384,1.12383 1.2171335,2.056293 2.3637974,2.504793 l 0.941168,-2.508061 C 11.387334,12.103434 11.265083,12.0273 11.148026,11.926228 10.959082,11.763087 10.82101,11.55896 10.746552,11.338411 l -2.5281424,0.822421 z"
+     id="path6-5"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.24567476;fill:#268bd2;fill-opacity:1"
+     d="m 8.1036435,10.103531 c -0.2515446,1.152453 0.025922,2.389365 0.7947203,3.351114 l 2.0690972,-1.70146 c -0.09075,-0.114893 -0.158556,-0.241958 -0.209395,-0.388018 -0.08206,-0.235756 -0.09957,-0.48157 -0.05378,-0.709798 L 8.1036435,10.103531 z"
+     id="path6-5-8"
+     inkscape:transform-center-x="2.5095619"
+     inkscape:transform-center-y="0.86106179" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.49480968;fill:#93a1a1;fill-opacity:1"
+     d="M 15.772636,9.6482718 C 15.406242,8.5270276 14.540862,7.6007144 13.391018,7.160408 l -0.923251,2.5147111 c 0.136424,0.053155 0.259217,0.128418 0.376992,0.2286523 0.190103,0.1617886 0.329627,0.3649246 0.405657,0.5849376 l 2.52222,-0.8404372 z"
+     id="path6-5-9" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.19031145;fill:#268bd2;fill-opacity:1"
+     d="m 15.902077,11.704701 c 0.243315,-1.154218 -0.04297,-2.3891188 -0.818609,-3.3453591 l -2.056915,1.7161791 c 0.09157,0.114243 0.160279,0.240821 0.212159,0.386514 0.08374,0.235165 0.103003,0.480844 0.05885,0.709395 l 2.604523,0.533271 z"
+     id="path6-5-8-1"
+     inkscape:transform-center-x="-2.5064827"
+     inkscape:transform-center-y="-0.88600496" />
+</svg>

--- a/Numix/32x32/devices/drive-harddisk-usb_alternative.svg
+++ b/Numix/32x32/devices/drive-harddisk-usb_alternative.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   height="32"
+   viewBox="0 0 32 32"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="drive-harddisk-usb_alternative.svg">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1215"
+     inkscape:window-height="776"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="19.0625"
+     inkscape:cx="16"
+     inkscape:cy="16"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2993" />
+  </sodipodi:namedview>
+  <rect
+     style="fill:#dc4946;fill-opacity:1;stroke:none"
+     id="rect3011"
+     width="18"
+     height="22"
+     x="7"
+     y="5"
+     ry="1.375" />
+  <rect
+     style="opacity:0.46366781;fill:#fdf6e3;fill-opacity:1;stroke:none"
+     id="rect3781"
+     width="3"
+     height="22"
+     x="20.007496"
+     y="5" />
+  <path
+     style="fill:#073642;fill-opacity:1"
+     d="m 16.058595,7.9768545 c -0.967908,-0.010049 -1.949124,0.2100007 -2.864461,0.6950524 -2.92908,1.5521681 -4.0163934,5.1799691 -2.464278,8.1089571 1.286459,2.427667 3.989809,3.601006 6.550347,3.05402 l -1.116297,-3.938632 c -0.03661,0.002 -0.06821,0.02106 -0.105311,0.02106 -1.116704,0 -2.021972,-0.905268 -2.021972,-2.021972 0,-1.116704 0.905268,-2.021972 2.021972,-2.021972 1.116704,0 2.021971,0.905268 2.021971,2.021972 0,0.499232 -0.184568,0.953133 -0.48443,1.305856 l 2.590652,3.096145 C 22.065195,16.484688 22.60724,13.578565 21.324147,11.157252 20.257069,9.1435638 18.187991,7.9989535 16.058595,7.9768525 z"
+     id="path6"
+     inkscape:connector-curvature="0" />
+  <path
+     style="fill:#073642;fill-opacity:1;stroke:none"
+     d="m 17.870744,17.813557 2.0625,6.1875 2.0625,0 0,-1.375 z"
+     id="path3879"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     style="opacity:0.49480968;fill:#93a1a1;fill-opacity:1"
+     d="m 10.351167,15.748237 c 0.537575,1.685741 1.825696,3.084433 3.545703,3.757182 l 1.41175,-3.762083 c -0.204063,-0.08118 -0.387439,-0.195396 -0.563024,-0.347003 -0.283415,-0.244712 -0.490523,-0.550901 -0.602209,-0.881724 l -3.79222,1.233628 z"
+     id="path6-5"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.24567476;fill:#268bd2;fill-opacity:1"
+     d="m 10.179019,12.662287 c -0.377315,1.728682 0.03888,3.584047 1.192077,5.026667 l 3.103653,-2.552185 c -0.13613,-0.17234 -0.237834,-0.362938 -0.314091,-0.582025 -0.123089,-0.353634 -0.149355,-0.722356 -0.08066,-1.064701 l -3.900972,-0.827756 z"
+     id="path6-5-8"
+     inkscape:transform-center-x="3.7643349"
+     inkscape:transform-center-y="1.2915912" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.49480968;fill:#93a1a1;fill-opacity:1"
+     d="M 21.682496,11.979397 C 21.132907,10.297535 19.834839,8.9080615 18.110077,8.2476026 l -1.384873,3.7720664 c 0.204636,0.07973 0.388824,0.192626 0.565486,0.342978 0.285153,0.242682 0.49444,0.547386 0.608485,0.877404 l 3.783321,-1.260654 z"
+     id="path6-5-9" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.19031145;fill:#268bd2;fill-opacity:1"
+     d="m 21.876657,15.064041 c 0.364973,-1.731329 -0.06446,-3.583677 -1.227911,-5.018033 l -3.085365,2.574264 c 0.137356,0.171363 0.240417,0.361229 0.318236,0.579769 0.125609,0.352747 0.154505,0.721271 0.08826,1.064097 l 3.906779,0.799903 z"
+     id="path6-5-8-1"
+     inkscape:transform-center-x="-3.7597156"
+     inkscape:transform-center-y="-1.3290048" />
+</svg>

--- a/Numix/48x48/devices/drive-harddisk-usb_alternative.svg
+++ b/Numix/48x48/devices/drive-harddisk-usb_alternative.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="100%"
+   height="100%"
+   sodipodi:docname="drive-harddisk-usb_alternative.svg">
+  <metadata
+     id="metadata32">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs30" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1215"
+     inkscape:window-height="776"
+     id="namedview28"
+     showgrid="true"
+     inkscape:zoom="12.708333"
+     inkscape:cx="24"
+     inkscape:cy="24"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3009" />
+  </sodipodi:namedview>
+  <rect
+     style="fill:#dc4946;fill-opacity:1;stroke:none"
+     id="rect3011"
+     width="26"
+     height="32"
+     x="11"
+     y="8"
+     ry="2" />
+  <rect
+     style="opacity:0.46366782;fill:#fdf6e3;fill-opacity:1;stroke:none"
+     id="rect3781"
+     width="4"
+     height="32"
+     x="30.038273"
+     y="8" />
+  <path
+     style="fill:#073642;fill-opacity:1"
+     d="m 24.05199,13.235534 c -1.436085,-0.01491 -2.891914,0.311579 -4.25,1.03125 -4.345877,2.302941 -5.959126,7.68551 -3.65625,12.03125 1.90872,3.60193 5.919679,5.342813 9.71875,4.53125 l -1.65625,-5.84375 c -0.05431,0.0029 -0.101211,0.03125 -0.15625,0.03125 -1.656854,0 -3,-1.343146 -3,-3 0,-1.656854 1.343146,-3 3,-3 1.656854,0 3,1.343146 3,3 0,0.740711 -0.273844,1.414165 -0.71875,1.9375 l 3.84375,4.59375 c 2.786994,-2.689433 3.591225,-7.001248 1.6875,-10.59375 -1.583223,-2.987699 -4.653114,-4.685958 -7.8125,-4.71875 z"
+     id="path6"
+     inkscape:connector-curvature="0" />
+  <path
+     style="fill:#073642;fill-opacity:1;stroke:none"
+     d="m 27,26.986548 3,9 3,0 0,-2 z"
+     id="path3879"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     style="opacity:0.49480969;fill:#93a1a1;fill-opacity:1"
+     d="m 15.583879,24.765926 c 0.7976,2.501133 2.708786,4.576373 5.260759,5.574531 l 2.094614,-5.581804 c -0.302767,-0.120455 -0.574843,-0.289908 -0.835358,-0.514848 -0.420503,-0.363079 -0.727789,-0.817371 -0.893499,-1.308214 l -5.626516,1.830335 z"
+     id="path6-5"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.24567474;fill:#268bd2;fill-opacity:1"
+     d="m 15.328462,20.187301 c -0.559824,2.564846 0.05769,5.31765 1.768686,7.458066 l 4.60489,-3.786678 c -0.201975,-0.2557 -0.352874,-0.538489 -0.466018,-0.86355 -0.182626,-0.524687 -0.221597,-1.071758 -0.119684,-1.579696 l -5.787874,-1.228142 z"
+     id="path6-5-8"
+     inkscape:transform-center-x="5.5851443"
+     inkscape:transform-center-y="1.916334" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.49480969;fill:#93a1a1;fill-opacity:1"
+     d="m 32.396173,19.174098 c -0.815425,-2.495379 -2.741369,-4.556931 -5.300398,-5.536855 l -2.054736,5.596606 c 0.303618,0.118292 0.576897,0.285799 0.83901,0.508875 0.423083,0.360069 0.733602,0.812157 0.90281,1.301806 l 5.613314,-1.870432 z"
+     id="path6-5-9" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.19031142;fill:#268bd2;fill-opacity:1"
+     d="m 32.68425,23.750784 c 0.54151,-2.568774 -0.09563,-5.317102 -1.821851,-7.445257 l -4.577757,3.819436 c 0.203795,0.254252 0.356707,0.535957 0.472167,0.860203 0.186366,0.523371 0.229239,1.07015 0.130953,1.578802 l 5.796488,1.186816 z"
+     id="path6-5-8-1"
+     inkscape:transform-center-x="-5.5782913"
+     inkscape:transform-center-y="-1.9718445" />
+</svg>


### PR DESCRIPTION
`devices` directories up to size `48x48`. Addresses https://github.com/numixproject/numix-icon-theme/issues/101, cf. comments over there.