### PR TITLE
Added document-import action icon

### DIFF
--- a/Numix/128x128/actions/document-export.svg
+++ b/Numix/128x128/actions/document-export.svg
@@ -1,6 +1,70 @@
-<svg width="128" xmlns="http://www.w3.org/2000/svg" height="128" viewBox="0 0 128 128" xmlns:xlink="http://www.w3.org/1999/xlink">
-<g style="fill-rule:evenodd">
-<path style="fill:#fff" d="M 13.714844 0 L 82.285156 0 C 96 0 96 0 96 14.222656 L 96 113.777344 C 96 128 96 128 82.285156 128 L 13.714844 128 C 0 128 0 128 0 113.777344 L 0 14.222656 C 0 0 0 0 13.714844 0 Z "/>
-<path style="fill:#268bd2" d="M 75.003906 107 C 76.128906 107 77.753906 106 79.753906 104 L 119.753906 72 C 127.78125 63.96875 127.753906 64 119.753906 56 L 79.753906 24 C 73.753906 18 72.128906 21 71.753906 33 C 71.628906 37 71.753906 42 71.753906 48 C 71.667969 48 71.585938 48 71.503906 48 C 31.753906 48 15.753906 72 16.003906 104.25 C 31.753906 88 47.753906 80 71.753906 80.5 C 71.746094 86.234375 71.632812 91.132812 71.753906 95 C 72.003906 103 72.753906 107 75.003906 107 Z "/>
-</g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="128"
+   height="128"
+   viewBox="0 0 128 128"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="document-export.svg">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview10"
+     showgrid="true"
+     inkscape:zoom="3.6875"
+     inkscape:cx="64"
+     inkscape:cy="64"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4142" />
+  </sodipodi:namedview>
+  <g
+     style="fill-rule:evenodd"
+     id="g4"
+     transform="scale(2.0000449,2)">
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff"
+       d="M 6.855469,0 41.144531,0 C 48,0 48,0 48,7.109375 l 0,49.78125 C 48,64 48,64 41.144531,64 L 6.855469,64 C 0,64 0,64 0,56.890625 L 0,7.109375 C 0,0 0,0 6.855469,0 Z"
+       id="path6" />
+    <path
+       style="fill:#268bd2"
+       d="m 36.860855,53.5 c 0.550313,0 1.243156,-0.602723 2.323546,-1.466364 L 58.751104,36.392411 c 4.338442,-3.468063 4.321561,-4.366043 0,-7.820612 L 39.184401,12.930575 C 35.943809,10.340111 36,10.963784 36,17.329669 36,17.329669 36.183437,25 36.06115,25 l -0.122293,0 C 16.494448,25 7.8776817,36.392411 7.9999737,52.155833 15.704359,44.213023 24.259978,39.755605 36,40 l 0,7.634541 C 36.122292,51.544847 35.760228,53.5 36.860855,53.5 Z"
+       id="path8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssccscccs" />
+  </g>
 </svg>

--- a/Numix/128x128/actions/document-import.svg
+++ b/Numix/128x128/actions/document-import.svg
@@ -7,13 +7,13 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="22"
-   height="22"
-   viewBox="0 0 22 22"
+   width="128"
+   height="128"
+   viewBox="0 0 128 128"
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="document-export.svg">
+   sodipodi:docname="document-import.svg">
   <metadata
      id="metadata14">
     <rdf:RDF>
@@ -22,6 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -40,9 +41,9 @@
      inkscape:window-height="704"
      id="namedview10"
      showgrid="true"
-     inkscape:zoom="30.341309"
-     inkscape:cx="13.147405"
-     inkscape:cy="9.6816653"
+     inkscape:zoom="3.6875"
+     inkscape:cx="64"
+     inkscape:cy="64"
      inkscape:window-x="0"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
@@ -53,16 +54,18 @@
   </sodipodi:namedview>
   <g
      style="fill-rule:evenodd"
-     id="g4">
+     id="g4"
+     transform="matrix(-2.0000449,0,0,2,128,0)">
     <path
-       style="fill:#fff"
-       d="m 3,2 10,0 c 2,0 2,0 2,2 l 0,14 c 0,2 0,2 -2,2 L 3,20 C 1,20 1,20 1,18 L 1,4 C 1,2 1,2 3,2 z"
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff"
+       d="M 6.855469,0 41.144531,0 C 48,0 48,0 48,7.109375 l 0,49.78125 C 48,64 48,64 41.144531,64 L 6.855469,64 C 0,64 0,64 0,56.890625 L 0,7.109375 C 0,0 0,0 6.855469,0 Z"
        id="path6" />
     <path
        style="fill:#268bd2"
-       d="m 13.929049,17.837132 6.857176,-5.379909 c 1.667486,-1.308253 1.569643,-1.458466 0,-2.6899546 L 13.929049,4.3873594 C 12.974499,3.6365364 13,3.9152323 13,5.7715043 L 13,8 C 6.1856823,8 3.0000011,12.457223 3.0004255,17.879162 5.7004383,15.147177 8.8856951,13.915939 13,14 l 0,2.003072 c 0,0.978165 -0.0255,2.498573 0.929049,1.83406 z"
+       d="m 36.860855,11.5 c 0.550313,0 1.243156,0.602723 2.323546,1.466364 l 19.566703,15.641225 c 4.338442,3.468063 4.321561,4.366043 0,7.820612 L 39.184401,52.069425 C 35.943809,54.659889 36,54.036216 36,47.670331 36,47.670331 36.183437,40 36.06115,40 l -0.122293,0 C 16.494448,40 7.8776817,28.607589 7.9999737,12.844167 15.704359,20.786977 24.259978,25.244395 36,25 l 0,-7.634541 C 36.122292,13.455153 35.760228,11.5 36.860855,11.5 Z"
        id="path8"
        inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cssccccccc" />
+       sodipodi:nodetypes="sssssccscccs" />
   </g>
 </svg>

--- a/Numix/16x16/actions/document-export.svg
+++ b/Numix/16x16/actions/document-export.svg
@@ -1,6 +1,68 @@
-<svg width="16" xmlns="http://www.w3.org/2000/svg" height="16" viewBox="0 0 16 16">
-<g style="fill-rule:evenodd">
-<path style="fill:#fff" d="m 1.714286,4.9999996e-8 8.571429,0 C 12,4.9999996e-8 12,4.9999996e-8 12,1.7777778 L 12,14.222222 C 12,16 12,16 10.285715,16 L 1.714286,16 C 0,16 0,16 0,14.222222 L 0,1.7777778 C 0,4.9999998e-8 0,4.9999998e-8 1.714286,4.9999998e-8 z"/>
-<path style="fill:#268bd2" d="m 9.3753602,13.375 c 0.140625,0 0.34375,-0.125 0.59375,-0.375 L 14.96911,9 c 1.003692,-1.0036924 1,-1 0,-2 L 9.9691102,3 c -0.75,-0.75 -0.953125,-0.375 -1,1.125 -0.01563,0.5 0,1.125 0,1.875 -0.01055,-4.4e-5 -0.02069,0 -0.03125,0 -4.96875,0 -6.96875,3 -6.9375,7.03125 C 3.9691102,11 5.9691102,10 8.9691102,10.0625 c -9.56e-4,0.716944 -0.0151,1.329167 0,1.8125 0.03125,1 0.125,1.5 0.40625,1.5 z"/>
-</g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="document-export.svg">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview10"
+     showgrid="true"
+     inkscape:zoom="41.7193"
+     inkscape:cx="8"
+     inkscape:cy="7.0412111"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4142" />
+  </sodipodi:namedview>
+  <g
+     style="fill-rule:evenodd"
+     id="g4">
+    <path
+       style="fill:#fff"
+       d="m 1.714286,4.9999996e-8 8.571429,0 C 12,4.9999996e-8 12,4.9999996e-8 12,1.7777778 L 12,14.222222 C 12,16 12,16 10.285715,16 L 1.714286,16 C 0,16 0,16 0,14.222222 L 0,1.7777778 C 0,4.9999998e-8 0,4.9999998e-8 1.714286,4.9999998e-8 z"
+       id="path6" />
+    <path
+       style="fill:#268bd2"
+       d="m 9.3759609,13.375 c 0.1406364,0 0.3176995,-0.154139 0.5937983,-0.375 1.6668018,-1.333333 5.0004068,-4 5.0004068,-4 1.108484,-0.8867141 1.104405,-1.1165478 0,-2 L 9.9697592,3 C 9.1414628,2.3374168 9.0165566,2.625 8.9696778,4.125 L 8.9384258,6 C 3.9692706,6 1.9691077,9 2.0003602,13.03125 3.9692706,11 5.9694335,10 8.9696778,10.0625 l 0,1.8125 c 0,1.000488 0.1250102,1.5 0.4062831,1.5 z"
+       id="path8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssccccss" />
+  </g>
 </svg>

--- a/Numix/16x16/actions/document-import.svg
+++ b/Numix/16x16/actions/document-import.svg
@@ -7,13 +7,13 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="22"
-   height="22"
-   viewBox="0 0 22 22"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="document-export.svg">
+   sodipodi:docname="document-import.svg">
   <metadata
      id="metadata14">
     <rdf:RDF>
@@ -22,6 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -40,9 +41,9 @@
      inkscape:window-height="704"
      id="namedview10"
      showgrid="true"
-     inkscape:zoom="30.341309"
-     inkscape:cx="13.147405"
-     inkscape:cy="9.6816653"
+     inkscape:zoom="20.85965"
+     inkscape:cx="8"
+     inkscape:cy="7.0412111"
      inkscape:window-x="0"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
@@ -53,16 +54,18 @@
   </sodipodi:namedview>
   <g
      style="fill-rule:evenodd"
-     id="g4">
+     id="g4"
+     transform="matrix(-1,0,0,1,16,0)">
     <path
-       style="fill:#fff"
-       d="m 3,2 10,0 c 2,0 2,0 2,2 l 0,14 c 0,2 0,2 -2,2 L 3,20 C 1,20 1,20 1,18 L 1,4 C 1,2 1,2 3,2 z"
-       id="path6" />
+       style="fill:#ffffff"
+       d="m 1.714286,4.9999996e-8 8.571429,0 C 12,4.9999996e-8 12,4.9999996e-8 12,1.7777778 L 12,14.222222 C 12,16 12,16 10.285715,16 L 1.714286,16 C 0,16 0,16 0,14.222222 L 0,1.7777778 C 0,4.9999998e-8 0,4.9999998e-8 1.714286,4.9999998e-8 Z"
+       id="path6"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#268bd2"
-       d="m 13.929049,17.837132 6.857176,-5.379909 c 1.667486,-1.308253 1.569643,-1.458466 0,-2.6899546 L 13.929049,4.3873594 C 12.974499,3.6365364 13,3.9152323 13,5.7715043 L 13,8 C 6.1856823,8 3.0000011,12.457223 3.0004255,17.879162 5.7004383,15.147177 8.8856951,13.915939 13,14 l 0,2.003072 c 0,0.978165 -0.0255,2.498573 0.929049,1.83406 z"
+       d="m 9.3759609,2.6638519 c 0.1406364,0 0.3176995,0.154139 0.5937983,0.375 1.6668018,1.333333 5.0004068,4 5.0004068,4 1.108484,0.8867141 1.104405,1.1165478 0,2 L 9.9697592,13.038852 c -0.8282964,0.662583 -0.9532026,0.375 -1.0000814,-1.125 l -0.031252,-1.875 c -4.9691552,0 -6.9693181,-3.0000001 -6.9380656,-7.0312501 1.9689104,2.03125 3.9690733,3.03125 6.9693176,2.96875 l 0,-1.8125 c 0,-1.000488 0.1250102,-1.5 0.4062831,-1.5 z"
        id="path8"
        inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cssccccccc" />
+       sodipodi:nodetypes="sssssccccss" />
   </g>
 </svg>

--- a/Numix/22x22/actions/document-import.svg
+++ b/Numix/22x22/actions/document-import.svg
@@ -13,7 +13,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="document-export.svg">
+   sodipodi:docname="document-import.svg">
   <metadata
      id="metadata14">
     <rdf:RDF>
@@ -22,6 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -40,8 +41,8 @@
      inkscape:window-height="704"
      id="namedview10"
      showgrid="true"
-     inkscape:zoom="30.341309"
-     inkscape:cx="13.147405"
+     inkscape:zoom="15.170655"
+     inkscape:cx="0.29364226"
      inkscape:cy="9.6816653"
      inkscape:window-x="0"
      inkscape:window-y="27"
@@ -53,14 +54,16 @@
   </sodipodi:namedview>
   <g
      style="fill-rule:evenodd"
-     id="g4">
+     id="g4"
+     transform="matrix(-1,0,0,1,22.000425,0)">
     <path
-       style="fill:#fff"
-       d="m 3,2 10,0 c 2,0 2,0 2,2 l 0,14 c 0,2 0,2 -2,2 L 3,20 C 1,20 1,20 1,18 L 1,4 C 1,2 1,2 3,2 z"
-       id="path6" />
+       style="fill:#ffffff"
+       d="m 3,2 10,0 c 2,0 2,0 2,2 l 0,14 c 0,2 0,2 -2,2 L 3,20 C 1,20 1,20 1,18 L 1,4 C 1,2 1,2 3,2 Z"
+       id="path6"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#268bd2"
-       d="m 13.929049,17.837132 6.857176,-5.379909 c 1.667486,-1.308253 1.569643,-1.458466 0,-2.6899546 L 13.929049,4.3873594 C 12.974499,3.6365364 13,3.9152323 13,5.7715043 L 13,8 C 6.1856823,8 3.0000011,12.457223 3.0004255,17.879162 5.7004383,15.147177 8.8856951,13.915939 13,14 l 0,2.003072 c 0,0.978165 -0.0255,2.498573 0.929049,1.83406 z"
+       d="m 13.929049,4.1628675 6.857176,5.379909 c 1.667486,1.3082525 1.569643,1.4584655 0,2.6899545 L 13.929049,17.61264 C 12.974499,18.363463 13,18.084767 13,16.228495 l 0,-2.228496 c -6.8143177,0 -9.9999989,-4.4572225 -9.9995745,-9.8791615 C 5.7004383,6.8528225 8.8856951,8.0840605 13,7.9999995 l 0,-2.003072 c 0,-0.978165 -0.0255,-2.498573 0.929049,-1.83406 z"
        id="path8"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cssccccccc" />

--- a/Numix/24x24/actions/document-export.svg
+++ b/Numix/24x24/actions/document-export.svg
@@ -1,6 +1,66 @@
-<svg width="24" xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24">
-<g style="fill-rule:evenodd" transform="translate(1 1)">
-<path style="fill:#fff" d="m 3,2 10,0 c 2,0 2,0 2,2 l 0,14 c 0,2 0,2 -2,2 L 3,20 C 1,20 1,20 1,18 L 1,4 C 1,2 1,2 3,2 z"/>
-<path style="fill:#268bd2" d="m 13.957456,18.104503 6.875,-5.5 c 1.378907,-1.378906 1.375,-1.375 0,-2.7500003 l -6.875,-5.5 c -0.957031,-0.767583 -0.957031,-0.482666 -0.957031,1.415042 -0.01953,0.6875 -0.04297,1.459958 0,2.459958 -0.01563,0 0.01563,0 0,0 -6.8320305,0 -10.0429683,4.3750003 -9.9999995,9.9179693 2.707031,-2.792969 5.875,-4.003907 9.9999995,-3.917969 0,0.984374 -0.01953,1.335937 0,2 0,1 0,2.554347 0.957031,1.875 z"/>
-</g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="document-export.svg">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview10"
+     showgrid="false"
+     inkscape:zoom="19.666667"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     transform="translate(1,1)"
+     style="fill-rule:evenodd"
+     id="g4">
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff"
+       d="m 3,2 10,0 c 2,0 2,0 2,2 l 0,14 c 0,2 0,2 -2,2 L 3,20 C 1,20 1,20 1,18 L 1,4 C 1,2 1,2 3,2 Z"
+       id="path6" />
+    <path
+       style="fill:#268bd2"
+       d="m 13.929049,17.837132 6.857176,-5.379909 c 1.667486,-1.308253 1.569643,-1.458466 0,-2.6899546 L 13.929049,4.3873594 C 12.974499,3.6365364 13,3.9152323 13,5.7715043 L 13,8 C 6.1856823,8 3.0000011,12.457223 3.0004255,17.879162 5.7004383,15.147177 8.8856951,13.915939 13,14 l 0,2.003072 c 0,0.978165 -0.0255,2.498573 0.929049,1.83406 z"
+       id="path8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cssccccccc" />
+  </g>
 </svg>

--- a/Numix/24x24/actions/document-import.svg
+++ b/Numix/24x24/actions/document-import.svg
@@ -7,13 +7,13 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="22"
-   height="22"
-   viewBox="0 0 22 22"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="document-export.svg">
+   sodipodi:docname="document-import.svg">
   <metadata
      id="metadata14">
     <rdf:RDF>
@@ -22,6 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -40,27 +41,29 @@
      inkscape:window-height="704"
      id="namedview10"
      showgrid="true"
-     inkscape:zoom="30.341309"
-     inkscape:cx="13.147405"
-     inkscape:cy="9.6816653"
+     inkscape:zoom="19.666667"
+     inkscape:cx="12"
+     inkscape:cy="12"
      inkscape:window-x="0"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
        type="xygrid"
-       id="grid4142" />
+       id="grid4152" />
   </sodipodi:namedview>
   <g
+     transform="matrix(-1,0,0,1,23.000425,1)"
      style="fill-rule:evenodd"
      id="g4">
     <path
-       style="fill:#fff"
-       d="m 3,2 10,0 c 2,0 2,0 2,2 l 0,14 c 0,2 0,2 -2,2 L 3,20 C 1,20 1,20 1,18 L 1,4 C 1,2 1,2 3,2 z"
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff"
+       d="m 3,2 10,0 c 2,0 2,0 2,2 l 0,14 c 0,2 0,2 -2,2 L 3,20 C 1,20 1,20 1,18 L 1,4 C 1,2 1,2 3,2 Z"
        id="path6" />
     <path
        style="fill:#268bd2"
-       d="m 13.929049,17.837132 6.857176,-5.379909 c 1.667486,-1.308253 1.569643,-1.458466 0,-2.6899546 L 13.929049,4.3873594 C 12.974499,3.6365364 13,3.9152323 13,5.7715043 L 13,8 C 6.1856823,8 3.0000011,12.457223 3.0004255,17.879162 5.7004383,15.147177 8.8856951,13.915939 13,14 l 0,2.003072 c 0,0.978165 -0.0255,2.498573 0.929049,1.83406 z"
+       d="m 13.929049,4.1628675 6.857176,5.379909 c 1.667486,1.3082525 1.569643,1.4584655 0,2.6899545 L 13.929049,17.61264 C 12.974499,18.363463 13,18.084767 13,16.228495 l 0,-2.228496 c -6.8143177,0 -9.9999989,-4.4572225 -9.9995745,-9.8791615 C 5.7004383,6.8528225 8.8856951,8.0840605 13,7.9999995 l 0,-2.003072 c 0,-0.978165 -0.0255,-2.498573 0.929049,-1.83406 z"
        id="path8"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cssccccccc" />

--- a/Numix/256x256/actions/document-export.svg
+++ b/Numix/256x256/actions/document-export.svg
@@ -1,6 +1,66 @@
-<svg width="256" xmlns="http://www.w3.org/2000/svg" height="256" viewBox="0 0 256 256" xmlns:xlink="http://www.w3.org/1999/xlink">
-<g style="fill-rule:evenodd">
-<path style="fill:#fff" d="M 27.429688 0 L 164.570312 0 C 192 0 192 0 192 28.445312 L 192 227.554688 C 192 256 192 256 164.570312 256 L 27.429688 256 C 0 256 0 256 0 227.554688 L 0 28.445312 C 0 0 0 0 27.429688 0 Z "/>
-<path style="fill:#268bd2" d="M 150.003906 214 C 152.253906 214 155.503906 212 159.503906 208 L 239.503906 144 C 255.566406 127.941406 255.503906 128 239.503906 112 L 159.503906 48 C 147.503906 36 144.253906 42 143.503906 66 C 143.253906 74 143.503906 84 143.503906 96 C 143.335938 96 143.175781 96 143.003906 96 C 63.503906 96 31.503906 144 32.003906 208.5 C 63.503906 176 95.503906 160 143.503906 161 C 143.492188 172.472656 143.265625 182.265625 143.503906 190 C 144.003906 206 145.503906 214 150.003906 214 Z "/>
-</g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="256"
+   height="256"
+   viewBox="0 0 256 256"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="document-export.svg">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview10"
+     showgrid="false"
+     inkscape:zoom="0.921875"
+     inkscape:cx="128"
+     inkscape:cy="128"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <g
+     style="fill-rule:evenodd"
+     id="g4"
+     transform="scale(4.0000898,4)">
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff"
+       d="M 6.855469,0 41.144531,0 C 48,0 48,0 48,7.109375 l 0,49.78125 C 48,64 48,64 41.144531,64 L 6.855469,64 C 0,64 0,64 0,56.890625 L 0,7.109375 C 0,0 0,0 6.855469,0 Z"
+       id="path6" />
+    <path
+       style="fill:#268bd2"
+       d="m 36.860855,53.5 c 0.550313,0 1.243156,-0.602723 2.323546,-1.466364 L 58.751104,36.392411 c 4.338442,-3.468063 4.321561,-4.366043 0,-7.820612 L 39.184401,12.930575 C 35.943809,10.340111 36,10.963784 36,17.329669 36,17.329669 36.183437,25 36.06115,25 l -0.122293,0 C 16.494448,25 7.8776817,36.392411 7.9999737,52.155833 15.704359,44.213023 24.259978,39.755605 36,40 l 0,7.634541 C 36.122292,51.544847 35.760228,53.5 36.860855,53.5 Z"
+       id="path8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssccscccs" />
+  </g>
 </svg>

--- a/Numix/256x256/actions/document-import.svg
+++ b/Numix/256x256/actions/document-import.svg
@@ -7,13 +7,13 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="22"
-   height="22"
-   viewBox="0 0 22 22"
+   width="256"
+   height="256"
+   viewBox="0 0 256 256"
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="document-export.svg">
+   sodipodi:docname="document-import.svg">
   <metadata
      id="metadata14">
     <rdf:RDF>
@@ -22,6 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -39,30 +40,28 @@
      inkscape:window-width="1366"
      inkscape:window-height="704"
      id="namedview10"
-     showgrid="true"
-     inkscape:zoom="30.341309"
-     inkscape:cx="13.147405"
-     inkscape:cy="9.6816653"
+     showgrid="false"
+     inkscape:zoom="0.921875"
+     inkscape:cx="128"
+     inkscape:cy="128"
      inkscape:window-x="0"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg2">
-    <inkscape:grid
-       type="xygrid"
-       id="grid4142" />
-  </sodipodi:namedview>
+     inkscape:current-layer="svg2" />
   <g
      style="fill-rule:evenodd"
-     id="g4">
+     id="g4"
+     transform="matrix(-4.0000898,0,0,4,256,0)">
     <path
-       style="fill:#fff"
-       d="m 3,2 10,0 c 2,0 2,0 2,2 l 0,14 c 0,2 0,2 -2,2 L 3,20 C 1,20 1,20 1,18 L 1,4 C 1,2 1,2 3,2 z"
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff"
+       d="M 6.855469,0 41.144531,0 C 48,0 48,0 48,7.109375 l 0,49.78125 C 48,64 48,64 41.144531,64 L 6.855469,64 C 0,64 0,64 0,56.890625 L 0,7.109375 C 0,0 0,0 6.855469,0 Z"
        id="path6" />
     <path
        style="fill:#268bd2"
-       d="m 13.929049,17.837132 6.857176,-5.379909 c 1.667486,-1.308253 1.569643,-1.458466 0,-2.6899546 L 13.929049,4.3873594 C 12.974499,3.6365364 13,3.9152323 13,5.7715043 L 13,8 C 6.1856823,8 3.0000011,12.457223 3.0004255,17.879162 5.7004383,15.147177 8.8856951,13.915939 13,14 l 0,2.003072 c 0,0.978165 -0.0255,2.498573 0.929049,1.83406 z"
+       d="m 36.860855,11.5 c 0.550313,0 1.243156,0.602723 2.323546,1.466364 l 19.566703,15.641225 c 4.338442,3.468063 4.321561,4.366043 0,7.820612 L 39.184401,52.069425 C 35.943809,54.659889 36,54.036216 36,47.670331 36,47.670331 36.183437,40 36.06115,40 l -0.122293,0 C 16.494448,40 7.8776817,28.607589 7.9999737,12.844167 15.704359,20.786977 24.259978,25.244395 36,25 l 0,-7.634541 C 36.122292,13.455153 35.760228,11.5 36.860855,11.5 Z"
        id="path8"
        inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cssccccccc" />
+       sodipodi:nodetypes="sssssccscccs" />
   </g>
 </svg>

--- a/Numix/32x32/actions/document-export.svg
+++ b/Numix/32x32/actions/document-export.svg
@@ -1,6 +1,68 @@
-<svg width="32" xmlns="http://www.w3.org/2000/svg" height="32" viewBox="0 0 32 32" xmlns:xlink="http://www.w3.org/1999/xlink">
-<g style="fill-rule:evenodd">
-<path style="fill:#fff" d="M 3.429688 0 L 20.570312 0 C 24 0 24 0 24 3.554688 L 24 28.445312 C 24 32 24 32 20.570312 32 L 3.429688 32 C 0 32 0 32 0 28.445312 L 0 3.554688 C 0 0 0 0 3.429688 0 Z "/>
-<path style="fill:#268bd2" d="M 18.75 26.75 C 19.03125 26.75 19.4375 26.5 19.9375 26 L 29.9375 18 C 31.945312 15.992188 31.9375 16 29.9375 14 L 19.9375 6 C 18.4375 4.5 18.03125 5.25 17.9375 8.25 C 17.90625 9.25 17.9375 10.5 17.9375 12 C 17.917969 12 17.898438 12 17.875 12 C 7.9375 12 3.9375 18 4 26.0625 C 7.9375 22 11.9375 20 17.9375 20.125 C 17.9375 21.558594 17.90625 22.785156 17.9375 23.75 C 18 25.75 18.1875 26.75 18.75 26.75 Z "/>
-</g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   height="32"
+   viewBox="0 0 32 32"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="document-export.svg">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview10"
+     showgrid="true"
+     inkscape:zoom="14.75"
+     inkscape:cx="2.779661"
+     inkscape:cy="16"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4142" />
+  </sodipodi:namedview>
+  <g
+     style="fill-rule:evenodd"
+     id="g4">
+    <path
+       style="fill:#fff"
+       d="M 3.429688 0 L 20.570312 0 C 24 0 24 0 24 3.554688 L 24 28.445312 C 24 32 24 32 20.570312 32 L 3.429688 32 C 0 32 0 32 0 28.445312 L 0 3.554688 C 0 0 0 0 3.429688 0 Z "
+       id="path6" />
+    <path
+       style="fill:#268bd2"
+       d="m 18.751106,26.75 c 0.281272,0 0.63539,-0.308274 1.18759,-0.75 l 10.00075,-8 c 2.217423,-1.773806 2.208796,-2.233096 0,-4 L 19.938696,6 c -1.656598,-1.3251783 -1.937646,-1 -2.00015,2.25 -0.01924,1.0003032 0,3.75 0,3.75 l -0.0625,0 C 7.9377954,12 3.9374954,18 4.0000001,26.0625 7.9377954,22 11.938095,20 17.938546,20.125 l 0,3.625 c 0.0625,2.25 0.250018,3 0.81256,3 z"
+       id="path8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssscscccs" />
+  </g>
 </svg>

--- a/Numix/32x32/actions/document-import.svg
+++ b/Numix/32x32/actions/document-import.svg
@@ -7,13 +7,13 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="22"
-   height="22"
-   viewBox="0 0 22 22"
+   width="32"
+   height="32"
+   viewBox="0 0 32 32"
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="document-export.svg">
+   sodipodi:docname="document-import.svg">
   <metadata
      id="metadata14">
     <rdf:RDF>
@@ -22,6 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -40,9 +41,9 @@
      inkscape:window-height="704"
      id="namedview10"
      showgrid="true"
-     inkscape:zoom="30.341309"
-     inkscape:cx="13.147405"
-     inkscape:cy="9.6816653"
+     inkscape:zoom="14.75"
+     inkscape:cx="16"
+     inkscape:cy="16"
      inkscape:window-x="0"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
@@ -53,16 +54,18 @@
   </sodipodi:namedview>
   <g
      style="fill-rule:evenodd"
-     id="g4">
+     id="g4"
+     transform="matrix(-1,0,0,1,31.99928,0)">
     <path
-       style="fill:#fff"
-       d="m 3,2 10,0 c 2,0 2,0 2,2 l 0,14 c 0,2 0,2 -2,2 L 3,20 C 1,20 1,20 1,18 L 1,4 C 1,2 1,2 3,2 z"
-       id="path6" />
+       style="fill:#ffffff"
+       d="M 3.429688,0 20.570312,0 C 24,0 24,0 24,3.554688 l 0,24.890624 C 24,32 24,32 20.570312,32 L 3.429688,32 C 0,32 0,32 0,28.445312 L 0,3.554688 C 0,0 0,0 3.429688,0 Z"
+       id="path6"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#268bd2"
-       d="m 13.929049,17.837132 6.857176,-5.379909 c 1.667486,-1.308253 1.569643,-1.458466 0,-2.6899546 L 13.929049,4.3873594 C 12.974499,3.6365364 13,3.9152323 13,5.7715043 L 13,8 C 6.1856823,8 3.0000011,12.457223 3.0004255,17.879162 5.7004383,15.147177 8.8856951,13.915939 13,14 l 0,2.003072 c 0,0.978165 -0.0255,2.498573 0.929049,1.83406 z"
+       d="m 18.751106,5.2696434 c 0.281272,0 0.63539,0.308274 1.18759,0.75 3.333583,2.666667 10.00075,7.9999996 10.00075,7.9999996 2.217423,1.773806 2.208796,2.233096 0,4 l -10.00075,8 c -1.656598,1.325179 -1.937646,1 -2.00015,-2.25 -0.01924,-1.000303 0,-3.75 0,-3.75 l -0.0625,0 c -9.9382506,0 -13.9385506,-6 -13.8760459,-14.0624996 3.9377953,4.0624996 7.9380949,6.0624996 13.9385459,5.9374996 0,-1.433594 -0.03125,-2.6601556 0,-3.6249996 0.0625,-2.25 0.250018,-3 0.81256,-3 z"
        id="path8"
        inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cssccccccc" />
+       sodipodi:nodetypes="sssssscscccs" />
   </g>
 </svg>

--- a/Numix/48x48/actions/document-export.svg
+++ b/Numix/48x48/actions/document-export.svg
@@ -1,6 +1,69 @@
-<svg width="48" xmlns="http://www.w3.org/2000/svg" height="48" viewBox="0 0 48 48" xmlns:xlink="http://www.w3.org/1999/xlink">
-<g style="fill-rule:evenodd">
-<path style="fill:#fff" d="M 8 6 L 28 6 C 32 6 32 6 32 10 L 32 38 C 32 42 32 42 28 42 L 8 42 C 4 42 4 42 4 38 L 4 10 C 4 6 4 6 8 6 Z "/>
-<path style="fill:#268bd2" d="M 29.914062 38.210938 L 43.664062 27.210938 C 46.421875 24.453125 46.414062 24.460938 43.664062 21.710938 L 29.914062 10.710938 C 28 9.175781 28 9.742188 28 13.539062 C 27.960938 14.914062 27.914062 16.460938 28 18.460938 C 27.96875 18.460938 28.03125 18.460938 28 18.460938 C 14.335938 18.460938 7.914062 27.210938 8 38.296875 C 13.414062 32.710938 19.75 30.289062 28 30.460938 C 28 32.429688 27.960938 33.132812 28 34.460938 C 28 36.460938 28 39.566406 29.914062 38.210938 Z "/>
-</g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="document-export.svg">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview10"
+     showgrid="true"
+     inkscape:zoom="13.906433"
+     inkscape:cx="28.417545"
+     inkscape:cy="21.966102"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4144" />
+  </sodipodi:namedview>
+  <g
+     style="fill-rule:evenodd"
+     id="g4">
+    <path
+       style="fill:#fff"
+       d="M 8 6 L 28 6 C 32 6 32 6 32 10 L 32 38 C 32 42 32 42 28 42 L 8 42 C 4 42 4 42 4 38 L 4 10 C 4 6 4 6 8 6 Z "
+       id="path6" />
+    <path
+       style="fill:#268bd2"
+       d="m 29.945364,37.674727 13.76964,-10.781234 c 3.049845,-2.387942 3.041205,-3.009441 0,-5.390617 L 29.945364,10.721641 C 28.026658,9.2193491 28,10.024842 28,13.49352 27.96089,14.841175 28,18 28,18 c -0.03129,0 0.0313,0 0,0 C 14.316421,18 7.9139405,26.893493 8.0000012,37.758955 13.421796,32.28411 19.738216,29.9104 28,30.078858 l 0,3.920448 c 0,1.960225 0.02857,5.003932 1.945364,3.675421 z"
+       id="path8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssccscccc" />
+  </g>
 </svg>

--- a/Numix/48x48/actions/document-import.svg
+++ b/Numix/48x48/actions/document-import.svg
@@ -7,13 +7,13 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="22"
-   height="22"
-   viewBox="0 0 22 22"
+   width="48"
+   height="48"
+   viewBox="0 0 48 48"
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="document-export.svg">
+   sodipodi:docname="document-import.svg">
   <metadata
      id="metadata14">
     <rdf:RDF>
@@ -22,6 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -40,29 +41,31 @@
      inkscape:window-height="704"
      id="namedview10"
      showgrid="true"
-     inkscape:zoom="30.341309"
-     inkscape:cx="13.147405"
-     inkscape:cy="9.6816653"
+     inkscape:zoom="13.906433"
+     inkscape:cx="28.417545"
+     inkscape:cy="21.966102"
      inkscape:window-x="0"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
        type="xygrid"
-       id="grid4142" />
+       id="grid4144" />
   </sodipodi:namedview>
   <g
      style="fill-rule:evenodd"
-     id="g4">
+     id="g4"
+     transform="matrix(-1,0,0,1,47.999149,0)">
     <path
-       style="fill:#fff"
-       d="m 3,2 10,0 c 2,0 2,0 2,2 l 0,14 c 0,2 0,2 -2,2 L 3,20 C 1,20 1,20 1,18 L 1,4 C 1,2 1,2 3,2 z"
-       id="path6" />
+       style="fill:#ffffff"
+       d="m 8,6 20,0 c 4,0 4,0 4,4 l 0,28 c 0,4 0,4 -4,4 L 8,42 C 4,42 4,42 4,38 L 4,10 C 4,6 4,6 8,6 Z"
+       id="path6"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#268bd2"
-       d="m 13.929049,17.837132 6.857176,-5.379909 c 1.667486,-1.308253 1.569643,-1.458466 0,-2.6899546 L 13.929049,4.3873594 C 12.974499,3.6365364 13,3.9152323 13,5.7715043 L 13,8 C 6.1856823,8 3.0000011,12.457223 3.0004255,17.879162 5.7004383,15.147177 8.8856951,13.915939 13,14 l 0,2.003072 c 0,0.978165 -0.0255,2.498573 0.929049,1.83406 z"
+       d="m 29.945364,10.325273 13.76964,10.781234 c 3.049845,2.387942 3.041205,3.009441 0,5.390617 L 29.945364,37.278359 C 28.026658,38.780651 28,37.975158 28,34.50648 27.96089,33.158825 28,30 28,30 c -0.03129,0 0.0313,0 0,0 C 14.316421,30 7.9139405,21.106507 8.0000012,10.241045 13.421796,15.71589 19.738216,18.0896 28,17.921142 l 0,-3.920448 c 0,-1.960225 0.02857,-5.0039318 1.945364,-3.675421 z"
        id="path8"
        inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cssccccccc" />
+       sodipodi:nodetypes="csssccscccc" />
   </g>
 </svg>

--- a/Numix/64x64/actions/document-export.svg
+++ b/Numix/64x64/actions/document-export.svg
@@ -1,6 +1,68 @@
-<svg width="64" xmlns="http://www.w3.org/2000/svg" height="64" viewBox="0 0 64 64" xmlns:xlink="http://www.w3.org/1999/xlink">
-<g style="fill-rule:evenodd">
-<path style="fill:#fff" d="M 6.855469 0 L 41.144531 0 C 48 0 48 0 48 7.109375 L 48 56.890625 C 48 64 48 64 41.144531 64 L 6.855469 64 C 0 64 0 64 0 56.890625 L 0 7.109375 C 0 0 0 0 6.855469 0 Z "/>
-<path style="fill:#268bd2" d="M 37.5 53.5 C 38.0625 53.5 38.875 53 39.875 52 L 59.875 36 C 63.890625 31.984375 63.875 32 59.875 28 L 39.875 12 C 36.875 9 36.0625 10.5 35.875 16.5 C 35.8125 18.5 35.875 21 35.875 24 C 35.835938 24 35.792969 24 35.75 24 C 15.875 24 7.875 36 8 52.125 C 15.875 44 23.875 40 35.875 40.25 C 35.871094 43.117188 35.816406 45.566406 35.875 47.5 C 36 51.5 36.375 53.5 37.5 53.5 Z "/>
-</g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="document-export.svg">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview10"
+     showgrid="true"
+     inkscape:zoom="5.2149125"
+     inkscape:cx="39.746276"
+     inkscape:cy="35.835155"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4142" />
+  </sodipodi:namedview>
+  <g
+     style="fill-rule:evenodd"
+     id="g4">
+    <path
+       style="fill:#fff"
+       d="M 6.855469 0 L 41.144531 0 C 48 0 48 0 48 7.109375 L 48 56.890625 C 48 64 48 64 41.144531 64 L 6.855469 64 C 0 64 0 64 0 56.890625 L 0 7.109375 C 0 0 0 0 6.855469 0 Z "
+       id="path6" />
+    <path
+       style="fill:#268bd2"
+       d="m 36.860855,53.5 c 0.550313,0 1.243156,-0.602723 2.323546,-1.466364 L 58.751104,36.392411 c 4.338442,-3.468063 4.321561,-4.366043 0,-7.820612 L 39.184401,12.930575 C 35.943809,10.340111 36,10.963784 36,17.329669 36,17.329669 36.183437,25 36.06115,25 l -0.122293,0 C 16.494448,25 7.8776817,36.392411 7.9999737,52.155833 15.704359,44.213023 24.259978,39.755605 36,40 l 0,7.634541 C 36.122292,51.544847 35.760228,53.5 36.860855,53.5 Z"
+       id="path8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssccscccs" />
+  </g>
 </svg>

--- a/Numix/64x64/actions/document-import.svg
+++ b/Numix/64x64/actions/document-import.svg
@@ -7,13 +7,13 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="22"
-   height="22"
-   viewBox="0 0 22 22"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64"
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="document-export.svg">
+   sodipodi:docname="document-import.svg">
   <metadata
      id="metadata14">
     <rdf:RDF>
@@ -22,6 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -40,9 +41,9 @@
      inkscape:window-height="704"
      id="namedview10"
      showgrid="true"
-     inkscape:zoom="30.341309"
-     inkscape:cx="13.147405"
-     inkscape:cy="9.6816653"
+     inkscape:zoom="7.375"
+     inkscape:cx="39.746276"
+     inkscape:cy="35.835155"
      inkscape:window-x="0"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
@@ -53,16 +54,18 @@
   </sodipodi:namedview>
   <g
      style="fill-rule:evenodd"
-     id="g4">
+     id="g4"
+     transform="matrix(-1,0,0,1,63.998608,0)">
     <path
-       style="fill:#fff"
-       d="m 3,2 10,0 c 2,0 2,0 2,2 l 0,14 c 0,2 0,2 -2,2 L 3,20 C 1,20 1,20 1,18 L 1,4 C 1,2 1,2 3,2 z"
-       id="path6" />
+       style="fill:#ffffff"
+       d="M 6.855469,0 41.144531,0 C 48,0 48,0 48,7.109375 l 0,49.78125 C 48,64 48,64 41.144531,64 L 6.855469,64 C 0,64 0,64 0,56.890625 L 0,7.109375 C 0,0 0,0 6.855469,0 Z"
+       id="path6"
+       inkscape:connector-curvature="0" />
     <path
        style="fill:#268bd2"
-       d="m 13.929049,17.837132 6.857176,-5.379909 c 1.667486,-1.308253 1.569643,-1.458466 0,-2.6899546 L 13.929049,4.3873594 C 12.974499,3.6365364 13,3.9152323 13,5.7715043 L 13,8 C 6.1856823,8 3.0000011,12.457223 3.0004255,17.879162 5.7004383,15.147177 8.8856951,13.915939 13,14 l 0,2.003072 c 0,0.978165 -0.0255,2.498573 0.929049,1.83406 z"
+       d="m 36.860855,11.5 c 0.550313,0 1.243156,0.602723 2.323546,1.466364 l 19.566703,15.641225 c 4.338442,3.468063 4.321561,4.366043 0,7.820612 L 39.184401,52.069425 C 35.943809,54.659889 36,54.036216 36,47.670331 36,47.670331 36.183437,40 36.06115,40 l -0.122293,0 C 16.494448,40 7.8776817,28.607589 7.9999737,12.844167 15.704359,20.786977 24.259978,25.244395 36,25 l 0,-7.634541 C 36.122292,13.455153 35.760228,11.5 36.860855,11.5 Z"
        id="path8"
        inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cssccccccc" />
+       sodipodi:nodetypes="sssssccscccs" />
   </g>
 </svg>


### PR DESCRIPTION
Added ``document-import`` (one from #437) by basically mirroring existing ``document-export``.
Fixed alignment in ``document-export``.

Exapmle (altered colour for the sake of visibility):
``document-export``
![document-export](https://cloud.githubusercontent.com/assets/7050624/8729666/c742ae8e-2bec-11e5-92b3-24aeb5bc3f74.png)

``document-import``
![document-import](https://cloud.githubusercontent.com/assets/7050624/8729668/cbe2381a-2bec-11e5-9286-aeb7c11284c5.png)
