### PR TITLE
Added nemo-eject.svg

### DIFF
--- a/Numix/128x128/actions/nemo-eject.svg
+++ b/Numix/128x128/actions/nemo-eject.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+ <g transform="matrix(6.6666667,0,0,8.0000001,10.666666,-1.04e-6)" fill="#dc322f" fill-opacity="1">
+  <path d="m 14 11 0 2 -12 0 0 -2 z"/>
+  <path d="m 2 9 6 -6 6 6"/>
+ </g>
+</svg>

--- a/Numix/16x16/actions/nemo-eject.svg
+++ b/Numix/16x16/actions/nemo-eject.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+ <g transform="matrix(0.83333333,0,0,1,1.3333333,0)" fill="#dc322f" fill-opacity="1">
+  <path d="m 14 11 0 2 -12 0 0 -2 z"/>
+  <path d="m 2 9 6 -6 6 6"/>
+ </g>
+</svg>

--- a/Numix/22x22/actions/nemo-eject.svg
+++ b/Numix/22x22/actions/nemo-eject.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22">
+ <g transform="matrix(1.1666667,0,0,1.4,1.6666666,-0.2)" fill="#dc322f" fill-opacity="1">
+  <path d="m 14 10.143 0 2.143 -12 0 0 -2.143 z"/>
+  <path d="m 2 8.714 6 -5.714 6 5.714"/>
+ </g>
+</svg>

--- a/Numix/24x24/actions/nemo-eject.svg
+++ b/Numix/24x24/actions/nemo-eject.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+ <g transform="matrix(1.1666667,0,0,1.4,2.6666666,0.8000004)" fill="#dc322f" fill-opacity="1">
+  <path d="m 14 10.143 0 2.143 -12 0 0 -2.143 z"/>
+  <path d="m 2 8.714 6 -5.714 6 5.714"/>
+ </g>
+</svg>

--- a/Numix/256x256/actions/nemo-eject.svg
+++ b/Numix/256x256/actions/nemo-eject.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+ <g transform="matrix(13.333333,0,0,16,21.333334,-2.5999998e-7)" fill="#dc322f" fill-opacity="1">
+  <path d="m 14 11 0 2 -12 0 0 -2 z"/>
+  <path d="m 2 9 6 -6 6 6"/>
+ </g>
+</svg>

--- a/Numix/32x32/actions/nemo-eject.svg
+++ b/Numix/32x32/actions/nemo-eject.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+ <g transform="matrix(1.6666667,0,0,2,2.6666666,0)" fill="#dc322f" fill-opacity="1">
+  <path d="m 14 11 0 2 -12 0 0 -2 z"/>
+  <path d="m 2 9 6 -6 6 6"/>
+ </g>
+</svg>

--- a/Numix/48x48/actions/nemo-eject.svg
+++ b/Numix/48x48/actions/nemo-eject.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+ <g transform="matrix(2.3333333,0,0,2.7999999,5.3333333,1.6000014)" fill="#dc322f" fill-opacity="1">
+  <path d="m 14 10.143 0 2.143 -12 0 0 -2.143 z"/>
+  <path d="m 2 8.714 6 -5.714 6 5.714"/>
+ </g>
+</svg>

--- a/Numix/64x64/actions/nemo-eject.svg
+++ b/Numix/64x64/actions/nemo-eject.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+ <g transform="matrix(3.3333333,0,0,4,5.333333,-2.0799999e-7)" fill="#dc322f" fill-opacity="1">
+  <path d="m 14 11 0 2 -12 0 0 -2 z"/>
+  <path d="m 2 9 6 -6 6 6"/>
+ </g>
+</svg>


### PR DESCRIPTION
Added ``nemo-eject.svg``. It's the drive eject icon for Nemo.
Original design present in ``hicolor/16x16/actions`` and ``hicolor/32x32/actions``:
![nemo-eject](https://cloud.githubusercontent.com/assets/7050624/8374168/6fbe22e6-1bf3-11e5-8a84-119decdf5858.png)

New design:
![nemo-eject](https://cloud.githubusercontent.com/assets/7050624/8374157/5919c4a0-1bf3-11e5-8279-ed92a9c2358f.png)

The new one however will be shown only when just the Numix base theme is chosen.
With Numix Circle selected for some reason still the app icon ``nemo.svg`` is shown (related to #132)
