### PR TITLE
adds Humanity to the inheritence instead of gnome, hicolor

### DIFF
--- a/Numix/index.theme
+++ b/Numix/index.theme
@@ -3,7 +3,7 @@ Name=Numix
 
 Comment=Icon theme from Numix Project
 
-Inherits=gnome,hicolor
+Inherits=Humanity
 
 Example=folder
 


### PR DESCRIPTION
This will fix #160 as ```gnome, hiclolor``` doesn’t have any application icon, and ```Humanity``` inherits from ```gnome,hicolor```
