### PR TITLE
Fixes opacity of gtk-connect and gtk-disconnect

### DIFF
--- a/Numix/128x128/actions/gtk-connect.svg
+++ b/Numix/128x128/actions/gtk-connect.svg
@@ -59,12 +59,12 @@
      id="g3000"
      transform="matrix(0.80000001,0,0,0.80000001,1.4000005,107.4)" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 110.06676,7.9999923 c -0.85332,0 -1.66948,0.31856 -2.26844,0.930472 l -22.742533,22.7399227 -10.353408,0 c -0.852512,-0.006 -1.723312,0.32856 -2.326616,0.930532 L 57.311011,47.663995 c -1.223468,1.197716 -1.223468,3.454952 0,4.652668 l 18.438316,18.436204 c 0.615372,0.614742 1.456748,0.951376 2.32662,0.930528 0.835016,-0.006 1.677508,-0.340318 2.268432,-0.930528 L 95.467371,55.631683 c 0.60228,-0.602912 0.93744,-1.415808 0.9306,-2.268188 l 0,-10.410352 22.684429,-22.681744 c 1.22347,-1.197775 1.22347,-3.454951 0,-4.652667 l -6.68902,-6.6882677 c -0.5992,-0.611648 -1.47324,-0.930472 -2.32662,-0.930472 z"
      id="path2994"
      inkscape:connector-curvature="0" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 49.924055,56.329563 c -0.835024,0.006 -1.677512,0.39888 -2.268436,0.988712 L 32.532627,72.381283 c -0.602308,0.602908 -0.93744,1.473984 -0.930598,2.326364 l 0,10.35216 -22.6844238,22.739933 c -1.2234752,1.19778 -1.2234752,3.39678 0,4.59455 l 6.6890158,6.68821 c 1.19784,1.22335 3.397148,1.22335 4.59505,0 l 22.74254,-22.681815 10.353412,0 c 0.852496,0.006 1.723296,-0.32848 2.326608,-0.930534 L 70.688975,80.348967 c 1.22354,-1.19772 1.22354,-3.396712 0,-4.594488 L 52.250667,57.318275 c -0.61538,-0.61474 -1.456812,-1.009552 -2.326612,-0.988712 z"
      id="path3804-7"
      inkscape:connector-curvature="0" />

--- a/Numix/128x128/actions/gtk-disconnect.svg
+++ b/Numix/128x128/actions/gtk-disconnect.svg
@@ -59,13 +59,13 @@
      id="g3000"
      transform="matrix(0.80000001,0,0,0.80000001,1.4000005,107.4)" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 110.06676,7.9999918 c -0.85332,0 -1.66948,0.31856 -2.26844,0.930472 l -11.542533,11.5399192 -10.353408,0 c -0.852504,-0.006 -1.723304,0.32848 -2.326616,0.930544 L 68.511011,36.463991 c -1.223476,1.197724 -1.223476,3.454952 0,4.652672 l 18.438316,18.436204 c 0.615372,0.61474 1.456752,0.951376 2.32662,0.930528 0.835016,-0.006 1.677508,-0.34032 2.268432,-0.930528 L 106.66737,44.431679 c 0.60235,-0.602908 0.93744,-1.415804 0.9306,-2.268184 l 0,-10.410348 11.48443,-11.48174 c 1.22347,-1.197784 1.22347,-3.45496 0,-4.652671 l -6.68902,-6.6882722 c -0.5992,-0.61164 -1.47324,-0.930472 -2.32662,-0.930472 z"
      id="path2994"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="scccccccccccccccs" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 38.724055,67.529563 c -0.835022,0.006 -1.677512,0.39888 -2.268438,0.988712 l -15.12299,15.063012 c -0.602308,0.602904 -0.93744,1.47398 -0.930596,2.32636 l 0,10.352159 -11.4844255,11.539934 c -1.2234757,1.19777 -1.2234757,3.39678 0,4.59455 l 6.6890155,6.68821 c 1.19784,1.22335 3.397148,1.22335 4.59505,0 l 11.54254,-11.48181 10.353408,0 c 0.852504,0.006 1.723304,-0.32848 2.326612,-0.93053 L 59.488983,91.548959 c 1.223536,-1.197712 1.223536,-3.396708 0,-4.59448 L 41.050667,68.518275 c -0.615376,-0.614752 -1.45681,-1.009552 -2.326612,-0.988712 z"
      id="path3804-7"
      inkscape:connector-curvature="0"

--- a/Numix/16x16/actions/gtk-connect.svg
+++ b/Numix/16x16/actions/gtk-connect.svg
@@ -59,12 +59,12 @@
      id="g3000"
      transform="matrix(0.80000001,0,0,0.80000001,1.4000005,-4.600003)" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 14.580966,-9e-7 c -0.121902,0 -0.238497,0.045511 -0.324062,0.1329248 l -3.248934,3.2485604 -1.4790583,0 c -0.121787,-8.8e-4 -0.246187,0.046934 -0.332374,0.1329336 l -2.152107,2.1518672 c -0.174782,0.1711024 -0.174782,0.4935644 0,0.6646668 l 2.634045,2.6337432 c 0.08791,0.087822 0.208107,0.1359108 0.3323743,0.1329332 0.119288,-8.8e-4 0.239644,-0.048622 0.324062,-0.1329332 l 2.160427,-2.1601696 c 0.08604,-0.086134 0.13392,-0.202258 0.132943,-0.3240268 l 0,-1.4871916 3.240632,-3.2402496 c 0.174782,-0.1711112 0.174782,-0.4935644 0,-0.6646668 L 14.91334,0.1329239 C 14.82774,0.0455459 14.702878,-9e-7 14.580966,-9e-7 Z"
      id="path2994"
      inkscape:connector-curvature="0" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 5.9891506,6.9042231 c -0.1192888,8.8e-4 -0.2396444,0.056978 -0.3240624,0.1412448 L 3.504661,9.1973259 c -0.086044,0.086134 -0.13392,0.2105692 -0.1329424,0.332338 l 0,1.4788801 -3.24063213,3.248561 c -0.1747822,0.171111 -0.1747822,0.485254 0,0.656365 l 0.95557363,0.955458 c 0.1711201,0.174764 0.4853068,0.174764 0.6564357,0 l 3.2489344,-3.240259 1.4790585,0 c 0.121786,8.8e-4 0.246186,-0.04693 0.332373,-0.132933 l 2.152107,-2.16017 c 0.174791,-0.171102 0.174791,-0.4852441 0,-0.6563553 L 6.3215237,7.0454679 C 6.2336127,6.9576455 6.1134077,6.9012455 5.9891506,6.9042231 Z"
      id="path3804-7"
      inkscape:connector-curvature="0" />

--- a/Numix/16x16/actions/gtk-disconnect.svg
+++ b/Numix/16x16/actions/gtk-disconnect.svg
@@ -59,13 +59,13 @@
      id="g3000"
      transform="matrix(0.80000001,0,0,0.80000001,1.4000005,-4.600003)" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 14.580966,-1e-6 c -0.121902,0 -0.238497,0.04551 -0.324062,0.132925 l -1.648934,1.64856 -1.479058,0 c -0.121787,-8.8e-4 -0.246187,0.04693 -0.332374,0.132934 L 8.6444307,4.066285 c -0.174782,0.171103 -0.174782,0.493565 0,0.664667 l 2.6340453,2.633743 c 0.08791,0.08782 0.208107,0.135911 0.332374,0.132933 0.119288,-8.8e-4 0.239644,-0.04862 0.324062,-0.132933 l 2.160427,-2.160169 c 0.08605,-0.08613 0.13392,-0.202258 0.132943,-0.324027 l 0,-1.487192 1.640632,-1.640249 c 0.174782,-0.171112 0.174782,-0.493565 0,-0.664667 L 14.91334,0.132924 C 14.82774,0.045546 14.702878,-1e-6 14.580966,-1e-6 Z"
      id="path2994"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="scccccccccccccccs" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="M 4.3891506,8.504223 C 4.2698618,8.505103 4.1495062,8.561203 4.0650882,8.645468 L 1.904661,10.797326 c -0.086044,0.08613 -0.13392,0.210569 -0.1329424,0.332338 l 0,1.47888 -1.64063212,1.648561 c -0.1747822,0.171111 -0.1747822,0.485254 0,0.656365 l 0.95557362,0.955458 c 0.1711201,0.174764 0.4853068,0.174764 0.6564357,0 l 1.6489344,-1.640259 1.4790584,0 c 0.1217864,8.8e-4 0.2461864,-0.04693 0.3323732,-0.132933 l 2.1521069,-2.16017 c 0.174791,-0.171102 0.174791,-0.485244 0,-0.656355 L 4.7215238,8.645468 C 4.633613,8.557646 4.5134082,8.501246 4.3891506,8.504223 Z"
      id="path3804-7"
      inkscape:connector-curvature="0"

--- a/Numix/22x22/actions/gtk-connect.svg
+++ b/Numix/22x22/actions/gtk-connect.svg
@@ -59,12 +59,12 @@
      id="g3000"
      transform="matrix(0.80000001,0,0,0.80000001,1.4000005,1.399997)" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 19.226207,0.99999913 c -0.152378,0 -0.298121,0.056889 -0.405078,0.16615597 l -4.061167,4.0607003 -1.848823,0 c -0.152234,-0.0011 -0.307734,0.058668 -0.415467,0.166167 L 9.8055382,8.0828561 c -0.2184774,0.2138775 -0.2184774,0.6169563 0,0.8308338 l 3.2925558,3.2921791 c 0.109888,0.109775 0.260134,0.169889 0.415468,0.166166 0.14911,-0.0011 0.299555,-0.06077 0.405077,-0.166166 l 2.700534,-2.7002114 c 0.10755,-0.107663 0.1674,-0.252823 0.166179,-0.405034 l 0,-1.8589899 4.05079,-4.0503117 c 0.218477,-0.213889 0.218477,-0.6169555 0,-0.8308335 L 19.641674,1.1661551 c -0.107,-0.1092225 -0.263077,-0.16615597 -0.415467,-0.16615597 z"
      id="path2994"
      inkscape:connector-curvature="0" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 8.4864382,9.6302786 c -0.149111,0.0011 -0.2995555,0.07123 -0.405078,0.176556 L 5.3808263,12.496658 c -0.107555,0.107662 -0.1674,0.263211 -0.166178,0.415422 l 0,1.8486 -4.05079,4.060701 c -0.2184777,0.213889 -0.2184777,0.606568 0,0.820456 l 1.194467,1.194323 c 0.2139001,0.218455 0.6066335,0.218455 0.8205446,0 l 4.0611678,-4.050324 1.8488231,0 c 0.1522325,0.0011 0.3077325,-0.05866 0.4154662,-0.166166 l 2.690133,-2.700212 c 0.218489,-0.213878 0.218489,-0.606555 0,-0.820444 L 8.9019045,9.8068346 C 8.7920158,9.6970596 8.6417595,9.6265576 8.4864382,9.6302786 Z"
      id="path3804-7"
      inkscape:connector-curvature="0" />

--- a/Numix/22x22/actions/gtk-disconnect.svg
+++ b/Numix/22x22/actions/gtk-disconnect.svg
@@ -59,13 +59,13 @@
      id="g3000"
      transform="matrix(0.80000001,0,0,0.80000001,1.4000005,1.399997)" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 19.226207,0.99999903 c -0.152378,0 -0.298121,0.056887 -0.405078,0.16615627 l -2.061167,2.0606999 -1.848823,0 c -0.152233,-0.0011 -0.307733,0.058662 -0.415467,0.1661675 l -2.690134,2.6898336 c -0.218478,0.2138788 -0.218478,0.6169562 0,0.8308337 l 3.292556,3.292179 c 0.109888,0.109775 0.260134,0.169889 0.415468,0.166166 0.14911,-0.0011 0.299555,-0.06077 0.405077,-0.166166 l 2.700534,-2.7002115 c 0.107563,-0.1076625 0.1674,-0.2528225 0.166179,-0.4050337 l 0,-1.8589899 2.05079,-2.0503112 c 0.218477,-0.21389 0.218477,-0.6169562 0,-0.8308337 L 19.641674,1.1661553 c -0.107,-0.1092225 -0.263077,-0.16615627 -0.415467,-0.16615627 z"
      id="path2994"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="scccccccccccccccs" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 6.4864383,11.630279 c -0.149111,0.0011 -0.2995555,0.07123 -0.405078,0.176556 l -2.7005339,2.689823 c -0.107555,0.107662 -0.1674,0.263211 -0.166178,0.415422 l 0,1.8486 -2.05079,2.060701 c -0.2184778,0.213889 -0.2184778,0.606568 0,0.820456 l 1.1944669,1.194323 c 0.2139001,0.218455 0.6066335,0.218455 0.8205446,0 l 2.0611679,-2.050324 1.8488229,0 c 0.152233,0.0011 0.307733,-0.05866 0.4154665,-0.166166 l 2.6901338,-2.700213 c 0.218489,-0.213877 0.218489,-0.606555 0,-0.820443 L 6.9019047,11.806835 C 6.7920162,11.697058 6.6417603,11.626558 6.4864383,11.630279 Z"
      id="path3804-7"
      inkscape:connector-curvature="0"

--- a/Numix/24x24/actions/gtk-connect.svg
+++ b/Numix/24x24/actions/gtk-connect.svg
@@ -59,12 +59,12 @@
      id="g3000"
      transform="matrix(0.80000001,0,0,0.80000001,1.4000005,3.399997)" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 20.226207,1.9999989 c -0.152378,0 -0.298121,0.056889 -0.405078,0.166156 l -4.061167,4.0607003 -1.848823,0 c -0.152234,-0.0011 -0.307734,0.058668 -0.415467,0.166167 l -2.690134,2.6898336 c -0.218477,0.213878 -0.218477,0.616956 0,0.830834 l 3.292556,3.2921792 c 0.109888,0.109775 0.260134,0.169889 0.415468,0.166166 0.14911,-0.0011 0.299555,-0.06077 0.405077,-0.166166 l 2.700534,-2.700211 c 0.10755,-0.107663 0.1674,-0.252823 0.166179,-0.405034 l 0,-1.8589905 4.05079,-4.0503117 c 0.218477,-0.213889 0.218477,-0.6169555 0,-0.8308335 L 20.641674,2.1661549 c -0.107,-0.1092225 -0.263077,-0.166156 -0.415467,-0.166156 z"
      id="path2994"
      inkscape:connector-curvature="0" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 9.4864383,10.630279 c -0.149111,0.0011 -0.2995555,0.07123 -0.405078,0.176556 l -2.7005339,2.689823 c -0.107555,0.107662 -0.1674,0.263211 -0.166178,0.415422 l 0,1.8486 -4.05079,4.060701 c -0.2184777,0.213889 -0.2184777,0.606568 0,0.820456 l 1.194467,1.194323 c 0.2139001,0.218455 0.6066335,0.218455 0.8205446,0 l 4.0611678,-4.050324 1.8488232,0 c 0.152232,0.0011 0.307732,-0.05866 0.415466,-0.166166 l 2.690133,-2.700212 c 0.218489,-0.213878 0.218489,-0.606555 0,-0.820444 L 9.9019046,10.806835 C 9.7920159,10.69706 9.6417596,10.626558 9.4864383,10.630279 Z"
      id="path3804-7"
      inkscape:connector-curvature="0" />

--- a/Numix/24x24/actions/gtk-disconnect.svg
+++ b/Numix/24x24/actions/gtk-disconnect.svg
@@ -59,13 +59,13 @@
      id="g3000"
      transform="matrix(0.80000001,0,0,0.80000001,1.4000005,3.399997)" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 20.226207,1.9999989 c -0.152378,0 -0.298121,0.056887 -0.405078,0.1661563 l -2.061167,2.0606999 -1.848823,0 c -0.152233,-0.0011 -0.307733,0.058662 -0.415467,0.1661675 l -2.690134,2.6898336 c -0.218478,0.2138788 -0.218478,0.6169562 0,0.8308337 l 3.292556,3.2921791 c 0.109888,0.109775 0.260134,0.169889 0.415468,0.166166 0.14911,-0.0011 0.299555,-0.06077 0.405077,-0.166166 l 2.700534,-2.7002116 c 0.107563,-0.1076625 0.1674,-0.2528225 0.166179,-0.4050337 l 0,-1.8589899 2.05079,-2.0503112 c 0.218477,-0.21389 0.218477,-0.6169562 0,-0.8308337 L 20.641674,2.1661552 c -0.107,-0.1092225 -0.263077,-0.1661563 -0.415467,-0.1661563 z"
      id="path2994"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="scccccccccccccccs" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 7.4864384,12.630279 c -0.149111,0.0011 -0.2995555,0.07123 -0.405078,0.176556 l -2.7005339,2.689823 c -0.107555,0.107662 -0.1674,0.263211 -0.166178,0.415422 l 0,1.8486 -2.05079,2.060701 c -0.2184778,0.213889 -0.2184778,0.606568 0,0.820456 l 1.1944669,1.194323 c 0.2139001,0.218455 0.6066335,0.218455 0.8205446,0 l 2.0611679,-2.050324 1.8488229,0 c 0.152233,0.0011 0.307733,-0.05866 0.4154665,-0.166166 l 2.6901337,-2.700213 c 0.218489,-0.213877 0.218489,-0.606555 0,-0.820443 L 7.9019048,12.806835 C 7.7920163,12.697058 7.6417604,12.626558 7.4864384,12.630279 Z"
      id="path3804-7"
      inkscape:connector-curvature="0"

--- a/Numix/256x256/actions/gtk-connect.svg
+++ b/Numix/256x256/actions/gtk-connect.svg
@@ -59,12 +59,12 @@
      id="g3000"
      transform="matrix(0.80000001,0,0,0.80000001,1.4000005,235.4)" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 220.13351,15.999982 c -1.70664,0 -3.33896,0.63712 -4.53688,1.86094 l -45.48506,45.479847 -20.70682,0 c -1.70502,-0.012 -3.44662,0.65712 -4.65323,1.861064 l -30.1295,30.126149 c -2.44694,2.39543 -2.44694,6.909908 0,9.305338 l 36.87663,36.8724 c 1.23074,1.22949 2.9135,1.90276 4.65324,1.86106 1.67003,-0.012 3.35502,-0.68064 4.53686,-1.86106 l 30.24599,-30.24236 c 1.20456,-1.20583 1.87488,-2.83162 1.8612,-4.53638 l 0,-20.820699 45.36885,-45.363487 c 2.44694,-2.39555 2.44694,-6.909902 0,-9.305334 L 224.78675,17.860922 c -1.1984,-1.22329 -2.94648,-1.86094 -4.65324,-1.86094 z"
      id="path2994"
      inkscape:connector-curvature="0" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 99.848111,112.65912 c -1.670048,0.012 -3.355023,0.79776 -4.536871,1.97742 l -30.245983,30.12602 c -1.204616,1.20581 -1.87488,2.94796 -1.861196,4.65272 l 0,20.70432 -45.368846,45.47987 c -2.446951,2.39556 -2.446951,6.79356 0,9.1891 l 13.378031,13.37642 c 2.39568,2.4467 6.794295,2.4467 9.190099,0 l 45.485079,-45.36363 20.706826,0 c 1.70499,0.012 3.44659,-0.65696 4.65321,-1.86107 l 30.12949,-30.24237 c 2.44708,-2.39544 2.44708,-6.79342 0,-9.18897 l -36.87661,-36.87241 c -1.23076,-1.22948 -2.91363,-2.0191 -4.653229,-1.97742 z"
      id="path3804-7"
      inkscape:connector-curvature="0" />

--- a/Numix/256x256/actions/gtk-disconnect.svg
+++ b/Numix/256x256/actions/gtk-disconnect.svg
@@ -59,13 +59,13 @@
      id="g3000"
      transform="matrix(0.80000001,0,0,0.80000001,1.4000005,235.4)" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 220.13351,15.99998 c -1.70664,0 -3.33896,0.63712 -4.53688,1.86094 l -23.08506,23.079839 -20.70682,0 c -1.705,-0.012 -3.4466,0.65696 -4.65323,1.8611 l -30.1295,30.126119 c -2.44695,2.39546 -2.44695,6.9099 0,9.30534 l 36.87663,36.872412 c 1.23074,1.22948 2.9135,1.90274 4.65324,1.86104 1.67003,-0.012 3.35502,-0.68064 4.53686,-1.86104 l 30.24598,-30.242372 c 1.2047,-1.20582 1.87488,-2.83162 1.8612,-4.53638 l 0,-20.82068 22.96886,-22.963479 c 2.44694,-2.39558 2.44694,-6.90992 0,-9.305339 L 224.78675,17.86092 c -1.1984,-1.22328 -2.94648,-1.86094 -4.65324,-1.86094 z"
      id="path2994"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="scccccccccccccccs" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 77.448112,135.05911 c -1.670044,0.012 -3.355024,0.79776 -4.536876,1.97744 l -30.245979,30.12602 c -1.204616,1.20581 -1.87488,2.94796 -1.861192,4.65272 l 0,20.70432 -22.96885,23.07986 c -2.446951,2.39554 -2.446951,6.79356 0,9.1891 l 13.378031,13.37642 c 2.39568,2.4467 6.794296,2.4467 9.190099,0 l 23.08508,-22.96362 20.706815,0 c 1.705008,0.012 3.446608,-0.65696 4.653224,-1.86106 l 30.129496,-30.2424 c 2.44708,-2.39542 2.44708,-6.79342 0,-9.18896 l -36.876624,-36.8724 c -1.230752,-1.22952 -2.91362,-2.01912 -4.653224,-1.97744 z"
      id="path3804-7"
      inkscape:connector-curvature="0"

--- a/Numix/32x32/actions/gtk-connect.svg
+++ b/Numix/32x32/actions/gtk-connect.svg
@@ -59,12 +59,12 @@
      id="g3000"
      transform="matrix(0.80000001,0,0,0.80000001,1.4000005,11.399997)" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 27.51669,1.9999979 c -0.213329,0 -0.417369,0.079645 -0.567109,0.2326186 l -5.685634,5.6849801 -2.588352,0 c -0.213128,-0.00154 -0.430828,0.082138 -0.581654,0.2326338 l -3.766188,3.7657686 c -0.305867,0.299429 -0.305867,0.863738 0,1.163167 l 4.609579,4.609051 c 0.153843,0.153685 0.364187,0.237844 0.581655,0.232632 0.208754,-0.0015 0.419377,-0.08508 0.567108,-0.232632 l 3.780748,-3.780296 c 0.15057,-0.150728 0.23436,-0.353952 0.23265,-0.567047 l 0,-2.602588 5.671106,-5.6704357 c 0.305868,-0.2994446 0.305868,-0.8637384 0,-1.1631676 L 28.098344,2.2326165 C 27.948544,2.0797043 27.730036,1.9999979 27.51669,1.9999979 Z"
      id="path2994"
      inkscape:connector-curvature="0" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 12.481014,14.082391 c -0.208756,0.0015 -0.419378,0.09972 -0.567109,0.247178 l -3.780748,3.765752 c -0.1505771,0.150727 -0.23436,0.368496 -0.2326493,0.581591 l 0,2.58804 -5.6711061,5.684982 c -0.3058688,0.299444 -0.3058688,0.849195 0,1.148638 l 1.6722539,1.672052 c 0.2994601,0.305838 0.8492869,0.305838 1.1487624,0 l 5.6856351,-5.670453 2.588353,0 c 0.213124,0.0015 0.430824,-0.08212 0.581652,-0.232633 l 3.766186,-3.780296 c 0.305885,-0.29943 0.305885,-0.849178 0,-1.148622 l -4.609577,-4.609051 c -0.153845,-0.153685 -0.364203,-0.252388 -0.581653,-0.247178 z"
      id="path3804-7"
      inkscape:connector-curvature="0" />

--- a/Numix/32x32/actions/gtk-disconnect.svg
+++ b/Numix/32x32/actions/gtk-disconnect.svg
@@ -59,13 +59,13 @@
      id="g3000"
      transform="matrix(0.80000001,0,0,0.80000001,1.4000005,11.399997)" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 27.51669,1.9999979 c -0.213329,0 -0.417369,0.079642 -0.567109,0.2326185 l -2.885634,2.8849801 -2.588352,0 c -0.213126,-0.00154 -0.430826,0.082124 -0.581654,0.2326352 L 17.127753,9.115998 c -0.305869,0.2994306 -0.305869,0.8637384 0,1.163168 l 4.609579,4.609051 c 0.153843,0.153685 0.364188,0.237844 0.581655,0.232632 0.208754,-0.0015 0.419377,-0.08508 0.567108,-0.232632 l 3.780748,-3.780297 c 0.150588,-0.150727 0.23436,-0.353951 0.23265,-0.567046 l 0,-2.6025868 2.871106,-2.8704355 c 0.305868,-0.299446 0.305868,-0.8637398 0,-1.1631676 L 28.098344,2.2326164 C 27.948544,2.0797056 27.730036,1.9999979 27.51669,1.9999979 Z"
      id="path2994"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="scccccccccccccccs" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 9.6810138,16.882391 c -0.2087555,0.0015 -0.4193778,0.09972 -0.5671093,0.247178 L 5.333157,20.895322 c -0.150577,0.150726 -0.23436,0.368495 -0.2326492,0.58159 l 0,2.58804 -2.8711061,2.884982 c -0.3058689,0.299444 -0.3058689,0.849195 0,1.148638 l 1.6722537,1.672052 c 0.2994602,0.305838 0.849287,0.305838 1.1487625,0 l 2.8856351,-2.870453 2.588352,0 c 0.213126,0.0015 0.430826,-0.08212 0.581653,-0.232633 l 3.766188,-3.780298 c 0.305884,-0.299428 0.305884,-0.849177 0,-1.14862 L 10.262667,17.129569 C 10.108823,16.975881 9.8984646,16.877181 9.6810138,16.882391 Z"
      id="path3804-7"
      inkscape:connector-curvature="0"

--- a/Numix/48x48/actions/gtk-connect.svg
+++ b/Numix/48x48/actions/gtk-connect.svg
@@ -59,12 +59,12 @@
      id="g3000"
      transform="matrix(0.80000001,0,0,0.80000001,1.4000005,27.399997)" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 40.452416,3.9999973 c -0.304755,0 -0.596244,0.1137779 -0.810156,0.3323112 l -8.122335,8.1214015 -3.697646,0 c -0.304466,-0.0022 -0.615466,0.117334 -0.830933,0.332334 l -5.380268,5.379668 c -0.436956,0.427756 -0.436956,1.233911 0,1.661667 l 6.585113,6.584358 c 0.219777,0.219555 0.520266,0.339777 0.830933,0.332333 0.298222,-0.0022 0.599111,-0.121556 0.810156,-0.332333 l 5.401068,-5.400424 c 0.215111,-0.215334 0.3348,-0.505645 0.332356,-0.810067 l 0,-3.717979 8.10158,-8.1006236 c 0.436955,-0.4277783 0.436955,-1.2339118 0,-1.6616675 L 41.28335,4.3323085 C 41.06935,4.113864 40.757194,3.9999973 40.452416,3.9999973 Z"
      id="path2994"
      inkscape:connector-curvature="0" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 18.972877,21.260557 c -0.298222,0.0022 -0.599111,0.142445 -0.810156,0.353112 l -5.401068,5.379645 c -0.215111,0.215334 -0.3348,0.526423 -0.332356,0.830845 l 0,3.697201 -8.1015801,8.121402 c -0.4369557,0.427778 -0.4369557,1.213134 0,1.640912 l 2.388934,2.388645 c 0.4278001,0.436911 1.213267,0.436911 1.6410893,0 l 8.1223358,-8.100647 3.697646,0 c 0.304466,0.0022 0.615466,-0.117333 0.830933,-0.332333 l 5.380268,-5.400424 c 0.436978,-0.427755 0.436978,-1.213111 0,-1.640889 L 19.80381,21.613669 c -0.219777,-0.219556 -0.520289,-0.360556 -0.830933,-0.353112 z"
      id="path3804-7"
      inkscape:connector-curvature="0" />

--- a/Numix/48x48/actions/gtk-disconnect.svg
+++ b/Numix/48x48/actions/gtk-disconnect.svg
@@ -59,13 +59,13 @@
      id="g3000"
      transform="matrix(0.80000001,0,0,0.80000001,1.4000005,27.399997)" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 40.452416,3.9999973 c -0.304755,0 -0.596244,0.1137779 -0.810156,0.3323112 l -4.122335,4.1214015 -3.697646,0 c -0.304466,-0.0022 -0.615466,0.117334 -0.830933,0.332334 l -5.380268,5.379668 c -0.436956,0.427756 -0.436956,1.233911 0,1.661667 l 6.585113,6.584358 c 0.219777,0.219555 0.520266,0.339777 0.830933,0.332333 0.298222,-0.0022 0.599111,-0.121556 0.810156,-0.332333 l 5.401068,-5.400424 c 0.215111,-0.215334 0.3348,-0.505645 0.332356,-0.810067 l 0,-3.717979 4.10158,-4.1006236 c 0.436955,-0.4277783 0.436955,-1.2339118 0,-1.6616675 L 41.28335,4.3323085 C 41.06935,4.113864 40.757194,3.9999973 40.452416,3.9999973 Z"
      id="path2994"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="scccccccccccccccs" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 14.972877,25.260557 c -0.298222,0.0022 -0.599111,0.142445 -0.810156,0.353112 l -5.401068,5.379645 c -0.215111,0.215334 -0.3348,0.526423 -0.332356,0.830845 l 0,3.697201 -4.1015801,4.121402 c -0.4369557,0.427778 -0.4369557,1.213134 0,1.640912 l 2.388934,2.388645 c 0.4278001,0.436911 1.213267,0.436911 1.6410893,0 l 4.1223358,-4.100647 3.697646,0 c 0.304466,0.0022 0.615466,-0.117333 0.830933,-0.332333 l 5.380268,-5.400424 c 0.436978,-0.427755 0.436978,-1.213111 0,-1.640889 L 15.80381,25.613669 c -0.219777,-0.219556 -0.520289,-0.360556 -0.830933,-0.353112 z"
      id="path3804-7"
      inkscape:connector-curvature="0"

--- a/Numix/64x64/actions/gtk-connect.svg
+++ b/Numix/64x64/actions/gtk-connect.svg
@@ -59,12 +59,12 @@
      id="g3000"
      transform="matrix(0.80000001,0,0,0.80000001,1.4000005,43.399997)" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 55.03338,3.9999957 c -0.426658,0 -0.834738,0.15928 -1.134218,0.465236 l -11.371268,11.3699613 -5.176704,0 c -0.426256,-0.003 -0.861656,0.16428 -1.163308,0.465266 l -7.532376,7.531538 c -0.611734,0.598858 -0.611734,1.727476 0,2.326334 l 9.219158,9.218102 c 0.307686,0.307371 0.728374,0.475688 1.16331,0.465264 0.417508,-0.003 0.838754,-0.170159 1.134216,-0.465264 l 7.561496,-7.560592 c 0.30114,-0.301456 0.46872,-0.707904 0.4653,-1.134094 l 0,-5.205176 11.342212,-11.340872 c 0.611736,-0.5988877 0.611736,-1.7274757 0,-2.3263333 l -3.34451,-3.344134 c -0.2996,-0.305824 -0.736616,-0.465236 -1.163308,-0.465236 z"
      id="path2994"
      inkscape:connector-curvature="0" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 24.962028,28.164781 c -0.417512,0.003 -0.838756,0.19944 -1.134218,0.494356 l -7.561496,7.531504 c -0.301154,0.301454 -0.46872,0.736992 -0.465299,1.163182 l 0,5.17608 -11.3422118,11.369964 c -0.6117376,0.598888 -0.6117376,1.69839 0,2.297276 l 3.3445078,3.344104 c 0.5989202,0.611676 1.6985738,0.611676 2.297525,0 l 11.37127,-11.340906 5.176706,0 c 0.426248,0.003 0.861648,-0.16424 1.163304,-0.465266 l 7.532372,-7.560592 c 0.61177,-0.59886 0.61177,-1.698356 0,-2.297244 l -9.219154,-9.218102 c -0.30769,-0.30737 -0.728406,-0.504776 -1.163306,-0.494356 z"
      id="path3804-7"
      inkscape:connector-curvature="0" />

--- a/Numix/64x64/actions/gtk-disconnect.svg
+++ b/Numix/64x64/actions/gtk-disconnect.svg
@@ -59,13 +59,13 @@
      id="g3000"
      transform="matrix(0.80000001,0,0,0.80000001,1.4000005,43.399997)" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 55.03338,3.9999954 c -0.426658,0 -0.834738,0.15928 -1.134218,0.465236 l -5.771268,5.7699596 -5.176704,0 c -0.426252,-0.003 -0.861652,0.16424 -1.163308,0.465272 l -7.532376,7.531532 c -0.611738,0.598862 -0.611738,1.727476 0,2.326336 l 9.219158,9.218102 c 0.307686,0.30737 0.728376,0.475688 1.16331,0.465264 0.417508,-0.003 0.838754,-0.17016 1.134216,-0.465264 l 7.561496,-7.560594 c 0.301176,-0.301454 0.46872,-0.707902 0.4653,-1.134092 l 0,-5.205174 5.742212,-5.74087 c 0.611736,-0.5988921 0.611736,-1.7274801 0,-2.3263356 l -3.34451,-3.344136 c -0.2996,-0.30582 -0.736616,-0.465236 -1.163308,-0.465236 z"
      id="path2994"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="scccccccccccccccs" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1.;fill:#888888;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 19.362028,33.764781 c -0.417511,0.003 -0.838756,0.19944 -1.134219,0.494356 l -7.561495,7.531506 c -0.301154,0.301452 -0.46872,0.73699 -0.465298,1.16318 l 0,5.17608 -5.7422126,5.769964 c -0.6117378,0.598888 -0.6117378,1.69839 0,2.297276 l 3.3445074,3.344104 c 0.5989204,0.611677 1.698574,0.611677 2.2975252,0 l 5.77127,-5.740906 5.176704,0 c 0.426252,0.003 0.861652,-0.16424 1.163306,-0.465266 l 7.532376,-7.560596 c 0.611768,-0.598856 0.611768,-1.698354 0,-2.29724 l -9.219158,-9.218102 c -0.307688,-0.307376 -0.728405,-0.504776 -1.163306,-0.494356 z"
      id="path3804-7"
      inkscape:connector-curvature="0"


### PR DESCRIPTION
I made an error when designing these icons. Instead of full opacity I used 90% (don't ask me why...)