### PR TITLE
gtk-index overhaul

### DIFF
--- a/Numix/128x128/actions/gtk-index.svg
+++ b/Numix/128x128/actions/gtk-index.svg
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -42,17 +42,41 @@
      id="namedview14"
      showgrid="true"
      inkscape:zoom="1.7383042"
-     inkscape:cx="9.0125481"
-     inkscape:cy="83.368454"
+     inkscape:cx="44.054942"
+     inkscape:cy="71.381086"
      inkscape:window-x="0"
      inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2"
-     showguides="false">
+     inkscape:showpageshadow="false">
     <inkscape:grid
        type="xygrid"
        id="grid4146" />
   </sodipodi:namedview>
+  <path
+     sodipodi:type="star"
+     style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path4144"
+     sodipodi:sides="3"
+     sodipodi:cx="4"
+     sodipodi:cy="4.0847459"
+     sodipodi:r1="3"
+     sodipodi:r2="1.5"
+     sodipodi:arg1="0"
+     sodipodi:arg2="1.0471976"
+     inkscape:flatsided="true"
+     inkscape:rounded="0"
+     inkscape:randomized="0"
+     d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
+     inkscape:transform-center-x="-2.6666665"
+     transform="matrix(3.5555558,0,0,4.2339022,3.1111106,-1.2944141)" />
+  <rect
+     style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect4146"
+     width="76"
+     height="8"
+     x="40"
+     y="12" />
   <path
      sodipodi:type="star"
      style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
@@ -68,15 +92,15 @@
      inkscape:rounded="0"
      inkscape:randomized="0"
      d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
-     inkscape:transform-center-x="-3.9999986"
-     transform="matrix(5.3333332,0,0,3.8490018,-5.333333,6.2778097)" />
+     inkscape:transform-center-x="-2.6666665"
+     transform="matrix(3.5555558,0,0,4.2339022,3.1111106,30.705583)" />
   <rect
      style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect4146-5"
-     width="76"
-     height="12"
-     x="44"
-     y="16.000002" />
+     width="44.000004"
+     height="8"
+     x="40"
+     y="44.000004" />
   <path
      sodipodi:type="star"
      style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
@@ -92,15 +116,15 @@
      inkscape:rounded="0"
      inkscape:randomized="0"
      d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
-     inkscape:transform-center-x="-3.9999986"
-     transform="matrix(5.3333332,0,0,3.8490018,-5.333333,34.27781)" />
+     inkscape:transform-center-x="-2.6666665"
+     transform="matrix(3.5555558,0,0,4.2339022,3.1111106,62.705589)" />
   <rect
      style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect4146-5-6"
      width="76"
-     height="12"
-     x="44"
-     y="44.000004" />
+     height="8"
+     x="40"
+     y="76" />
   <path
      sodipodi:type="star"
      style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
@@ -116,37 +140,13 @@
      inkscape:rounded="0"
      inkscape:randomized="0"
      d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
-     inkscape:transform-center-x="-3.9999986"
-     transform="matrix(5.3333332,0,0,3.8490018,-5.333333,62.277806)" />
+     inkscape:transform-center-x="-2.6666665"
+     transform="matrix(3.5555558,0,0,4.2339022,3.1111106,94.705585)" />
   <rect
      style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect4146-5-6-8"
-     width="76"
-     height="12"
-     x="44"
-     y="72" />
-  <rect
-     style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4146-5-6-8-3"
-     width="76"
-     height="12"
-     x="44"
-     y="100" />
-  <path
-     sodipodi:type="star"
-     style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="path4144-3-6-4-3"
-     sodipodi:sides="3"
-     sodipodi:cx="4"
-     sodipodi:cy="4.0847459"
-     sodipodi:r1="3"
-     sodipodi:r2="1.5"
-     sodipodi:arg1="0"
-     sodipodi:arg2="1.0471976"
-     inkscape:flatsided="true"
-     inkscape:rounded="0"
-     inkscape:randomized="0"
-     d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
-     inkscape:transform-center-x="-3.9999986"
-     transform="matrix(5.3333332,0,0,3.8490018,-5.333333,90.277802)" />
+     width="60.000004"
+     height="8"
+     x="40"
+     y="108" />
 </svg>

--- a/Numix/16x16/actions/gtk-index.svg
+++ b/Numix/16x16/actions/gtk-index.svg
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -41,9 +41,9 @@
      inkscape:window-height="747"
      id="namedview14"
      showgrid="true"
-     inkscape:zoom="19.666667"
-     inkscape:cx="8.5283606"
-     inkscape:cy="8.879146"
+     inkscape:zoom="27.812867"
+     inkscape:cx="8.3811544"
+     inkscape:cy="9.0377685"
      inkscape:window-x="0"
      inkscape:window-y="21"
      inkscape:window-maximized="1"
@@ -52,6 +52,30 @@
        type="xygrid"
        id="grid4146" />
   </sodipodi:namedview>
+  <path
+     sodipodi:type="star"
+     style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path4144"
+     sodipodi:sides="3"
+     sodipodi:cx="4"
+     sodipodi:cy="4.0847459"
+     sodipodi:r1="3"
+     sodipodi:r2="1.5"
+     sodipodi:arg1="0"
+     sodipodi:arg2="1.0471976"
+     inkscape:flatsided="true"
+     inkscape:rounded="0"
+     inkscape:randomized="0"
+     d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
+     inkscape:transform-center-x="-0.33333321"
+     transform="matrix(0.44444444,0,0,0.48112522,-0.11111111,1.5347257)" />
+  <rect
+     style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect4146"
+     width="11"
+     height="1"
+     x="4"
+     y="3" />
   <path
      sodipodi:type="star"
      style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
@@ -67,39 +91,15 @@
      inkscape:rounded="0"
      inkscape:randomized="0"
      d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
-     inkscape:transform-center-x="-0.49999994"
-     transform="matrix(0.66666667,0,0,0.76980036,-0.66666667,-0.14443891)" />
+     inkscape:transform-center-x="-0.33333321"
+     transform="matrix(0.44444444,0,0,0.48112522,-0.11111111,4.5347257)" />
   <rect
      style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect4146-5"
-     width="10"
-     height="2"
-     x="5"
-     y="2" />
-  <path
-     sodipodi:type="star"
-     style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="path4144-3-6"
-     sodipodi:sides="3"
-     sodipodi:cx="4"
-     sodipodi:cy="4.0847459"
-     sodipodi:r1="3"
-     sodipodi:r2="1.5"
-     sodipodi:arg1="0"
-     sodipodi:arg2="1.0471976"
-     inkscape:flatsided="true"
-     inkscape:rounded="0"
-     inkscape:randomized="0"
-     d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
-     inkscape:transform-center-x="-0.49999992"
-     transform="matrix(0.66666667,0,0,0.76980036,-0.66666666,4.8555611)" />
-  <rect
-     style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4146-5-6"
-     width="10"
-     height="2"
-     x="5"
-     y="7" />
+     width="6"
+     height="1"
+     x="4"
+     y="6" />
   <path
      sodipodi:type="star"
      style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
@@ -115,13 +115,37 @@
      inkscape:rounded="0"
      inkscape:randomized="0"
      d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
-     inkscape:transform-center-x="-0.49999993"
-     transform="matrix(0.66666667,0,0,0.76980036,-0.66666666,9.8555611)" />
+     inkscape:transform-center-x="-0.33333321"
+     transform="matrix(0.44444444,0,0,0.48112522,-0.11111111,7.5347257)" />
   <rect
      style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect4146-5-6-8"
-     width="10"
-     height="2"
-     x="5"
+     width="8"
+     height="1"
+     x="4"
      y="12" />
+  <rect
+     style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect4146-0"
+     width="11"
+     height="1"
+     x="4"
+     y="9" />
+  <path
+     sodipodi:type="star"
+     style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path4144-3-6-4-1"
+     sodipodi:sides="3"
+     sodipodi:cx="4"
+     sodipodi:cy="4.0847459"
+     sodipodi:r1="3"
+     sodipodi:r2="1.5"
+     sodipodi:arg1="0"
+     sodipodi:arg2="1.0471976"
+     inkscape:flatsided="true"
+     inkscape:rounded="0"
+     inkscape:randomized="0"
+     d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
+     inkscape:transform-center-x="-0.33333321"
+     transform="matrix(0.44444444,0,0,0.48112522,-0.11111111,10.534726)" />
 </svg>

--- a/Numix/22x22/actions/gtk-index.svg
+++ b/Numix/22x22/actions/gtk-index.svg
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -42,8 +42,8 @@
      id="namedview14"
      showgrid="true"
      inkscape:zoom="19.666667"
-     inkscape:cx="7.8708416"
-     inkscape:cy="8.879146"
+     inkscape:cx="8.2277467"
+     inkscape:cy="10.424304"
      inkscape:window-x="0"
      inkscape:window-y="21"
      inkscape:window-maximized="1"
@@ -52,6 +52,30 @@
        type="xygrid"
        id="grid4146" />
   </sodipodi:namedview>
+  <path
+     sodipodi:type="star"
+     style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path4144"
+     sodipodi:sides="3"
+     sodipodi:cx="4"
+     sodipodi:cy="4.0847459"
+     sodipodi:r1="3"
+     sodipodi:r2="1.5"
+     sodipodi:arg1="0"
+     sodipodi:arg2="1.0471976"
+     inkscape:flatsided="true"
+     inkscape:rounded="0"
+     inkscape:randomized="0"
+     d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
+     inkscape:transform-center-x="-0.4166666"
+     transform="matrix(0.55555555,0,0,0.76980035,0.61111116,0.35556121)" />
+  <rect
+     style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect4146"
+     width="13"
+     height="1"
+     x="7"
+     y="3" />
   <path
      sodipodi:type="star"
      style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
@@ -67,15 +91,15 @@
      inkscape:rounded="0"
      inkscape:randomized="0"
      d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
-     inkscape:transform-center-x="-0.49999994"
-     transform="matrix(0.66666667,0,0,0.76980036,1.3333333,1.8555611)" />
+     inkscape:transform-center-x="-0.4166666"
+     transform="matrix(0.55555555,0,0,0.76980035,0.61111116,5.3555612)" />
   <rect
      style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect4146-5"
-     width="11"
-     height="2"
-     x="8"
-     y="4" />
+     width="7"
+     height="1"
+     x="7"
+     y="8" />
   <path
      sodipodi:type="star"
      style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
@@ -91,15 +115,15 @@
      inkscape:rounded="0"
      inkscape:randomized="0"
      d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
-     inkscape:transform-center-x="-0.49999992"
-     transform="matrix(0.66666667,0,0,0.76980036,1.3333333,7.8555611)" />
+     inkscape:transform-center-x="-0.4166666"
+     transform="matrix(0.55555555,0,0,0.76980035,0.61111116,10.355561)" />
   <rect
      style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect4146-5-6"
-     width="11"
-     height="2"
-     x="8"
-     y="10" />
+     width="13"
+     height="1"
+     x="7"
+     y="13" />
   <path
      sodipodi:type="star"
      style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
@@ -115,13 +139,13 @@
      inkscape:rounded="0"
      inkscape:randomized="0"
      d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
-     inkscape:transform-center-x="-0.49999993"
-     transform="matrix(0.66666667,0,0,0.76980036,1.3333333,13.855561)" />
+     inkscape:transform-center-x="-0.4166666"
+     transform="matrix(0.55555555,0,0,0.76980035,0.61111116,15.355561)" />
   <rect
      style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect4146-5-6-8"
-     width="11"
-     height="2"
-     x="8"
-     y="16" />
+     width="10"
+     height="1"
+     x="7"
+     y="18" />
 </svg>

--- a/Numix/24x24/actions/gtk-index.svg
+++ b/Numix/24x24/actions/gtk-index.svg
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -41,9 +41,9 @@
      inkscape:window-height="747"
      id="namedview14"
      showgrid="true"
-     inkscape:zoom="19.666667"
-     inkscape:cx="7.8708416"
-     inkscape:cy="8.879146"
+     inkscape:zoom="13.906433"
+     inkscape:cx="-0.048870124"
+     inkscape:cy="9.6357546"
      inkscape:window-x="0"
      inkscape:window-y="21"
      inkscape:window-maximized="1"
@@ -52,6 +52,30 @@
        type="xygrid"
        id="grid4146" />
   </sodipodi:namedview>
+  <path
+     sodipodi:type="star"
+     style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path4144"
+     sodipodi:sides="3"
+     sodipodi:cx="4"
+     sodipodi:cy="4.0847459"
+     sodipodi:r1="3"
+     sodipodi:r2="1.5"
+     sodipodi:arg1="0"
+     sodipodi:arg2="1.0471976"
+     inkscape:flatsided="true"
+     inkscape:rounded="0"
+     inkscape:randomized="0"
+     d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
+     inkscape:transform-center-x="-0.4166666"
+     transform="matrix(0.55555555,0,0,0.76980035,1.6111111,1.3555613)" />
+  <rect
+     style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect4146"
+     width="13"
+     height="1"
+     x="8"
+     y="4" />
   <path
      sodipodi:type="star"
      style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
@@ -67,15 +91,15 @@
      inkscape:rounded="0"
      inkscape:randomized="0"
      d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
-     inkscape:transform-center-x="-0.49999994"
-     transform="matrix(0.66666667,0,0,0.76980036,2.3333333,2.8555612)" />
+     inkscape:transform-center-x="-0.4166666"
+     transform="matrix(0.55555555,0,0,0.76980035,1.6111111,6.3555613)" />
   <rect
      style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect4146-5"
-     width="11"
-     height="2"
-     x="9"
-     y="5" />
+     width="7"
+     height="1"
+     x="8"
+     y="9" />
   <path
      sodipodi:type="star"
      style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
@@ -91,15 +115,15 @@
      inkscape:rounded="0"
      inkscape:randomized="0"
      d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
-     inkscape:transform-center-x="-0.49999992"
-     transform="matrix(0.66666667,0,0,0.76980036,2.3333333,8.8555612)" />
+     inkscape:transform-center-x="-0.4166666"
+     transform="matrix(0.55555555,0,0,0.76980035,1.6111111,11.355561)" />
   <rect
      style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect4146-5-6"
-     width="11"
-     height="2"
-     x="9"
-     y="11" />
+     width="13"
+     height="1"
+     x="8"
+     y="14" />
   <path
      sodipodi:type="star"
      style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
@@ -115,13 +139,13 @@
      inkscape:rounded="0"
      inkscape:randomized="0"
      d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
-     inkscape:transform-center-x="-0.49999993"
-     transform="matrix(0.66666667,0,0,0.76980036,2.3333333,14.855561)" />
+     inkscape:transform-center-x="-0.4166666"
+     transform="matrix(0.55555555,0,0,0.76980035,1.6111111,16.355561)" />
   <rect
      style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect4146-5-6-8"
-     width="11"
-     height="2"
-     x="9"
-     y="17" />
+     width="10"
+     height="1"
+     x="8"
+     y="19" />
 </svg>

--- a/Numix/256x256/actions/gtk-index.svg
+++ b/Numix/256x256/actions/gtk-index.svg
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -42,17 +42,41 @@
      id="namedview14"
      showgrid="true"
      inkscape:zoom="1.7383042"
-     inkscape:cx="9.0125481"
-     inkscape:cy="83.368454"
+     inkscape:cx="44.054942"
+     inkscape:cy="94.392019"
      inkscape:window-x="0"
      inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2"
-     showguides="false">
+     inkscape:showpageshadow="false">
     <inkscape:grid
        type="xygrid"
        id="grid4146" />
   </sodipodi:namedview>
+  <path
+     sodipodi:type="star"
+     style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path4144"
+     sodipodi:sides="3"
+     sodipodi:cx="4"
+     sodipodi:cy="4.0847459"
+     sodipodi:r1="3"
+     sodipodi:r2="1.5"
+     sodipodi:arg1="0"
+     sodipodi:arg2="1.0471976"
+     inkscape:flatsided="true"
+     inkscape:rounded="0"
+     inkscape:randomized="0"
+     d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
+     inkscape:transform-center-x="-5.3333333"
+     transform="matrix(7.1111121,0,0,8.467805,6.2222083,-2.5888285)" />
+  <rect
+     style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect4146"
+     width="152.00002"
+     height="16.000002"
+     x="79.999992"
+     y="23.999994" />
   <path
      sodipodi:type="star"
      style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
@@ -68,15 +92,15 @@
      inkscape:rounded="0"
      inkscape:randomized="0"
      d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
-     inkscape:transform-center-x="-7.9999969"
-     transform="matrix(10.666667,0,0,7.6980042,-10.666679,12.555614)" />
+     inkscape:transform-center-x="-5.3333333"
+     transform="matrix(7.1111121,0,0,8.467805,6.2222083,61.411156)" />
   <rect
      style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect4146-5"
-     width="152.00002"
-     height="24.000002"
-     x="88"
-     y="31.999996" />
+     width="88.000015"
+     height="16.000002"
+     x="79.999992"
+     y="88" />
   <path
      sodipodi:type="star"
      style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
@@ -92,15 +116,15 @@
      inkscape:rounded="0"
      inkscape:randomized="0"
      d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
-     inkscape:transform-center-x="-7.9999969"
-     transform="matrix(10.666667,0,0,7.6980042,-10.666679,68.555616)" />
+     inkscape:transform-center-x="-5.3333333"
+     transform="matrix(7.1111121,0,0,8.467805,6.2222083,125.41119)" />
   <rect
      style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect4146-5-6"
      width="152.00002"
-     height="24.000002"
-     x="88"
-     y="88.000008" />
+     height="16.000002"
+     x="79.999992"
+     y="152" />
   <path
      sodipodi:type="star"
      style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
@@ -116,37 +140,13 @@
      inkscape:rounded="0"
      inkscape:randomized="0"
      d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
-     inkscape:transform-center-x="-7.9999969"
-     transform="matrix(10.666667,0,0,7.6980042,-10.666679,124.55561)" />
+     inkscape:transform-center-x="-5.3333333"
+     transform="matrix(7.1111121,0,0,8.467805,6.2222083,189.41117)" />
   <rect
      style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect4146-5-6-8"
-     width="152.00002"
-     height="24.000002"
-     x="88"
-     y="144" />
-  <rect
-     style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4146-5-6-8-3"
-     width="152.00002"
-     height="24.000002"
-     x="88"
-     y="200" />
-  <path
-     sodipodi:type="star"
-     style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="path4144-3-6-4-3"
-     sodipodi:sides="3"
-     sodipodi:cx="4"
-     sodipodi:cy="4.0847459"
-     sodipodi:r1="3"
-     sodipodi:r2="1.5"
-     sodipodi:arg1="0"
-     sodipodi:arg2="1.0471976"
-     inkscape:flatsided="true"
-     inkscape:rounded="0"
-     inkscape:randomized="0"
-     d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
-     inkscape:transform-center-x="-7.9999969"
-     transform="matrix(10.666667,0,0,7.6980042,-10.666679,180.5556)" />
+     width="120.00002"
+     height="16.000002"
+     x="79.999992"
+     y="216" />
 </svg>

--- a/Numix/32x32/actions/gtk-index.svg
+++ b/Numix/32x32/actions/gtk-index.svg
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -41,18 +41,42 @@
      inkscape:window-height="747"
      id="namedview14"
      showgrid="true"
-     inkscape:zoom="13.906434"
-     inkscape:cx="17.719341"
-     inkscape:cy="17.182176"
+     inkscape:zoom="19.666667"
+     inkscape:cx="17.609195"
+     inkscape:cy="18.151385"
      inkscape:window-x="0"
      inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2"
-     showguides="false">
+     inkscape:showpageshadow="false">
     <inkscape:grid
        type="xygrid"
        id="grid4146" />
   </sodipodi:namedview>
+  <path
+     sodipodi:type="star"
+     style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path4144"
+     sodipodi:sides="3"
+     sodipodi:cx="4"
+     sodipodi:cy="4.0847459"
+     sodipodi:r1="3"
+     sodipodi:r2="1.5"
+     sodipodi:arg1="0"
+     sodipodi:arg2="1.0471976"
+     inkscape:flatsided="true"
+     inkscape:rounded="0"
+     inkscape:randomized="0"
+     d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
+     inkscape:transform-center-x="-0.66666648"
+     transform="matrix(0.88888889,0,0,1.0584755,0.77777778,-0.32360346)" />
+  <rect
+     style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect4146"
+     width="19"
+     height="2"
+     x="10"
+     y="3" />
   <path
      sodipodi:type="star"
      style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
@@ -68,15 +92,15 @@
      inkscape:rounded="0"
      inkscape:randomized="0"
      d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
-     inkscape:transform-center-x="-0.9999997"
-     transform="matrix(1.3333333,0,0,0.96225045,-1.3333332,1.5694517)" />
+     inkscape:transform-center-x="-0.66666648"
+     transform="matrix(0.88888889,0,0,1.0584755,0.77777778,7.6763965)" />
   <rect
      style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect4146-5"
-     width="19"
-     height="3"
-     x="11"
-     y="4" />
+     width="11"
+     height="2"
+     x="10"
+     y="11" />
   <path
      sodipodi:type="star"
      style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
@@ -92,15 +116,15 @@
      inkscape:rounded="0"
      inkscape:randomized="0"
      d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
-     inkscape:transform-center-x="-0.99999966"
-     transform="matrix(1.3333333,0,0,0.96225045,-1.3333332,8.5694516)" />
+     inkscape:transform-center-x="-0.66666648"
+     transform="matrix(0.88888889,0,0,1.0584755,0.77777778,15.676397)" />
   <rect
      style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect4146-5-6"
      width="19"
-     height="3"
-     x="11"
-     y="11" />
+     height="2"
+     x="10"
+     y="19" />
   <path
      sodipodi:type="star"
      style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
@@ -116,37 +140,13 @@
      inkscape:rounded="0"
      inkscape:randomized="0"
      d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
-     inkscape:transform-center-x="-0.99999968"
-     transform="matrix(1.3333333,0,0,0.96225045,-1.3333332,15.569451)" />
+     inkscape:transform-center-x="-0.66666648"
+     transform="matrix(0.88888889,0,0,1.0584755,0.77777778,23.676397)" />
   <rect
      style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect4146-5-6-8"
-     width="19"
-     height="3"
-     x="11"
-     y="18" />
-  <rect
-     style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4146-5-6-8-3"
-     width="19"
-     height="3"
-     x="11"
-     y="25" />
-  <path
-     sodipodi:type="star"
-     style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="path4144-3-6-4-3"
-     sodipodi:sides="3"
-     sodipodi:cx="4"
-     sodipodi:cy="4.0847459"
-     sodipodi:r1="3"
-     sodipodi:r2="1.5"
-     sodipodi:arg1="0"
-     sodipodi:arg2="1.0471976"
-     inkscape:flatsided="true"
-     inkscape:rounded="0"
-     inkscape:randomized="0"
-     d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
-     inkscape:transform-center-x="-0.99999968"
-     transform="matrix(1.3333333,0,0,0.96225045,-1.3333332,22.569451)" />
+     width="15"
+     height="2"
+     x="10"
+     y="27" />
 </svg>

--- a/Numix/48x48/actions/gtk-index.svg
+++ b/Numix/48x48/actions/gtk-index.svg
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -41,9 +41,9 @@
      inkscape:window-height="747"
      id="namedview14"
      showgrid="true"
-     inkscape:zoom="9.8333333"
-     inkscape:cx="24.328865"
-     inkscape:cy="23.223051"
+     inkscape:zoom="4.9166667"
+     inkscape:cx="34.941195"
+     inkscape:cy="24.013175"
      inkscape:window-x="0"
      inkscape:window-y="21"
      inkscape:window-maximized="1"
@@ -68,14 +68,14 @@
      inkscape:randomized="0"
      d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
      inkscape:transform-center-x="-0.83333316"
-     transform="matrix(1.1111111,0,0,1.5396007,3.2222223,2.7111226)" />
+     transform="matrix(1.1111111,0,0,1.5396007,3.2222223,1.2111224)" />
   <rect
      style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect4146"
      width="27"
-     height="4"
+     height="3"
      x="15"
-     y="7" />
+     y="6" />
   <path
      sodipodi:type="star"
      style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
@@ -92,12 +92,12 @@
      inkscape:randomized="0"
      d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
      inkscape:transform-center-x="-0.83333316"
-     transform="matrix(1.1111111,0,0,1.5396007,3.2222223,12.711122)" />
+     transform="matrix(1.1111111,0,0,1.5396007,3.2222223,12.211122)" />
   <rect
      style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect4146-5"
-     width="27"
-     height="4"
+     width="15"
+     height="3"
      x="15"
      y="17" />
   <path
@@ -116,14 +116,14 @@
      inkscape:randomized="0"
      d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
      inkscape:transform-center-x="-0.83333316"
-     transform="matrix(1.1111111,0,0,1.5396007,3.2222223,22.711122)" />
+     transform="matrix(1.1111111,0,0,1.5396007,3.2222223,23.211122)" />
   <rect
      style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect4146-5-6"
      width="27"
-     height="4"
+     height="3"
      x="15"
-     y="27" />
+     y="28" />
   <path
      sodipodi:type="star"
      style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
@@ -140,12 +140,12 @@
      inkscape:randomized="0"
      d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
      inkscape:transform-center-x="-0.83333316"
-     transform="matrix(1.1111111,0,0,1.5396007,3.2222223,32.711122)" />
+     transform="matrix(1.1111111,0,0,1.5396007,3.2222223,34.211122)" />
   <rect
      style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect4146-5-6-8"
-     width="27"
-     height="4"
+     width="21"
+     height="3"
      x="15"
-     y="37" />
+     y="39" />
 </svg>

--- a/Numix/64x64/actions/gtk-index.svg
+++ b/Numix/64x64/actions/gtk-index.svg
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -41,18 +41,42 @@
      inkscape:window-height="747"
      id="namedview14"
      showgrid="true"
-     inkscape:zoom="4.9166668"
-     inkscape:cx="7.7625269"
-     inkscape:cy="41.628667"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="35.873676"
+     inkscape:cy="33.174665"
      inkscape:window-x="0"
      inkscape:window-y="21"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2"
-     showguides="false">
+     inkscape:showpageshadow="false">
     <inkscape:grid
        type="xygrid"
        id="grid4146" />
   </sodipodi:namedview>
+  <path
+     sodipodi:type="star"
+     style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path4144"
+     sodipodi:sides="3"
+     sodipodi:cx="4"
+     sodipodi:cy="4.0847459"
+     sodipodi:r1="3"
+     sodipodi:r2="1.5"
+     sodipodi:arg1="0"
+     sodipodi:arg2="1.0471976"
+     inkscape:flatsided="true"
+     inkscape:rounded="0"
+     inkscape:randomized="0"
+     d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
+     inkscape:transform-center-x="-1.3333331"
+     transform="matrix(1.7777778,0,0,2.116951,1.5555556,-0.64720712)" />
+  <rect
+     style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect4146"
+     width="38"
+     height="4"
+     x="20"
+     y="5.999999" />
   <path
      sodipodi:type="star"
      style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
@@ -68,15 +92,15 @@
      inkscape:rounded="0"
      inkscape:randomized="0"
      d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
-     inkscape:transform-center-x="-1.9999993"
-     transform="matrix(2.6666666,0,0,1.9245009,-2.6666665,3.138904)" />
+     inkscape:transform-center-x="-1.3333331"
+     transform="matrix(1.7777778,0,0,2.116951,1.5555556,15.352791)" />
   <rect
      style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect4146-5"
-     width="38"
-     height="6"
-     x="22"
-     y="7.9999995" />
+     width="22"
+     height="4"
+     x="20"
+     y="22" />
   <path
      sodipodi:type="star"
      style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
@@ -92,15 +116,15 @@
      inkscape:rounded="0"
      inkscape:randomized="0"
      d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
-     inkscape:transform-center-x="-1.9999993"
-     transform="matrix(2.6666666,0,0,1.9245009,-2.6666665,17.138904)" />
+     inkscape:transform-center-x="-1.3333331"
+     transform="matrix(1.7777778,0,0,2.116951,1.5555556,31.352793)" />
   <rect
      style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect4146-5-6"
      width="38"
-     height="6"
-     x="22"
-     y="22" />
+     height="4"
+     x="20"
+     y="38" />
   <path
      sodipodi:type="star"
      style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
@@ -116,37 +140,13 @@
      inkscape:rounded="0"
      inkscape:randomized="0"
      d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
-     inkscape:transform-center-x="-1.9999993"
-     transform="matrix(2.6666666,0,0,1.9245009,-2.6666665,31.138902)" />
+     inkscape:transform-center-x="-1.3333331"
+     transform="matrix(1.7777778,0,0,2.116951,1.5555556,47.352793)" />
   <rect
      style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect4146-5-6-8"
-     width="38"
-     height="6"
-     x="22"
-     y="36" />
-  <rect
-     style="opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4146-5-6-8-3"
-     width="38"
-     height="6"
-     x="22"
-     y="50" />
-  <path
-     sodipodi:type="star"
-     style="opacity:1;fill:#268bd2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="path4144-3-6-4-3"
-     sodipodi:sides="3"
-     sodipodi:cx="4"
-     sodipodi:cy="4.0847459"
-     sodipodi:r1="3"
-     sodipodi:r2="1.5"
-     sodipodi:arg1="0"
-     sodipodi:arg2="1.0471976"
-     inkscape:flatsided="true"
-     inkscape:rounded="0"
-     inkscape:randomized="0"
-     d="M 7,4.0847459 2.5,6.6828221 2.5,1.4866697 Z"
-     inkscape:transform-center-x="-1.9999993"
-     transform="matrix(2.6666666,0,0,1.9245009,-2.6666665,45.138902)" />
+     width="30"
+     height="4"
+     x="20"
+     y="54" />
 </svg>


### PR DESCRIPTION
I made an improvement for `gtk-index.svg` arguably the worst icon I commited in the last days. This is much better now. 
My proposed version for the gtk icons now:
![unbenannt](https://cloud.githubusercontent.com/assets/6475757/8031332/bfa326d2-0dcd-11e5-81d0-c3f593f3f178.png)
