### PR TITLE
Added drive-harddisk-solidstate-symbolic.svg

### DIFF
--- a/Numix-Light/scalable/devices/drive-harddisk-solidstate-symbolic.svg
+++ b/Numix-Light/scalable/devices/drive-harddisk-solidstate-symbolic.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 16.0002 16"
+   style="enable-background:new"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   width="100%"
+   height="100%"
+   sodipodi:docname="drive-harddisk-solidstate-symbolic.svg">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="773"
+     id="namedview10"
+     showgrid="true"
+     inkscape:zoom="34.0625"
+     inkscape:cx="8.0001"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3833" />
+  </sodipodi:namedview>
+  <g
+     id="g3759"
+     style="fill:#bebebe;fill-opacity:1">
+    <path
+       sodipodi:nodetypes="ssssssssssssssss"
+       inkscape:connector-curvature="0"
+       id="rect2984"
+       d="M 3,0 C 1.892,0 1,0.892 1,2 l 0,12 c 0,1.108 0.892,2 2,2 l 10,0 c 1.108,0 2,-0.892 2,-2 L 15,2 C 15,0.892 14.108,0 13,0 Z m 0.5,13 9,0 c 0.277,0 0.5,0.223 0.5,0.5 0,0.277 -0.223,0.5 -0.5,0.5 l -9,0 C 3.223,14 3,13.777 3,13.5 3,13.223 3.223,13 3.5,13 Z"
+       style="fill:#353535;fill-opacity:1;stroke:none" />
+  </g>
+</svg>

--- a/Numix/scalable/devices/drive-harddisk-solidstate-symbolic.svg
+++ b/Numix/scalable/devices/drive-harddisk-solidstate-symbolic.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 16.0002 16"
+   style="enable-background:new"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   width="100%"
+   height="100%"
+   sodipodi:docname="drive-harddisk-solidstate-symbolic.svg">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="773"
+     id="namedview10"
+     showgrid="true"
+     inkscape:zoom="34.0625"
+     inkscape:cx="8.0001"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3833" />
+  </sodipodi:namedview>
+  <g
+     id="g3759"
+     style="fill:#bebebe;fill-opacity:1">
+    <path
+       sodipodi:nodetypes="ssssssssssssssss"
+       inkscape:connector-curvature="0"
+       id="rect2984"
+       d="M 3,0 C 1.892,0 1,0.892 1,2 l 0,12 c 0,1.108 0.892,2 2,2 l 10,0 c 1.108,0 2,-0.892 2,-2 L 15,2 C 15,0.892 14.108,0 13,0 Z m 0.5,13 9,0 c 0.277,0 0.5,0.223 0.5,0.5 0,0.277 -0.223,0.5 -0.5,0.5 l -9,0 C 3.223,14 3,13.777 3,13.5 3,13.223 3.223,13 3.5,13 Z"
+       style="fill:#bebebe;fill-opacity:1;stroke:none" />
+  </g>
+</svg>


### PR DESCRIPTION
Fixes https://github.com/numixproject/numix-icon-theme/issues/585.

![drive-harddisk-solidstate-symbolic](https://cloud.githubusercontent.com/assets/7164227/8213013/59cda608-151f-11e5-9bf5-1535194d15fc.png)

The design is based on and in line with `drive-harddisk-symbolic.svg`:

![drive-harddisk-symbolic](https://cloud.githubusercontent.com/assets/7164227/8213034/7c88dd52-151f-11e5-8b77-f90c510c0571.png)

