### PR TITLE
Three symlinks for freya

### DIFF
--- a/Numix/128x128/actions/dialog-ok-apply.svg
+++ b/Numix/128x128/actions/dialog-ok-apply.svg
@@ -1,0 +1,1 @@
+dialog-ok.svg

--- a/Numix/128x128/devices/battery-ac-adapter.svg
+++ b/Numix/128x128/devices/battery-ac-adapter.svg
@@ -1,0 +1,1 @@
+ac-adapter.svg

--- a/Numix/128x128/devices/tablet.svg
+++ b/Numix/128x128/devices/tablet.svg
@@ -1,0 +1,1 @@
+input-tablet.svg

--- a/Numix/16x16/actions/dialog-ok-apply.svg
+++ b/Numix/16x16/actions/dialog-ok-apply.svg
@@ -1,0 +1,1 @@
+dialog-ok.svg

--- a/Numix/16x16/devices/battery-ac-adapter.svg
+++ b/Numix/16x16/devices/battery-ac-adapter.svg
@@ -1,0 +1,1 @@
+ac-adapter.svg

--- a/Numix/16x16/devices/tablet.svg
+++ b/Numix/16x16/devices/tablet.svg
@@ -1,0 +1,1 @@
+input-tablet.svg

--- a/Numix/22x22/actions/dialog-ok-apply.svg
+++ b/Numix/22x22/actions/dialog-ok-apply.svg
@@ -1,0 +1,1 @@
+dialog-ok.svg

--- a/Numix/22x22/devices/battery-ac-adapter.svg
+++ b/Numix/22x22/devices/battery-ac-adapter.svg
@@ -1,0 +1,1 @@
+ac-adapter.svg

--- a/Numix/22x22/devices/tablet.svg
+++ b/Numix/22x22/devices/tablet.svg
@@ -1,0 +1,1 @@
+input-tablet.svg

--- a/Numix/24x24/actions/dialog-ok-apply.svg
+++ b/Numix/24x24/actions/dialog-ok-apply.svg
@@ -1,0 +1,1 @@
+dialog-ok.svg

--- a/Numix/24x24/devices/battery-ac-adapter.svg
+++ b/Numix/24x24/devices/battery-ac-adapter.svg
@@ -1,0 +1,1 @@
+ac-adapter.svg

--- a/Numix/24x24/devices/tablet.svg
+++ b/Numix/24x24/devices/tablet.svg
@@ -1,0 +1,1 @@
+input-tablet.svg

--- a/Numix/256x256/actions/dialog-ok-apply.svg
+++ b/Numix/256x256/actions/dialog-ok-apply.svg
@@ -1,0 +1,1 @@
+dialog-ok.svg

--- a/Numix/256x256/devices/battery-ac-adapter.svg
+++ b/Numix/256x256/devices/battery-ac-adapter.svg
@@ -1,0 +1,1 @@
+ac-adapter.svg

--- a/Numix/256x256/devices/tablet.svg
+++ b/Numix/256x256/devices/tablet.svg
@@ -1,0 +1,1 @@
+input-tablet.svg

--- a/Numix/32x32/actions/dialog-ok-apply.svg
+++ b/Numix/32x32/actions/dialog-ok-apply.svg
@@ -1,0 +1,1 @@
+dialog-ok.svg

--- a/Numix/32x32/devices/battery-ac-adapter.svg
+++ b/Numix/32x32/devices/battery-ac-adapter.svg
@@ -1,0 +1,1 @@
+ac-adapter.svg

--- a/Numix/32x32/devices/tablet.svg
+++ b/Numix/32x32/devices/tablet.svg
@@ -1,0 +1,1 @@
+input-tablet.svg

--- a/Numix/48x48/actions/dialog-ok-apply.svg
+++ b/Numix/48x48/actions/dialog-ok-apply.svg
@@ -1,0 +1,1 @@
+dialog-ok.svg

--- a/Numix/48x48/devices/battery-ac-adapter.svg
+++ b/Numix/48x48/devices/battery-ac-adapter.svg
@@ -1,0 +1,1 @@
+ac-adapter.svg

--- a/Numix/48x48/devices/tablet.svg
+++ b/Numix/48x48/devices/tablet.svg
@@ -1,0 +1,1 @@
+input-tablet.svg

--- a/Numix/64x64/actions/dialog-ok-apply.svg
+++ b/Numix/64x64/actions/dialog-ok-apply.svg
@@ -1,0 +1,1 @@
+dialog-ok.svg

--- a/Numix/64x64/devices/battery-ac-adapter.svg
+++ b/Numix/64x64/devices/battery-ac-adapter.svg
@@ -1,0 +1,1 @@
+ac-adapter.svg

--- a/Numix/64x64/devices/tablet.svg
+++ b/Numix/64x64/devices/tablet.svg
@@ -1,0 +1,1 @@
+input-tablet.svg


### PR DESCRIPTION
Symlink 
```tablet``` to ```input-tablet```
 ```dialog-ok``` to ```dialog-apply-ok```
 ```ac-adapter``` to ```battery-ac-adapter```