### PR TITLE
Aligns aptdaemon to grid

### DIFF
--- a/Numix/128x128/status/aptdaemon-add.svg
+++ b/Numix/128x128/status/aptdaemon-add.svg
@@ -1,3 +1,61 @@
-<svg width="128" xmlns="http://www.w3.org/2000/svg" height="128" viewBox="0 0 128 128" xmlns:xlink="http://www.w3.org/1999/xlink">
-<path style="fill:#c28e5c" d="M 39.582031 15.832031 L 19.792969 39.582031 L 59.375 39.582031 L 59.375 15.832031 Z M 67.292969 15.832031 L 67.292969 39.582031 L 106.875 39.582031 L 87.082031 15.832031 Z M 19.792969 47.5 L 19.792969 102.917969 L 75.207031 102.917969 L 75.207031 83.125 L 87.082031 83.125 L 87.082031 71.25 L 106.875 71.25 L 106.875 47.5 Z M 95 79.167969 L 95 91.042969 L 83.125 91.042969 L 83.125 102.917969 L 95 102.917969 L 95 114.792969 L 106.875 114.792969 L 106.875 102.917969 L 118.75 102.917969 L 118.75 91.042969 L 106.875 91.042969 L 106.875 79.167969 Z "/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="128"
+   height="128"
+   viewBox="0 0 128 128"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="aptdaemon-add.svg">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview6"
+     showgrid="true"
+     inkscape:zoom="2.6074563"
+     inkscape:cx="87.34396"
+     inkscape:cy="20.764179"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4138" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#c28e5c"
+     d="M 39.99985,20.000748 20,44.000568 l 39.9997,0 0,-23.99982 z m 27.99979,0 0,23.99982 39.9997,0 -19.999848,-23.99982 z M 20,52.000508 l 0,55.999592 55.999582,0 0,-19.99986 11.99991,0 0,-11.9999 19.999848,0 0,-23.999832 z m 76.00018,31.999772 0,11.9999 -11.99991,0 -0.0015,11.99992 11.99991,0 7.52e-4,11.9999 11.999908,0 -7.5e-4,-11.9999 11.99991,0 10e-4,-11.99992 -11.99991,0 0,-11.9999 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccccccccccccccccccccccccc" />
 </svg>

--- a/Numix/16x16/status/aptdaemon-add.svg
+++ b/Numix/16x16/status/aptdaemon-add.svg
@@ -1,3 +1,60 @@
-<svg width="16" xmlns="http://www.w3.org/2000/svg" height="16" viewBox="0 0 16 16" xmlns:xlink="http://www.w3.org/1999/xlink">
-<path style="fill:#c28e5c" d="M 4.949219 1.980469 L 2.472656 4.949219 L 7.421875 4.949219 L 7.421875 1.980469 Z M 8.410156 1.980469 L 8.410156 4.949219 L 13.359375 4.949219 L 10.886719 1.980469 Z M 2.472656 5.9375 L 2.472656 12.863281 L 9.402344 12.863281 L 9.402344 10.390625 L 10.886719 10.390625 L 10.886719 8.90625 L 13.359375 8.90625 L 13.359375 5.9375 Z M 11.875 9.894531 L 11.875 11.378906 L 10.390625 11.378906 L 10.390625 12.863281 L 11.875 12.863281 L 11.875 14.347656 L 13.359375 14.347656 L 13.359375 12.863281 L 14.84375 12.863281 L 14.84375 11.378906 L 13.359375 11.378906 L 13.359375 9.894531 Z "/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="aptdaemon-add.svg">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview6"
+     showgrid="true"
+     inkscape:zoom="2.6074563"
+     inkscape:cx="25.1244"
+     inkscape:cy="53.817074"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4138" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#c28e5c"
+     d="M 5,2 3,5 7.5,5 7.5,2 Z M 8.5,2 8.5,5 13,5 11,2 Z M 3,6 l 0,7 6,0 0,-2 2,0 0,-2 2,0 0,-3 z m 9,4 0,2 -2,0 0,1 2,0 0,2 1,0 0,-2 2,0 0,-1 -2,0 0,-2 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccccccccccccccccccccccccc" />
 </svg>

--- a/Numix/22x22/status/aptdaemon-add.svg
+++ b/Numix/22x22/status/aptdaemon-add.svg
@@ -1,3 +1,61 @@
-<svg width="22" xmlns="http://www.w3.org/2000/svg" height="22" viewBox="0 0 22 22" xmlns:xlink="http://www.w3.org/1999/xlink">
-<path style="fill:#c28e5c" d="M 6.804688 2.722656 L 3.402344 6.804688 L 10.203125 6.804688 L 10.203125 2.722656 Z M 11.566406 2.722656 L 11.566406 6.804688 L 18.371094 6.804688 L 14.96875 2.722656 Z M 3.402344 8.164062 L 3.402344 17.6875 L 12.925781 17.6875 L 12.925781 14.285156 L 14.96875 14.285156 L 14.96875 12.246094 L 18.371094 12.246094 L 18.371094 8.164062 Z M 16.328125 13.605469 L 16.328125 15.648438 L 14.285156 15.648438 L 14.285156 17.6875 L 16.328125 17.6875 L 16.328125 19.730469 L 18.371094 19.730469 L 18.371094 17.6875 L 20.410156 17.6875 L 20.410156 15.648438 L 18.371094 15.648438 L 18.371094 13.605469 Z "/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   viewBox="0 0 22 22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="aptdaemon-add.svg">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview6"
+     showgrid="true"
+     inkscape:zoom="16"
+     inkscape:cx="10.7873"
+     inkscape:cy="13.253789"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4138" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#c28e5c"
+     d="m 7,3 -4,4 7,0 0,-4 z m 5,0 0,4 7,0 -4,-4 z m -9,6 0,10.000235 10,0 L 13,15 l 2,0 0,-2 4,0 0,-4 z m 14,6 0,2 -1.999862,0 -2.75e-4,2.000235 2.000068,0 L 17.000068,21 19,21 l -1.37e-4,-1.999765 2.000035,0 L 21.000102,17 l -2.000034,0 6.8e-5,-2 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccccccccccccccccccccccccc" />
 </svg>

--- a/Numix/24x24/status/aptdaemon-add.svg
+++ b/Numix/24x24/status/aptdaemon-add.svg
@@ -1,3 +1,61 @@
-<svg width="24" xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" xmlns:xlink="http://www.w3.org/1999/xlink">
-<path style="fill:#c28e5c" d="M 7.421875 2.96875 L 3.710938 7.421875 L 11.132812 7.421875 L 11.132812 2.96875 Z M 12.617188 2.96875 L 12.617188 7.421875 L 20.039062 7.421875 L 16.328125 2.96875 Z M 3.710938 8.90625 L 3.710938 19.296875 L 14.101562 19.296875 L 14.101562 15.585938 L 16.328125 15.585938 L 16.328125 13.359375 L 20.039062 13.359375 L 20.039062 8.90625 Z M 17.8125 14.84375 L 17.8125 17.070312 L 15.585938 17.070312 L 15.585938 19.296875 L 17.8125 19.296875 L 17.8125 21.523438 L 20.039062 21.523438 L 20.039062 19.296875 L 22.265625 19.296875 L 22.265625 17.070312 L 20.039062 17.070312 L 20.039062 14.84375 Z "/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="aptdaemon-add.svg">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview6"
+     showgrid="true"
+     inkscape:zoom="16"
+     inkscape:cx="-2.715613"
+     inkscape:cy="5.4562622"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4138" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#c28e5c"
+     d="m 8,4 -4,4 7,0 0,-4 z m 5,0 0,4 7,0 -4,-4 z m -9,6 0,10.000235 10,0 L 14,16 l 2,0 0,-2 4,0 0,-4 z m 14,6 0,2 -1.999862,0 -2.75e-4,2.000235 2.000068,0 L 18.000068,22 20,22 l -1.37e-4,-1.999765 2.000035,0 L 22.000102,18 l -2.000034,0 6.8e-5,-2 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccccccccccccccccccccccccc" />
 </svg>

--- a/Numix/256x256/status/aptdaemon-add.svg
+++ b/Numix/256x256/status/aptdaemon-add.svg
@@ -1,3 +1,61 @@
-<svg width="256" xmlns="http://www.w3.org/2000/svg" height="256" viewBox="0 0 256 256" xmlns:xlink="http://www.w3.org/1999/xlink">
-<path style="fill:#c28e5c" d="M 79.167969 31.667969 L 39.582031 79.167969 L 118.75 79.167969 L 118.75 31.667969 Z M 134.582031 31.667969 L 134.582031 79.167969 L 213.75 79.167969 L 174.167969 31.667969 Z M 39.582031 95 L 39.582031 205.832031 L 150.417969 205.832031 L 150.417969 166.25 L 174.167969 166.25 L 174.167969 142.5 L 213.75 142.5 L 213.75 95 Z M 190 158.332031 L 190 182.082031 L 166.25 182.082031 L 166.25 205.832031 L 190 205.832031 L 190 229.582031 L 213.75 229.582031 L 213.75 205.832031 L 237.5 205.832031 L 237.5 182.082031 L 213.75 182.082031 L 213.75 158.332031 Z "/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="256"
+   height="256"
+   viewBox="0 0 256 256"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="aptdaemon-add.svg">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview6"
+     showgrid="true"
+     inkscape:zoom="0.921875"
+     inkscape:cx="127.68415"
+     inkscape:cy="7.2979903"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4138" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#c28e5c"
+     d="M 79.9999,40 40,88 l 79.9998,0 0,-48 z m 55.99986,0 0,48 79.9998,0 -39.9999,-48 z M 40,104 l 0,112.00002 111.99972,0 0,-40.00002 23.99994,0 0,-23.99998 39.9999,0 0,-48.00002 z m 152.00112,64.00002 0,23.99998 -23.99994,0 -0.003,24.00002 23.99994,0 0.001,23.99998 23.99994,0 -10e-4,-23.99998 23.99994,0 L 240,192 l -23.99994,0 0,-23.99998 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccccccccccccccccccccccccc" />
 </svg>

--- a/Numix/32x32/status/aptdaemon-add.svg
+++ b/Numix/32x32/status/aptdaemon-add.svg
@@ -1,3 +1,60 @@
-<svg width="32" xmlns="http://www.w3.org/2000/svg" height="32" viewBox="0 0 32 32" xmlns:xlink="http://www.w3.org/1999/xlink">
-<path style="fill:#c28e5c" d="M 9.894531 3.957031 L 4.949219 9.894531 L 14.84375 9.894531 L 14.84375 3.957031 Z M 16.824219 3.957031 L 16.824219 9.894531 L 26.71875 9.894531 L 21.769531 3.957031 Z M 4.949219 11.875 L 4.949219 25.730469 L 18.800781 25.730469 L 18.800781 20.78125 L 21.769531 20.78125 L 21.769531 17.8125 L 26.71875 17.8125 L 26.71875 11.875 Z M 23.75 19.792969 L 23.75 22.761719 L 20.78125 22.761719 L 20.78125 25.730469 L 23.75 25.730469 L 23.75 28.699219 L 26.71875 28.699219 L 26.71875 25.730469 L 29.6875 25.730469 L 29.6875 22.761719 L 26.71875 22.761719 L 26.71875 19.792969 Z "/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   height="32"
+   viewBox="0 0 32 32"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="aptdaemon-add.svg">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview6"
+     showgrid="true"
+     inkscape:zoom="14.75"
+     inkscape:cx="7.581874"
+     inkscape:cy="18.0365"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4138" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#c28e5c"
+     d="m 10,5 -5,6 10,0 0,-6 z m 7,0 0,6 10,0 -5,-6 z m -12,8 0,14 14,0 0,-5 3,0 0,-3 5,0 0,-6 z m 19.000187,8 0,3 -3,0 -3.75e-4,3 3,0 1.88e-4,3 3,0 -1.88e-4,-3 3,0 3.75e-4,-3 -3,0 0,-3 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccccccccccccccccccccccccc" />
 </svg>

--- a/Numix/48x48/status/aptdaemon-add.svg
+++ b/Numix/48x48/status/aptdaemon-add.svg
@@ -1,3 +1,61 @@
-<svg width="47.5" xmlns="http://www.w3.org/2000/svg" height="47.5" viewBox="0 0 38 38" xmlns:xlink="http://www.w3.org/1999/xlink">
-<path style="fill:#c38f5d" d="M 11.875 4.75 L 5.9375 11.875 L 17.8125 11.875 L 17.8125 4.75 Z M 20.1875 4.75 L 20.1875 11.875 L 32.0625 11.875 L 26.125 4.75 Z M 5.9375 14.25 L 5.9375 30.875 L 22.5625 30.875 L 22.5625 24.9375 L 26.125 24.9375 L 26.125 21.375 L 32.0625 21.375 L 32.0625 14.25 Z M 28.5 23.75 L 28.5 27.3125 L 24.9375 27.3125 L 24.9375 30.875 L 28.5 30.875 L 28.5 34.4375 L 32.0625 34.4375 L 32.0625 30.875 L 35.625 30.875 L 35.625 27.3125 L 32.0625 27.3125 L 32.0625 23.75 Z "/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="aptdaemon-add.svg">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview6"
+     showgrid="true"
+     inkscape:zoom="5.6568543"
+     inkscape:cx="53.717303"
+     inkscape:cy="31.828209"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4138" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#c28e5c"
+     d="m 15,7 -8,9 15,0 0,-9 z m 11,0 0,9 15,0 -8,-9 z m -19,12 0,22.000034 21,0 L 28,33 l 5,0 0,-5 8,0 0,-9 z m 29,12 0,5 -4.999711,0 -5.78e-4,5.000034 5.000144,0 2.9e-4,4.999966 4.999856,0 -2.9e-4,-4.999966 5.000072,0 L 46.000216,36 l -5.000072,0 1.45e-4,-5 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccccccccccccccccccccccccc" />
 </svg>

--- a/Numix/64x64/status/aptdaemon-add.svg
+++ b/Numix/64x64/status/aptdaemon-add.svg
@@ -1,3 +1,61 @@
-<svg width="64" xmlns="http://www.w3.org/2000/svg" height="64" viewBox="0 0 64 64" xmlns:xlink="http://www.w3.org/1999/xlink">
-<path style="fill:#c28e5c" d="M 19.792969 7.917969 L 9.894531 19.792969 L 29.6875 19.792969 L 29.6875 7.917969 Z M 33.644531 7.917969 L 33.644531 19.792969 L 53.4375 19.792969 L 43.542969 7.917969 Z M 9.894531 23.75 L 9.894531 51.457031 L 37.605469 51.457031 L 37.605469 41.5625 L 43.542969 41.5625 L 43.542969 35.625 L 53.4375 35.625 L 53.4375 23.75 Z M 47.5 39.582031 L 47.5 45.519531 L 41.5625 45.519531 L 41.5625 51.457031 L 47.5 51.457031 L 47.5 57.394531 L 53.4375 57.394531 L 53.4375 51.457031 L 59.375 51.457031 L 59.375 45.519531 L 53.4375 45.519531 L 53.4375 39.582031 Z "/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="aptdaemon-add.svg">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="747"
+     id="namedview6"
+     showgrid="true"
+     inkscape:zoom="7.375"
+     inkscape:cx="27.227034"
+     inkscape:cy="32.400991"
+     inkscape:window-x="0"
+     inkscape:window-y="21"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4138" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#c28e5c"
+     d="M 19.999925,10.000374 10,22.000284 l 19.99985,0 0,-11.99991 z m 13.999895,0 0,11.99991 19.999851,0 -9.999925,-11.99991 z M 10,26.000254 l 0,27.999791 27.999791,0 0,-9.999925 5.999955,0 0,-5.999955 9.999925,0 0,-11.999911 z m 38.00009,15.999881 0,5.999955 -5.999955,0 -7.5e-4,5.999955 5.999955,0 3.76e-4,5.999955 5.999955,0 -3.76e-4,-5.999955 5.999955,0 L 60,48.00009 l -5.999955,0 0,-5.999955 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccccccccccccccccccccccccc" />
 </svg>


### PR DESCRIPTION
While trying to fix #184 I recognized that none of the `aptdaemon-add.svg` icons in status is aligned to grid. I changed the icons accordingly