### PR TITLE
Added missing Eye of GNOME action icons

### DIFF
--- a/Numix/128x128/actions/eog-image-gallery.svg
+++ b/Numix/128x128/actions/eog-image-gallery.svg
@@ -1,0 +1,1 @@
+image-gallery.svg

--- a/Numix/128x128/actions/image-gallery.svg
+++ b/Numix/128x128/actions/image-gallery.svg
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="128"
+   height="128"
+   viewBox="0 0 128 128"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="eog-image-gallery.svg">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="-14.545046"
+     inkscape:cy="48.89444"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <rect
+     style="opacity:1;fill:#b58900;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     id="rect4148"
+     width="56"
+     height="56"
+     x="4"
+     y="4"
+     rx="5"
+     ry="5" />
+  <rect
+     y="4"
+     x="68"
+     height="56"
+     width="56"
+     id="rect4150"
+     style="opacity:1;fill:#268bd2;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     ry="5"
+     rx="5" />
+  <rect
+     style="opacity:1;fill:#db3330;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     id="rect4152"
+     width="56"
+     height="56"
+     x="68"
+     y="68"
+     ry="5"
+     rx="5" />
+  <rect
+     y="68"
+     x="4"
+     height="56"
+     width="56"
+     id="rect4154"
+     style="opacity:1;fill:#4caf50;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     ry="5"
+     rx="5" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     d="m 87.199992,19.999998 -11.199994,17.34376 0,14.65624 39.999992,0 0,-11.2 -8,-12.8 -7.999998,8 z"
+     id="path85"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccc" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     d="m 31.734376,76.008 c -5.105368,0 -9.25,3.90258 -9.25,8.71876 0,0.23688 0.0096,0.48184 0.0312,0.71872 -0.71832,-0.1676 -1.44608,-0.26408 -2.187504,-0.2656 -4.494719,0.0504 -8.328151,3.91818 -8.328151,8.73438 0,3.60252 2.345256,6.82364 5.906247,8.125 -1.067528,1.45514 -1.637544,3.18262 -1.640624,4.95312 0,4.8162 4.143096,8.71722 9.25,8.71876 2.125824,-0.002 4.18068,-0.6872 5.828128,-1.95314 1.695128,1.44286 3.89708,2.24538 6.187494,2.25 5.108448,0 9.23438,-3.91512 9.23438,-8.73438 -0.0028,-1.62896 -0.491016,-3.22804 -1.406252,-4.60936 3.93324,-1.09214 6.639084,-4.49228 6.640624,-8.35938 0,-4.81772 -3.07604,-8.6526 -10.171872,-8.71874 -0.30148,0 -0.606288,0.004 -0.906252,0.0312 0.0368,-0.29688 0.05784,-0.59064 0.06248,-0.89064 0,-4.81924 -4.135396,-8.72028 -9.250002,-8.71874 z m 0.2656,13.59376 a 7.1999996,7.1999996 0 0 1 7.203122,7.20312 7.1999996,7.1999996 0 0 1 -7.203122,7.20312 7.1999996,7.1999996 0 0 1 -7.203128,-7.20312 7.1999996,7.1999996 0 0 1 7.203128,-7.20312 z"
+     id="path35"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     d="m 86.898672,95.984 c 1.272,1.56266 2.62932,3.49866 1.60532,5.57866 C 85.333332,108 75.999998,105.33334 75.999998,116 l 39.999992,0 c 0,-10.66666 -9.33334,-8 -12.504,-14.43734 -1.024,-2.08 0.6,-3.832 1.60534,-5.57866 6.112,-10.60534 1.56532,-19.986662 -9.101338,-19.986662 -10.66666,0 -15.02933,12.696002 -9.10132,19.986662 z"
+     style="fill:#ffffff;fill-opacity:1"
+     id="path47" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;fill-opacity:1"
+     d="m 12.000001,27.999998 7.999999,0 0,24 8,0 0,-24 8,0 0,24 7.999998,0 0,-24 8,0 L 32,11.999996 Z"
+     id="path6"
+     sodipodi:nodetypes="cccccccccccc" />
+</svg>

--- a/Numix/128x128/actions/image-gallery.svg
+++ b/Numix/128x128/actions/image-gallery.svg
@@ -5,6 +5,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="128"
@@ -13,7 +14,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="eog-image-gallery.svg">
+   sodipodi:docname="eog-image-gallery1.svg">
   <metadata
      id="metadata12">
     <rdf:RDF>
@@ -27,7 +28,33 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs10" />
+     id="defs10">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4220"
+       id="linearGradient4226"
+       x1="2.250833"
+       y1="4.75"
+       x2="4.7508335"
+       y2="4.75"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4220">
+      <stop
+         style="stop-color:#e2d290;stop-opacity:0.70588237"
+         offset="0"
+         id="stop4222" />
+      <stop
+         id="stop4228"
+         offset="0.50504142"
+         style="stop-color:#e2d290;stop-opacity:1" />
+      <stop
+         style="stop-color:#e2d290;stop-opacity:0.70588237"
+         offset="1"
+         id="stop4224" />
+    </linearGradient>
+  </defs>
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -41,69 +68,116 @@
      inkscape:window-height="704"
      id="namedview8"
      showgrid="false"
-     inkscape:zoom="1"
+     inkscape:zoom="1.84375"
      inkscape:cx="-14.545046"
-     inkscape:cy="48.89444"
+     inkscape:cy="20.610169"
      inkscape:window-x="0"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2" />
-  <rect
-     style="opacity:1;fill:#b58900;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     id="rect4148"
-     width="56"
-     height="56"
-     x="4"
-     y="4"
-     rx="5"
-     ry="5" />
-  <rect
-     y="4"
-     x="68"
-     height="56"
-     width="56"
-     id="rect4150"
-     style="opacity:1;fill:#268bd2;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     ry="5"
-     rx="5" />
-  <rect
-     style="opacity:1;fill:#db3330;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     id="rect4152"
-     width="56"
-     height="56"
-     x="68"
-     y="68"
-     ry="5"
-     rx="5" />
-  <rect
-     y="68"
-     x="4"
-     height="56"
-     width="56"
-     id="rect4154"
-     style="opacity:1;fill:#4caf50;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     ry="5"
-     rx="5" />
-  <path
-     style="fill:#ffffff;fill-opacity:1"
-     d="m 87.199992,19.999998 -11.199994,17.34376 0,14.65624 39.999992,0 0,-11.2 -8,-12.8 -7.999998,8 z"
-     id="path85"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="cccccccc" />
-  <path
-     style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
-     d="m 31.734376,76.008 c -5.105368,0 -9.25,3.90258 -9.25,8.71876 0,0.23688 0.0096,0.48184 0.0312,0.71872 -0.71832,-0.1676 -1.44608,-0.26408 -2.187504,-0.2656 -4.494719,0.0504 -8.328151,3.91818 -8.328151,8.73438 0,3.60252 2.345256,6.82364 5.906247,8.125 -1.067528,1.45514 -1.637544,3.18262 -1.640624,4.95312 0,4.8162 4.143096,8.71722 9.25,8.71876 2.125824,-0.002 4.18068,-0.6872 5.828128,-1.95314 1.695128,1.44286 3.89708,2.24538 6.187494,2.25 5.108448,0 9.23438,-3.91512 9.23438,-8.73438 -0.0028,-1.62896 -0.491016,-3.22804 -1.406252,-4.60936 3.93324,-1.09214 6.639084,-4.49228 6.640624,-8.35938 0,-4.81772 -3.07604,-8.6526 -10.171872,-8.71874 -0.30148,0 -0.606288,0.004 -0.906252,0.0312 0.0368,-0.29688 0.05784,-0.59064 0.06248,-0.89064 0,-4.81924 -4.135396,-8.72028 -9.250002,-8.71874 z m 0.2656,13.59376 a 7.1999996,7.1999996 0 0 1 7.203122,7.20312 7.1999996,7.1999996 0 0 1 -7.203122,7.20312 7.1999996,7.1999996 0 0 1 -7.203128,-7.20312 7.1999996,7.1999996 0 0 1 7.203128,-7.20312 z"
-     id="path35"
-     inkscape:connector-curvature="0" />
-  <path
-     inkscape:connector-curvature="0"
-     d="m 86.898672,95.984 c 1.272,1.56266 2.62932,3.49866 1.60532,5.57866 C 85.333332,108 75.999998,105.33334 75.999998,116 l 39.999992,0 c 0,-10.66666 -9.33334,-8 -12.504,-14.43734 -1.024,-2.08 0.6,-3.832 1.60534,-5.57866 6.112,-10.60534 1.56532,-19.986662 -9.101338,-19.986662 -10.66666,0 -15.02933,12.696002 -9.10132,19.986662 z"
-     style="fill:#ffffff;fill-opacity:1"
-     id="path47" />
-  <path
-     inkscape:connector-curvature="0"
-     style="fill:#ffffff;fill-opacity:1"
-     d="m 12.000001,27.999998 7.999999,0 0,24 8,0 0,-24 8,0 0,24 7.999998,0 0,-24 8,0 L 32,11.999996 Z"
-     id="path6"
-     sodipodi:nodetypes="cccccccccccc" />
+  <g
+     id="g4193"
+     transform="matrix(8,0,0,8,-4,-4)">
+    <rect
+       y="9"
+       x="9"
+       height="7"
+       width="7"
+       id="rect4152"
+       style="opacity:1;fill:#b8ccd3;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061" />
+    <path
+       sodipodi:nodetypes="sccccccs"
+       inkscape:connector-curvature="0"
+       id="path47"
+       d="m 12.5,10.758559 c -1.333334,0 -1.877719,1.586714 -1.136719,2.498047 0.159,0.195333 0.327219,0.437266 0.199219,0.697265 -0.06464,0.131242 -0.152777,0.225729 -0.25,0.308594 0.33573,0.897327 1.930206,1.06583 2.375,0 -0.09722,-0.08286 -0.185358,-0.177352 -0.25,-0.308594 -0.128,-0.259999 0.07355,-0.478932 0.199219,-0.697265 0.764,-1.325667 0.196614,-2.498047 -1.136719,-2.498047 z"
+       style="fill:#e5b58b;fill-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccccsc"
+       inkscape:connector-curvature="0"
+       id="path4183"
+       d="M 11.3125,14.264 C 10.813633,14.757376 10,14.705201 10,16 l 5,0 c 0,-1.294799 -0.813633,-1.242624 -1.3125,-1.736 -0.359087,0.291488 -0.758149,0.476 -1.1875,0.476 -0.429351,0 -0.828413,-0.184512 -1.1875,-0.476 z"
+       style="opacity:1;fill:#cf362d;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061" />
+    <path
+       sodipodi:nodetypes="czcc"
+       inkscape:connector-curvature="0"
+       id="path75"
+       d="m 11,12.225356 c 0.465721,-0.324686 0.750318,-0.762784 1.5,-0.766797 0.749682,-0.004 1.066025,0.398033 1.5,0.655469 0.0332,-2.041425 -3.042969,-1.941397 -3,0.111328 z"
+       style="fill:#96413c;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+  </g>
+  <g
+     id="g4187"
+     transform="matrix(8,0,0,8,-4,4)">
+    <rect
+       style="opacity:1;fill:#3db2e1;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+       id="rect4150"
+       width="7"
+       height="7"
+       x="9"
+       y="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path85"
+       style="fill:#a2866a;fill-opacity:1"
+       d="M 13.943376,3.45 10,7 16,7 16,6 Z" />
+    <path
+       id="path87"
+       style="fill:#e5d740;fill-opacity:1"
+       d="m 13,2 c 0,0.5234285 -0.476572,1 -1,1 -0.523429,0 -1,-0.4765715 -1,-1 0,-0.5234286 0.476571,-1.00000011 1,-1.00000011 0.523428,0 1,0.47657151 1,1.00000011 z"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path91"
+       style="fill:#94785c;fill-opacity:1"
+       d="M 11.352941,2.5 9,5.4 9,7 14,7 Z" />
+  </g>
+  <g
+     id="g4199"
+     transform="matrix(8,0,0,8,4,-4)">
+    <rect
+       style="opacity:1;fill:#4fb45e;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+       id="rect4154"
+       width="7"
+       height="7"
+       x="0"
+       y="9" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path35"
+       d="m 3.4667969,9.901 c -0.6381705,0 -1.15625,0.487821 -1.15625,1.089844 0,0.02961 0.00121,0.06023 0.00391,0.08984 -0.089792,-0.02095 -0.1807596,-0.03301 -0.2734375,-0.0332 C 1.4791788,11.05383 1,11.537258 1,12.139281 c 0,0.450317 0.2931574,0.852956 0.7382812,1.015626 -0.133441,0.181893 -0.2046935,0.397828 -0.2050781,0.61914 0,0.602024 0.5178867,1.089652 1.15625,1.089844 0.2657283,-3.59e-4 0.5225854,-0.0859 0.7285157,-0.244141 0.211891,0.180357 0.4871354,0.280673 0.7734374,0.28125 0.6385554,0 1.1542969,-0.48939 1.1542969,-1.091797 C 5.3453435,13.605581 5.2843266,13.405697 5.1699219,13.233031 5.6615767,13.096514 5.9998072,12.671496 6,12.18811 6,11.585895 5.615495,11.106534 4.7285156,11.098266 c -0.037686,0 -0.075786,4.06e-4 -0.1132812,0.0039 0.00461,-0.03711 0.00723,-0.07383 0.00781,-0.111328 0,-0.602407 -0.5169246,-1.090036 -1.15625,-1.089844 z M 3.5,11.600219 A 0.89999998,0.89999998 0 0 1 4.4003906,12.50061 0.89999998,0.89999998 0 0 1 3.5,13.401 0.89999998,0.89999998 0 0 1 2.5996094,12.50061 0.89999998,0.89999998 0 0 1 3.5,11.600219 Z"
+       style="opacity:1;fill:#f1ef5d;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <circle
+       id="circle47"
+       style="fill:#9d8d6d;fill-opacity:1;stroke:none"
+       r="0.60000002"
+       cy="12.500218"
+       cx="3.5" />
+  </g>
+  <g
+     id="g4181"
+     transform="matrix(8,0,0,8,4,4)">
+    <rect
+       y="0"
+       x="0"
+       height="7"
+       width="7"
+       id="rect4148"
+       style="opacity:1;fill:#3c345d;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061" />
+    <path
+       id="path46"
+       style="opacity:1;fill:url(#linearGradient4226);fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 4.3645834,3.5 c -0.2702083,0.026873 -0.5589583,0.043674 -0.86375,0.043674 -0.305,0 -0.59375,-0.016801 -0.86375,-0.043674 L 2.250833,5.7830955 c 0.8416671,0.2996354 1.6770837,0.2785851 2.5000004,0 z"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path52"
+       style="opacity:1;fill:#787878;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="M 6,2.4454545 C 6,2.8220454 4.8806251,3.15 3.5000001,3.15 2.119375,3.15 1,2.8220454 1,2.4454545 1,2.0688637 2.119375,1.65 3.5000001,1.65 4.8806251,1.65 6,2.0688637 6,2.4454545 Z"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path54"
+       style="opacity:1;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 4.5416667,2.0499999 c 0,0.21 -0.4664583,0.399 -1.0416666,0.399 -0.5752084,0 -1.0416667,-0.189 -1.0416667,-0.399 C 2.4583334,1.4199999 2.8750001,1 3.5000001,1 c 0.625,0 1.0416666,0.4199999 1.0416666,1.0499999 z"
+       inkscape:connector-curvature="0" />
+  </g>
 </svg>

--- a/Numix/128x128/actions/slideshow-play.svg
+++ b/Numix/128x128/actions/slideshow-play.svg
@@ -1,0 +1,1 @@
+media-playback-start.svg

--- a/Numix/16x16/actions/eog-image-gallery.svg
+++ b/Numix/16x16/actions/eog-image-gallery.svg
@@ -1,0 +1,1 @@
+image-gallery.svg

--- a/Numix/16x16/actions/image-gallery.svg
+++ b/Numix/16x16/actions/image-gallery.svg
@@ -5,6 +5,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="16"
@@ -13,7 +14,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="eog-image-gallery1.svg">
+   sodipodi:docname="eog-image-gallery.svg">
   <metadata
      id="metadata18">
     <rdf:RDF>
@@ -27,7 +28,33 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs16" />
+     id="defs16">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4220">
+      <stop
+         style="stop-color:#e2d290;stop-opacity:0.70588237"
+         offset="0"
+         id="stop4222" />
+      <stop
+         id="stop4228"
+         offset="0.50504142"
+         style="stop-color:#e2d290;stop-opacity:1" />
+      <stop
+         style="stop-color:#e2d290;stop-opacity:0.70588237"
+         offset="1"
+         id="stop4224" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4220"
+       id="linearGradient4226"
+       x1="2.250833"
+       y1="4.75"
+       x2="4.7508334"
+       y2="4.75"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -43,9 +70,9 @@
      showgrid="false"
      inkscape:snap-smooth-nodes="true"
      inkscape:object-nodes="true"
-     inkscape:zoom="22.627417"
-     inkscape:cx="-0.50481484"
-     inkscape:cy="6.1942617"
+     inkscape:zoom="45.254834"
+     inkscape:cx="7.9688621"
+     inkscape:cy="4.9756695"
      inkscape:window-x="0"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
@@ -54,62 +81,105 @@
        type="xygrid"
        id="grid4146" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#b58900;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     id="rect4148"
-     width="7"
-     height="7"
-     x="0"
-     y="0"
-     rx="1"
-     ry="1" />
-  <rect
-     y="0"
-     x="9"
-     height="7"
-     width="7"
-     id="rect4150"
-     style="opacity:1;fill:#268bd2;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     ry="1"
-     rx="1" />
-  <rect
-     style="opacity:1;fill:#db3330;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     id="rect4152"
-     width="7"
-     height="7"
-     x="9"
-     y="9"
-     ry="1"
-     rx="1" />
-  <rect
-     y="9"
-     x="0"
-     height="7"
-     width="7"
-     id="rect4154"
-     style="opacity:1;fill:#4caf50;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     ry="1"
-     rx="1" />
-  <path
-     style="fill:#ffffff;fill-opacity:1"
-     d="M 11.4,2 10,4.1679688 10,6 15,6 15,4.6 14,3 13,4 Z"
-     id="path85"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="cccccccc" />
-  <path
-     style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
-     d="m 3.4667969,10.001 c -0.6381705,0 -1.15625,0.487821 -1.15625,1.089844 0,0.02961 0.00121,0.06023 0.00391,0.08984 -0.089792,-0.02095 -0.1807596,-0.03301 -0.2734375,-0.0332 C 1.4791788,11.15383 1,11.637258 1,12.239281 c 0,0.450317 0.2931574,0.852956 0.7382812,1.015626 -0.133441,0.181893 -0.2046935,0.397828 -0.2050781,0.61914 0,0.602024 0.5178867,1.089652 1.15625,1.089844 0.2657283,-3.59e-4 0.5225854,-0.0859 0.7285157,-0.244141 0.211891,0.180357 0.4871354,0.280673 0.7734374,0.28125 0.6385554,0 1.1542969,-0.48939 1.1542969,-1.091797 C 5.3453435,13.705581 5.2843266,13.505697 5.1699219,13.333031 5.6615767,13.196514 5.9998072,12.771496 6,12.28811 6,11.685895 5.615495,11.206534 4.7285156,11.198266 c -0.037686,0 -0.075786,4.06e-4 -0.1132812,0.0039 0.00461,-0.03711 0.00723,-0.07383 0.00781,-0.111328 0,-0.602407 -0.5169246,-1.090036 -1.15625,-1.089844 z M 3.5,11.700219 A 0.89999998,0.89999998 0 0 1 4.4003906,12.60061 0.89999998,0.89999998 0 0 1 3.5,13.501 0.89999998,0.89999998 0 0 1 2.5996094,12.60061 0.89999998,0.89999998 0 0 1 3.5,11.700219 Z"
-     id="path35"
-     inkscape:connector-curvature="0" />
-  <path
-     inkscape:connector-curvature="0"
-     d="m 11.362333,12.498 c 0.159,0.195333 0.328667,0.437333 0.200667,0.697333 C 11.166667,14 10,13.666667 10,15 l 5,0 c 0,-1.333333 -1.166667,-1 -1.563,-1.804667 -0.128,-0.26 0.075,-0.479 0.200667,-0.697333 0.764,-1.325667 0.195666,-2.498333 -1.137667,-2.498333 -1.333333,0 -1.878667,1.587 -1.137667,2.498333 z"
-     style="fill:#ffffff;fill-opacity:1"
-     id="path47" />
-  <path
-     inkscape:connector-curvature="0"
-     style="fill:#ffffff;fill-opacity:1"
-     d="M 1,3 2,3 2,6 3,6 3,3 4,3 4,6 5,6 5,3 6,3 3.5,1 Z"
-     id="path6"
-     sodipodi:nodetypes="cccccccccccc" />
+  <g
+     id="g4193">
+    <rect
+       y="9"
+       x="9"
+       height="7"
+       width="7"
+       id="rect4152"
+       style="opacity:1;fill:#b8ccd3;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061" />
+    <path
+       sodipodi:nodetypes="sccccccs"
+       inkscape:connector-curvature="0"
+       id="path47"
+       d="m 12.5,10.758559 c -1.333334,0 -1.877719,1.586714 -1.136719,2.498047 0.159,0.195333 0.327219,0.437266 0.199219,0.697265 -0.06464,0.131242 -0.152777,0.225729 -0.25,0.308594 0.33573,0.897327 1.930206,1.06583 2.375,0 -0.09722,-0.08286 -0.185358,-0.177352 -0.25,-0.308594 -0.128,-0.259999 0.07355,-0.478932 0.199219,-0.697265 0.764,-1.325667 0.196614,-2.498047 -1.136719,-2.498047 z"
+       style="fill:#e5b58b;fill-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccccsc"
+       inkscape:connector-curvature="0"
+       id="path4183"
+       d="M 11.3125,14.264 C 10.813633,14.757376 10,14.705201 10,16 l 5,0 c 0,-1.294799 -0.813633,-1.242624 -1.3125,-1.736 -0.359087,0.291488 -0.758149,0.476 -1.1875,0.476 -0.429351,0 -0.828413,-0.184512 -1.1875,-0.476 z"
+       style="opacity:1;fill:#cf362d;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061" />
+    <path
+       sodipodi:nodetypes="czcc"
+       inkscape:connector-curvature="0"
+       id="path75"
+       d="m 11,12.225356 c 0.465721,-0.324686 0.750318,-0.762784 1.5,-0.766797 0.749682,-0.004 1.066025,0.398033 1.5,0.655469 0.0332,-2.041425 -3.042969,-1.941397 -3,0.111328 z"
+       style="fill:#96413c;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+  </g>
+  <g
+     id="g4187">
+    <rect
+       style="opacity:1;fill:#3db2e1;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+       id="rect4150"
+       width="7"
+       height="7"
+       x="9"
+       y="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path85"
+       style="fill:#a2866a;fill-opacity:1"
+       d="M 13.943376,3.45 10,7 16,7 16,6 Z" />
+    <path
+       id="path87"
+       style="fill:#e5d740;fill-opacity:1"
+       d="m 13,2 c 0,0.5234285 -0.476572,1 -1,1 -0.523429,0 -1,-0.4765715 -1,-1 0,-0.5234286 0.476571,-1.00000011 1,-1.00000011 0.523428,0 1,0.47657151 1,1.00000011 z"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path91"
+       style="fill:#94785c;fill-opacity:1"
+       d="M 11.352941,2.5 9,5.4 9,7 14,7 Z" />
+  </g>
+  <g
+     id="g4199">
+    <rect
+       style="opacity:1;fill:#4fb45e;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+       id="rect4154"
+       width="7"
+       height="7"
+       x="0"
+       y="9" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path35"
+       d="m 3.4667969,9.901 c -0.6381705,0 -1.15625,0.487821 -1.15625,1.089844 0,0.02961 0.00121,0.06023 0.00391,0.08984 -0.089792,-0.02095 -0.1807596,-0.03301 -0.2734375,-0.0332 C 1.4791788,11.05383 1,11.537258 1,12.139281 c 0,0.450317 0.2931574,0.852956 0.7382812,1.015626 -0.133441,0.181893 -0.2046935,0.397828 -0.2050781,0.61914 0,0.602024 0.5178867,1.089652 1.15625,1.089844 0.2657283,-3.59e-4 0.5225854,-0.0859 0.7285157,-0.244141 0.211891,0.180357 0.4871354,0.280673 0.7734374,0.28125 0.6385554,0 1.1542969,-0.48939 1.1542969,-1.091797 C 5.3453435,13.605581 5.2843266,13.405697 5.1699219,13.233031 5.6615767,13.096514 5.9998072,12.671496 6,12.18811 6,11.585895 5.615495,11.106534 4.7285156,11.098266 c -0.037686,0 -0.075786,4.06e-4 -0.1132812,0.0039 0.00461,-0.03711 0.00723,-0.07383 0.00781,-0.111328 0,-0.602407 -0.5169246,-1.090036 -1.15625,-1.089844 z M 3.5,11.600219 A 0.89999998,0.89999998 0 0 1 4.4003906,12.50061 0.89999998,0.89999998 0 0 1 3.5,13.401 0.89999998,0.89999998 0 0 1 2.5996094,12.50061 0.89999998,0.89999998 0 0 1 3.5,11.600219 Z"
+       style="opacity:1;fill:#f1ef5d;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <circle
+       id="circle47"
+       style="fill:#9d8d6d;fill-opacity:1;stroke:none"
+       r="0.60000002"
+       cy="12.500218"
+       cx="3.5" />
+  </g>
+  <g
+     id="g4181">
+    <rect
+       y="0"
+       x="0"
+       height="7"
+       width="7"
+       id="rect4148"
+       style="opacity:1;fill:#3c345d;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061" />
+    <path
+       id="path46"
+       style="opacity:1;fill:url(#linearGradient4226);fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 4.3645834,3.5 c -0.2702083,0.026873 -0.5589583,0.043674 -0.86375,0.043674 -0.305,0 -0.59375,-0.016801 -0.86375,-0.043674 L 2.250833,5.7830955 c 0.8416671,0.2996354 1.6770837,0.2785851 2.5000004,0 z"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path52"
+       style="opacity:1;fill:#787878;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="M 6,2.4454545 C 6,2.8220454 4.8806251,3.15 3.5000001,3.15 2.119375,3.15 1,2.8220454 1,2.4454545 1,2.0688637 2.119375,1.65 3.5000001,1.65 4.8806251,1.65 6,2.0688637 6,2.4454545 Z"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path54"
+       style="opacity:1;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 4.5416667,2.0499999 c 0,0.21 -0.4664583,0.399 -1.0416666,0.399 -0.5752084,0 -1.0416667,-0.189 -1.0416667,-0.399 C 2.4583334,1.4199999 2.8750001,1 3.5000001,1 c 0.625,0 1.0416666,0.4199999 1.0416666,1.0499999 z"
+       inkscape:connector-curvature="0" />
+  </g>
 </svg>

--- a/Numix/16x16/actions/image-gallery.svg
+++ b/Numix/16x16/actions/image-gallery.svg
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="eog-image-gallery1.svg">
+  <metadata
+     id="metadata18">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs16" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview14"
+     showgrid="false"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:object-nodes="true"
+     inkscape:zoom="22.627417"
+     inkscape:cx="-0.50481484"
+     inkscape:cy="6.1942617"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4146" />
+  </sodipodi:namedview>
+  <rect
+     style="opacity:1;fill:#b58900;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     id="rect4148"
+     width="7"
+     height="7"
+     x="0"
+     y="0"
+     rx="1"
+     ry="1" />
+  <rect
+     y="0"
+     x="9"
+     height="7"
+     width="7"
+     id="rect4150"
+     style="opacity:1;fill:#268bd2;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     ry="1"
+     rx="1" />
+  <rect
+     style="opacity:1;fill:#db3330;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     id="rect4152"
+     width="7"
+     height="7"
+     x="9"
+     y="9"
+     ry="1"
+     rx="1" />
+  <rect
+     y="9"
+     x="0"
+     height="7"
+     width="7"
+     id="rect4154"
+     style="opacity:1;fill:#4caf50;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     ry="1"
+     rx="1" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     d="M 11.4,2 10,4.1679688 10,6 15,6 15,4.6 14,3 13,4 Z"
+     id="path85"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccc" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     d="m 3.4667969,10.001 c -0.6381705,0 -1.15625,0.487821 -1.15625,1.089844 0,0.02961 0.00121,0.06023 0.00391,0.08984 -0.089792,-0.02095 -0.1807596,-0.03301 -0.2734375,-0.0332 C 1.4791788,11.15383 1,11.637258 1,12.239281 c 0,0.450317 0.2931574,0.852956 0.7382812,1.015626 -0.133441,0.181893 -0.2046935,0.397828 -0.2050781,0.61914 0,0.602024 0.5178867,1.089652 1.15625,1.089844 0.2657283,-3.59e-4 0.5225854,-0.0859 0.7285157,-0.244141 0.211891,0.180357 0.4871354,0.280673 0.7734374,0.28125 0.6385554,0 1.1542969,-0.48939 1.1542969,-1.091797 C 5.3453435,13.705581 5.2843266,13.505697 5.1699219,13.333031 5.6615767,13.196514 5.9998072,12.771496 6,12.28811 6,11.685895 5.615495,11.206534 4.7285156,11.198266 c -0.037686,0 -0.075786,4.06e-4 -0.1132812,0.0039 0.00461,-0.03711 0.00723,-0.07383 0.00781,-0.111328 0,-0.602407 -0.5169246,-1.090036 -1.15625,-1.089844 z M 3.5,11.700219 A 0.89999998,0.89999998 0 0 1 4.4003906,12.60061 0.89999998,0.89999998 0 0 1 3.5,13.501 0.89999998,0.89999998 0 0 1 2.5996094,12.60061 0.89999998,0.89999998 0 0 1 3.5,11.700219 Z"
+     id="path35"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     d="m 11.362333,12.498 c 0.159,0.195333 0.328667,0.437333 0.200667,0.697333 C 11.166667,14 10,13.666667 10,15 l 5,0 c 0,-1.333333 -1.166667,-1 -1.563,-1.804667 -0.128,-0.26 0.075,-0.479 0.200667,-0.697333 0.764,-1.325667 0.195666,-2.498333 -1.137667,-2.498333 -1.333333,0 -1.878667,1.587 -1.137667,2.498333 z"
+     style="fill:#ffffff;fill-opacity:1"
+     id="path47" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;fill-opacity:1"
+     d="M 1,3 2,3 2,6 3,6 3,3 4,3 4,6 5,6 5,3 6,3 3.5,1 Z"
+     id="path6"
+     sodipodi:nodetypes="cccccccccccc" />
+</svg>

--- a/Numix/16x16/actions/slideshow-play.svg
+++ b/Numix/16x16/actions/slideshow-play.svg
@@ -1,0 +1,1 @@
+media-playback-start.svg

--- a/Numix/22x22/actions/eog-image-gallery.svg
+++ b/Numix/22x22/actions/eog-image-gallery.svg
@@ -1,0 +1,1 @@
+image-gallery.svg

--- a/Numix/22x22/actions/image-gallery.svg
+++ b/Numix/22x22/actions/image-gallery.svg
@@ -5,6 +5,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="22"
@@ -13,7 +14,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="eog-image-gallery1.svg">
+   sodipodi:docname="eog-image-gallery.svg">
   <metadata
      id="metadata12">
     <rdf:RDF>
@@ -27,7 +28,34 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs10" />
+     id="defs10">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4220"
+       id="linearGradient4226"
+       x1="2.250833"
+       y1="4.75"
+       x2="4.7508335"
+       y2="4.75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.97188003,0,0.16871985)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4220">
+      <stop
+         style="stop-color:#e2d290;stop-opacity:0.70588237"
+         offset="0"
+         id="stop4222" />
+      <stop
+         id="stop4228"
+         offset="0.50504142"
+         style="stop-color:#e2d290;stop-opacity:1" />
+      <stop
+         style="stop-color:#e2d290;stop-opacity:0.70588237"
+         offset="1"
+         id="stop4224" />
+    </linearGradient>
+  </defs>
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -41,9 +69,9 @@
      inkscape:window-height="704"
      id="namedview8"
      showgrid="true"
-     inkscape:zoom="16"
-     inkscape:cx="3.6305164"
-     inkscape:cy="11.333262"
+     inkscape:zoom="64"
+     inkscape:cx="4.5585606"
+     inkscape:cy="17.583263"
      inkscape:window-x="0"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
@@ -52,62 +80,110 @@
        type="xygrid"
        id="grid4140" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#b58900;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     id="rect4148"
-     width="10"
-     height="10"
-     x="0"
-     y="2.6226044e-06"
-     rx="1"
-     ry="1" />
-  <rect
-     y="2.6226044e-06"
-     x="12"
-     height="10"
-     width="10"
-     id="rect4150"
-     style="opacity:1;fill:#268bd2;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     ry="1"
-     rx="1" />
-  <rect
-     style="opacity:1;fill:#db3330;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     id="rect4152"
-     width="10"
-     height="10"
-     x="12"
-     y="12"
-     ry="1"
-     rx="1" />
-  <rect
-     y="12"
-     x="0"
-     height="10"
-     width="10"
-     id="rect4154"
-     style="opacity:1;fill:#4caf50;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     ry="1"
-     rx="1" />
-  <path
-     style="fill:#ffffff;fill-opacity:1"
-     d="M 15.8,2.7000001 14,5.3015625 14,8 20,8 20,5.8199998 18.8,3.9000001 17.6,5.0999998 Z"
-     id="path85"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="cccccccc" />
-  <path
-     style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
-     d="m 4.9601563,14 c -0.7658046,0 -1.3875,0.585386 -1.3875,1.307813 0,0.03553 0.00145,0.07228 0.0047,0.107808 C 3.4696012,15.390481 3.3604401,15.376006 3.2492266,15.375781 2.5750146,15.383341 2,15.96351 2,16.685938 c 0,0.54038 0.3517888,1.023546 0.8859374,1.21875 -0.1601292,0.218272 -0.2456322,0.477394 -0.2460937,0.742969 0,0.722429 0.6214641,1.307582 1.3875,1.307813 0.318874,-4.31e-4 0.6271025,-0.103081 0.8742189,-0.292969 C 5.1558318,19.878929 5.486125,19.999308 5.8296874,20 6.5959539,20 7.2148437,19.412732 7.2148437,18.689844 7.2144122,18.445498 7.1411923,18.205637 7.0039062,17.998438 7.5938921,17.834617 7.9997686,17.324595 8,16.744533 8,16.021874 7.538594,15.446641 6.4742187,15.436719 c -0.045223,0 -0.090943,4.87e-4 -0.1359375,0.0047 0.00554,-0.04453 0.00868,-0.0886 0.00937,-0.133593 0,-0.722889 -0.6203094,-1.308044 -1.3874999,-1.307814 z M 5,16.039062 A 1.08,1.08 0 0 1 6.0804686,17.119532 1.08,1.08 0 0 1 5,18.2 1.08,1.08 0 0 1 3.9195313,17.119532 1.08,1.08 0 0 1 5,16.039062 Z"
-     id="path35"
-     inkscape:connector-curvature="0" />
-  <path
-     inkscape:connector-curvature="0"
-     d="m 15.634799,16.9976 c 0.1908,0.234399 0.394401,0.524799 0.240801,0.836799 C 15.400001,18.8 14,18.400001 14,20 l 6,0 c 0,-1.599999 -1.400001,-1.2 -1.8756,-2.165601 -0.1536,-0.312 0.09,-0.5748 0.240801,-0.836799 0.9168,-1.590801 0.234798,-2.997999 -1.365201,-2.997999 -1.599999,0 -2.254401,1.9044 -1.365201,2.997999 z"
-     style="fill:#ffffff;fill-opacity:1"
-     id="path47" />
-  <path
-     inkscape:connector-curvature="0"
-     style="fill:#ffffff;fill-opacity:1"
-     d="M 1.75,5 3,5 3,8 4,8 4,5 6,5 6,8 7,8 7,5 8.25,5 5,2.0000003 Z"
-     id="path6"
-     sodipodi:nodetypes="cccccccccccc" />
+  <g
+     id="g4193"
+     transform="matrix(1.4285714,0,0,1.4285714,-0.8571426,-0.85714286)">
+    <rect
+       y="9"
+       x="9"
+       height="7"
+       width="7"
+       id="rect4152"
+       style="opacity:1;fill:#b8ccd3;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061" />
+    <path
+       sodipodi:nodetypes="sccccccs"
+       inkscape:connector-curvature="0"
+       id="path47"
+       d="m 12.5,10.758559 c -1.333334,0 -1.877719,1.586714 -1.136719,2.498047 0.159,0.195333 0.327219,0.437266 0.199219,0.697265 -0.06464,0.131242 -0.152777,0.225729 -0.25,0.308594 0.33573,0.897327 1.930206,1.06583 2.375,0 -0.09722,-0.08286 -0.185358,-0.177352 -0.25,-0.308594 -0.128,-0.259999 0.07355,-0.478932 0.199219,-0.697265 0.764,-1.325667 0.196614,-2.498047 -1.136719,-2.498047 z"
+       style="fill:#e5b58b;fill-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccccsc"
+       inkscape:connector-curvature="0"
+       id="path4183"
+       d="M 11.3125,14.264 C 10.813633,14.757376 10,14.705201 10,16 l 5,0 c 0,-1.294799 -0.813633,-1.242624 -1.3125,-1.736 -0.359087,0.291488 -0.758149,0.476 -1.1875,0.476 -0.429351,0 -0.828413,-0.184512 -1.1875,-0.476 z"
+       style="opacity:1;fill:#cf362d;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061" />
+    <path
+       sodipodi:nodetypes="czcc"
+       inkscape:connector-curvature="0"
+       id="path75"
+       d="m 11,12.225356 c 0.465721,-0.324686 0.750318,-0.762784 1.5,-0.766797 0.749682,-0.004 1.066025,0.398033 1.5,0.655469 0.0332,-2.041425 -3.042969,-1.941397 -3,0.111328 z"
+       style="fill:#96413c;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+  </g>
+  <g
+     id="g4187"
+     transform="matrix(1.4285714,0,0,1.4285714,-0.8571426,2e-7)">
+    <rect
+       style="opacity:1;fill:#3db2e1;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+       id="rect4150"
+       width="7"
+       height="7"
+       x="9"
+       y="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path85"
+       style="fill:#a2866a;fill-opacity:1"
+       d="M 13.943376,3.45 10,7 16,7 16,6 Z" />
+    <path
+       id="path87"
+       style="fill:#e5d740;fill-opacity:1"
+       d="m 13,2 c 0,0.5234285 -0.476572,1 -1,1 -0.523429,0 -1,-0.4765715 -1,-1 0,-0.5234286 0.476571,-1.00000011 1,-1.00000011 0.523428,0 1,0.47657151 1,1.00000011 z"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path91"
+       style="fill:#94785c;fill-opacity:1"
+       d="M 11.352941,2.5 9,5.4 9,7 14,7 Z" />
+  </g>
+  <g
+     id="g4199"
+     transform="matrix(1.4285714,0,0,1.4285714,0,-0.85714286)">
+    <rect
+       style="opacity:1;fill:#4fb45e;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+       id="rect4154"
+       width="7"
+       height="7"
+       x="0"
+       y="9" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path35"
+       d="m 3.4667969,9.901 c -0.6381705,0 -1.15625,0.487821 -1.15625,1.089844 0,0.02961 0.00121,0.06023 0.00391,0.08984 -0.089792,-0.02095 -0.1807596,-0.03301 -0.2734375,-0.0332 C 1.4791788,11.05383 1,11.537258 1,12.139281 c 0,0.450317 0.2931574,0.852956 0.7382812,1.015626 -0.133441,0.181893 -0.2046935,0.397828 -0.2050781,0.61914 0,0.602024 0.5178867,1.089652 1.15625,1.089844 0.2657283,-3.59e-4 0.5225854,-0.0859 0.7285157,-0.244141 0.211891,0.180357 0.4871354,0.280673 0.7734374,0.28125 0.6385554,0 1.1542969,-0.48939 1.1542969,-1.091797 C 5.3453435,13.605581 5.2843266,13.405697 5.1699219,13.233031 5.6615767,13.096514 5.9998072,12.671496 6,12.18811 6,11.585895 5.615495,11.106534 4.7285156,11.098266 c -0.037686,0 -0.075786,4.06e-4 -0.1132812,0.0039 0.00461,-0.03711 0.00723,-0.07383 0.00781,-0.111328 0,-0.602407 -0.5169246,-1.090036 -1.15625,-1.089844 z M 3.5,11.600219 A 0.89999998,0.89999998 0 0 1 4.4003906,12.50061 0.89999998,0.89999998 0 0 1 3.5,13.401 0.89999998,0.89999998 0 0 1 2.5996094,12.50061 0.89999998,0.89999998 0 0 1 3.5,11.600219 Z"
+       style="opacity:1;fill:#f1ef5d;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <circle
+       id="circle47"
+       style="fill:#9d8d6d;fill-opacity:1;stroke:none"
+       r="0.60000002"
+       cy="12.500218"
+       cx="3.5" />
+  </g>
+  <g
+     id="g4181"
+     transform="scale(1.4285714,1.4285714)">
+    <rect
+       y="0"
+       x="0"
+       height="7"
+       width="7"
+       id="rect4148"
+       style="opacity:1;fill:#3c345d;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061" />
+    <path
+       id="path46"
+       style="opacity:1;fill:url(#linearGradient4226);fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 4.3645834,3.5702999 c -0.2702083,0.026117 -0.5589583,0.042446 -0.86375,0.042446 -0.305,0 -0.59375,-0.016328 -0.86375,-0.042446 L 2.250833,5.7891948 c 0.8416671,0.2912097 1.6770837,0.2707513 2.5000004,0 z"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path52"
+       style="opacity:1;fill:#787878;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="M 6,2.4637879 C 6,2.8679954 4.8806251,3.2900001 3.5000001,3.2900001 2.119375,3.2900001 1,2.8679954 1,2.4637879 1,2.0595805 2.119375,1.596 3.5000001,1.596 4.8806251,1.596 6,2.0595805 6,2.4637879 Z"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssss" />
+    <path
+       id="path54"
+       style="opacity:1;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 4.5416667,2.0499999 c 0,0.21 -0.4664583,0.399 -1.0416666,0.399 -0.5752084,0 -1.0416667,-0.189 -1.0416667,-0.399 C 2.4583334,1.4199999 2.8750001,1 3.5000001,1 c 0.625,0 1.0416666,0.4199999 1.0416666,1.0499999 z"
+       inkscape:connector-curvature="0" />
+  </g>
 </svg>

--- a/Numix/22x22/actions/image-gallery.svg
+++ b/Numix/22x22/actions/image-gallery.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   viewBox="0 0 22 22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="eog-image-gallery1.svg">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview8"
+     showgrid="true"
+     inkscape:zoom="16"
+     inkscape:cx="3.6305164"
+     inkscape:cy="11.333262"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4140" />
+  </sodipodi:namedview>
+  <rect
+     style="opacity:1;fill:#b58900;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     id="rect4148"
+     width="10"
+     height="10"
+     x="0"
+     y="2.6226044e-06"
+     rx="1"
+     ry="1" />
+  <rect
+     y="2.6226044e-06"
+     x="12"
+     height="10"
+     width="10"
+     id="rect4150"
+     style="opacity:1;fill:#268bd2;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     ry="1"
+     rx="1" />
+  <rect
+     style="opacity:1;fill:#db3330;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     id="rect4152"
+     width="10"
+     height="10"
+     x="12"
+     y="12"
+     ry="1"
+     rx="1" />
+  <rect
+     y="12"
+     x="0"
+     height="10"
+     width="10"
+     id="rect4154"
+     style="opacity:1;fill:#4caf50;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     ry="1"
+     rx="1" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     d="M 15.8,2.7000001 14,5.3015625 14,8 20,8 20,5.8199998 18.8,3.9000001 17.6,5.0999998 Z"
+     id="path85"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccc" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     d="m 4.9601563,14 c -0.7658046,0 -1.3875,0.585386 -1.3875,1.307813 0,0.03553 0.00145,0.07228 0.0047,0.107808 C 3.4696012,15.390481 3.3604401,15.376006 3.2492266,15.375781 2.5750146,15.383341 2,15.96351 2,16.685938 c 0,0.54038 0.3517888,1.023546 0.8859374,1.21875 -0.1601292,0.218272 -0.2456322,0.477394 -0.2460937,0.742969 0,0.722429 0.6214641,1.307582 1.3875,1.307813 0.318874,-4.31e-4 0.6271025,-0.103081 0.8742189,-0.292969 C 5.1558318,19.878929 5.486125,19.999308 5.8296874,20 6.5959539,20 7.2148437,19.412732 7.2148437,18.689844 7.2144122,18.445498 7.1411923,18.205637 7.0039062,17.998438 7.5938921,17.834617 7.9997686,17.324595 8,16.744533 8,16.021874 7.538594,15.446641 6.4742187,15.436719 c -0.045223,0 -0.090943,4.87e-4 -0.1359375,0.0047 0.00554,-0.04453 0.00868,-0.0886 0.00937,-0.133593 0,-0.722889 -0.6203094,-1.308044 -1.3874999,-1.307814 z M 5,16.039062 A 1.08,1.08 0 0 1 6.0804686,17.119532 1.08,1.08 0 0 1 5,18.2 1.08,1.08 0 0 1 3.9195313,17.119532 1.08,1.08 0 0 1 5,16.039062 Z"
+     id="path35"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     d="m 15.634799,16.9976 c 0.1908,0.234399 0.394401,0.524799 0.240801,0.836799 C 15.400001,18.8 14,18.400001 14,20 l 6,0 c 0,-1.599999 -1.400001,-1.2 -1.8756,-2.165601 -0.1536,-0.312 0.09,-0.5748 0.240801,-0.836799 0.9168,-1.590801 0.234798,-2.997999 -1.365201,-2.997999 -1.599999,0 -2.254401,1.9044 -1.365201,2.997999 z"
+     style="fill:#ffffff;fill-opacity:1"
+     id="path47" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;fill-opacity:1"
+     d="M 1.75,5 3,5 3,8 4,8 4,5 6,5 6,8 7,8 7,5 8.25,5 5,2.0000003 Z"
+     id="path6"
+     sodipodi:nodetypes="cccccccccccc" />
+</svg>

--- a/Numix/22x22/actions/slideshow-play.svg
+++ b/Numix/22x22/actions/slideshow-play.svg
@@ -1,0 +1,1 @@
+media-playback-start.svg

--- a/Numix/24x24/actions/eog-image-gallery.svg
+++ b/Numix/24x24/actions/eog-image-gallery.svg
@@ -1,0 +1,1 @@
+image-gallery.svg

--- a/Numix/24x24/actions/image-gallery.svg
+++ b/Numix/24x24/actions/image-gallery.svg
@@ -5,6 +5,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="24"
@@ -13,7 +14,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="eog-image-gallery1.svg">
+   sodipodi:docname="eog-image-gallery.svg">
   <metadata
      id="metadata20">
     <rdf:RDF>
@@ -27,7 +28,34 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs18" />
+     id="defs18">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4220"
+       id="linearGradient4226"
+       x1="2.250833"
+       y1="4.75"
+       x2="4.7508335"
+       y2="4.75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.97188003,0,0.16871985)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4220">
+      <stop
+         style="stop-color:#e2d290;stop-opacity:0.70588237"
+         offset="0"
+         id="stop4222" />
+      <stop
+         id="stop4228"
+         offset="0.50504142"
+         style="stop-color:#e2d290;stop-opacity:1" />
+      <stop
+         style="stop-color:#e2d290;stop-opacity:0.70588237"
+         offset="1"
+         id="stop4224" />
+    </linearGradient>
+  </defs>
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -41,7 +69,7 @@
      inkscape:window-height="704"
      id="namedview16"
      showgrid="false"
-     inkscape:zoom="8"
+     inkscape:zoom="1"
      inkscape:cx="-7.9322034"
      inkscape:cy="12"
      inkscape:window-x="0"
@@ -52,62 +80,110 @@
        type="xygrid"
        id="grid4148" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#b58900;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     id="rect4148"
-     width="10"
-     height="10"
-     x="1"
-     y="1.0000019"
-     rx="1"
-     ry="1" />
-  <rect
-     y="1.0000019"
-     x="13"
-     height="10"
-     width="10"
-     id="rect4150"
-     style="opacity:1;fill:#268bd2;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     ry="1"
-     rx="1" />
-  <rect
-     style="opacity:1;fill:#db3330;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     id="rect4152"
-     width="10"
-     height="10"
-     x="13"
-     y="13"
-     ry="1"
-     rx="1" />
-  <rect
-     y="13"
-     x="1"
-     height="10"
-     width="10"
-     id="rect4154"
-     style="opacity:1;fill:#4caf50;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     ry="1"
-     rx="1" />
-  <path
-     style="fill:#ffffff;fill-opacity:1"
-     d="m 16.8,3.699999 -1.8,2.601562 0,2.698438 6,0 0,-2.18 -1.2,-1.92 -1.2,1.2 z"
-     id="path85"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="cccccccc" />
-  <path
-     style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
-     d="m 5.9601563,14.999998 c -0.7658046,0 -1.3875,0.585386 -1.3875,1.307813 0,0.03553 0.00145,0.07228 0.0047,0.107808 C 4.4696012,16.390479 4.3604401,16.376009 4.2492266,16.375779 3.575015,16.383339 3,16.963508 3,17.685936 c 0,0.54038 0.351789,1.023546 0.885937,1.21875 -0.160129,0.218272 -0.245632,0.477394 -0.246093,0.742969 0,0.722429 0.6214638,1.307582 1.3874997,1.307813 0.318874,-4.31e-4 0.6271025,-0.103081 0.8742189,-0.292969 0.2542692,0.216428 0.5845624,0.336807 0.9281248,0.337499 0.7662665,0 1.3851563,-0.587268 1.3851563,-1.310156 C 8.2144122,19.445496 8.1411927,19.205635 8.0039062,18.998436 8.5938921,18.834615 8.9997686,18.324593 9,17.744531 9,17.021872 8.538594,16.446639 7.4742187,16.436717 c -0.045223,0 -0.090943,4.87e-4 -0.1359375,0.0047 0.00554,-0.04453 0.00868,-0.0886 0.00937,-0.133593 0,-0.722889 -0.6203094,-1.308044 -1.3874999,-1.307814 z M 6,17.03906 A 1.08,1.08 0 0 1 7.0804686,18.11953 1.08,1.08 0 0 1 6,19.199998 1.08,1.08 0 0 1 4.9195313,18.11953 1.08,1.08 0 0 1 6,17.03906 Z"
-     id="path35"
-     inkscape:connector-curvature="0" />
-  <path
-     inkscape:connector-curvature="0"
-     d="m 16.634799,17.997598 c 0.1908,0.234399 0.394401,0.524799 0.240801,0.836799 C 16.400001,19.799998 15,19.399999 15,20.999998 l 6,0 c 0,-1.599999 -1.400001,-1.2 -1.8756,-2.165601 -0.1536,-0.312 0.09,-0.5748 0.240801,-0.836799 0.9168,-1.590801 0.234798,-2.997999 -1.365201,-2.997999 -1.599999,0 -2.254401,1.9044 -1.365201,2.997999 z"
-     style="fill:#ffffff;fill-opacity:1"
-     id="path47" />
-  <path
-     inkscape:connector-curvature="0"
-     style="fill:#ffffff;fill-opacity:1"
-     d="m 2.75,5.999999 1.25,0 0,3 1,0 0,-3 2,0 0,3 1,0 0,-3 1.25,0 -3.25,-3 z"
-     id="path6"
-     sodipodi:nodetypes="cccccccccccc" />
+  <g
+     id="g4193"
+     transform="matrix(1.4285714,0,0,1.4285714,0.142857,0.1428576)">
+    <rect
+       y="9"
+       x="9"
+       height="7"
+       width="7"
+       id="rect4152"
+       style="opacity:1;fill:#b8ccd3;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061" />
+    <path
+       sodipodi:nodetypes="sccccccs"
+       inkscape:connector-curvature="0"
+       id="path47"
+       d="m 12.5,10.758559 c -1.333334,0 -1.877719,1.586714 -1.136719,2.498047 0.159,0.195333 0.327219,0.437266 0.199219,0.697265 -0.06464,0.131242 -0.152777,0.225729 -0.25,0.308594 0.33573,0.897327 1.930206,1.06583 2.375,0 -0.09722,-0.08286 -0.185358,-0.177352 -0.25,-0.308594 -0.128,-0.259999 0.07355,-0.478932 0.199219,-0.697265 0.764,-1.325667 0.196614,-2.498047 -1.136719,-2.498047 z"
+       style="fill:#e5b58b;fill-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccccsc"
+       inkscape:connector-curvature="0"
+       id="path4183"
+       d="M 11.3125,14.264 C 10.813633,14.757376 10,14.705201 10,16 l 5,0 c 0,-1.294799 -0.813633,-1.242624 -1.3125,-1.736 -0.359087,0.291488 -0.758149,0.476 -1.1875,0.476 -0.429351,0 -0.828413,-0.184512 -1.1875,-0.476 z"
+       style="opacity:1;fill:#cf362d;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061" />
+    <path
+       sodipodi:nodetypes="czcc"
+       inkscape:connector-curvature="0"
+       id="path75"
+       d="m 11,12.225356 c 0.465721,-0.324686 0.750318,-0.762784 1.5,-0.766797 0.749682,-0.004 1.066025,0.398033 1.5,0.655469 0.0332,-2.041425 -3.042969,-1.941397 -3,0.111328 z"
+       style="fill:#96413c;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+  </g>
+  <g
+     id="g4187"
+     transform="matrix(1.4285714,0,0,1.4285714,0.142857,1.0000007)">
+    <rect
+       style="opacity:1;fill:#3db2e1;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+       id="rect4150"
+       width="7"
+       height="7"
+       x="9"
+       y="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path85"
+       style="fill:#a2866a;fill-opacity:1"
+       d="M 13.943376,3.45 10,7 16,7 16,6 Z" />
+    <path
+       id="path87"
+       style="fill:#e5d740;fill-opacity:1"
+       d="m 13,2 c 0,0.5234285 -0.476572,1 -1,1 -0.523429,0 -1,-0.4765715 -1,-1 0,-0.5234286 0.476571,-1.00000011 1,-1.00000011 0.523428,0 1,0.47657151 1,1.00000011 z"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path91"
+       style="fill:#94785c;fill-opacity:1"
+       d="M 11.352941,2.5 9,5.4 9,7 14,7 Z" />
+  </g>
+  <g
+     id="g4199"
+     transform="matrix(1.4285714,0,0,1.4285714,1,0.1428576)">
+    <rect
+       style="opacity:1;fill:#4fb45e;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+       id="rect4154"
+       width="7"
+       height="7"
+       x="0"
+       y="9" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path35"
+       d="m 3.4667969,9.901 c -0.6381705,0 -1.15625,0.487821 -1.15625,1.089844 0,0.02961 0.00121,0.06023 0.00391,0.08984 -0.089792,-0.02095 -0.1807596,-0.03301 -0.2734375,-0.0332 C 1.4791788,11.05383 1,11.537258 1,12.139281 c 0,0.450317 0.2931574,0.852956 0.7382812,1.015626 -0.133441,0.181893 -0.2046935,0.397828 -0.2050781,0.61914 0,0.602024 0.5178867,1.089652 1.15625,1.089844 0.2657283,-3.59e-4 0.5225854,-0.0859 0.7285157,-0.244141 0.211891,0.180357 0.4871354,0.280673 0.7734374,0.28125 0.6385554,0 1.1542969,-0.48939 1.1542969,-1.091797 C 5.3453435,13.605581 5.2843266,13.405697 5.1699219,13.233031 5.6615767,13.096514 5.9998072,12.671496 6,12.18811 6,11.585895 5.615495,11.106534 4.7285156,11.098266 c -0.037686,0 -0.075786,4.06e-4 -0.1132812,0.0039 0.00461,-0.03711 0.00723,-0.07383 0.00781,-0.111328 0,-0.602407 -0.5169246,-1.090036 -1.15625,-1.089844 z M 3.5,11.600219 A 0.89999998,0.89999998 0 0 1 4.4003906,12.50061 0.89999998,0.89999998 0 0 1 3.5,13.401 0.89999998,0.89999998 0 0 1 2.5996094,12.50061 0.89999998,0.89999998 0 0 1 3.5,11.600219 Z"
+       style="opacity:1;fill:#f1ef5d;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <circle
+       id="circle47"
+       style="fill:#9d8d6d;fill-opacity:1;stroke:none"
+       r="0.60000002"
+       cy="12.500218"
+       cx="3.5" />
+  </g>
+  <g
+     id="g4181"
+     transform="matrix(1.4285714,0,0,1.4285714,1,1.0000005)">
+    <rect
+       y="0"
+       x="0"
+       height="7"
+       width="7"
+       id="rect4148"
+       style="opacity:1;fill:#3c345d;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061" />
+    <path
+       id="path46"
+       style="opacity:1;fill:url(#linearGradient4226);fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 4.3645834,3.5702999 c -0.2702083,0.026117 -0.5589583,0.042446 -0.86375,0.042446 -0.305,0 -0.59375,-0.016328 -0.86375,-0.042446 L 2.250833,5.7891948 c 0.8416671,0.2912097 1.6770837,0.2707513 2.5000004,0 z"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path52"
+       style="opacity:1;fill:#787878;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="M 6,2.4637879 C 6,2.8679954 4.8806251,3.2900001 3.5000001,3.2900001 2.119375,3.2900001 1,2.8679954 1,2.4637879 1,2.0595805 2.119375,1.596 3.5000001,1.596 4.8806251,1.596 6,2.0595805 6,2.4637879 Z"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssss" />
+    <path
+       id="path54"
+       style="opacity:1;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 4.5416667,2.0499999 c 0,0.21 -0.4664583,0.399 -1.0416666,0.399 -0.5752084,0 -1.0416667,-0.189 -1.0416667,-0.399 C 2.4583334,1.4199999 2.8750001,1 3.5000001,1 c 0.625,0 1.0416666,0.4199999 1.0416666,1.0499999 z"
+       inkscape:connector-curvature="0" />
+  </g>
 </svg>

--- a/Numix/24x24/actions/image-gallery.svg
+++ b/Numix/24x24/actions/image-gallery.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="eog-image-gallery1.svg">
+  <metadata
+     id="metadata20">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs18" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview16"
+     showgrid="false"
+     inkscape:zoom="8"
+     inkscape:cx="-7.9322034"
+     inkscape:cy="12"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4148" />
+  </sodipodi:namedview>
+  <rect
+     style="opacity:1;fill:#b58900;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     id="rect4148"
+     width="10"
+     height="10"
+     x="1"
+     y="1.0000019"
+     rx="1"
+     ry="1" />
+  <rect
+     y="1.0000019"
+     x="13"
+     height="10"
+     width="10"
+     id="rect4150"
+     style="opacity:1;fill:#268bd2;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     ry="1"
+     rx="1" />
+  <rect
+     style="opacity:1;fill:#db3330;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     id="rect4152"
+     width="10"
+     height="10"
+     x="13"
+     y="13"
+     ry="1"
+     rx="1" />
+  <rect
+     y="13"
+     x="1"
+     height="10"
+     width="10"
+     id="rect4154"
+     style="opacity:1;fill:#4caf50;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     ry="1"
+     rx="1" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     d="m 16.8,3.699999 -1.8,2.601562 0,2.698438 6,0 0,-2.18 -1.2,-1.92 -1.2,1.2 z"
+     id="path85"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccc" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     d="m 5.9601563,14.999998 c -0.7658046,0 -1.3875,0.585386 -1.3875,1.307813 0,0.03553 0.00145,0.07228 0.0047,0.107808 C 4.4696012,16.390479 4.3604401,16.376009 4.2492266,16.375779 3.575015,16.383339 3,16.963508 3,17.685936 c 0,0.54038 0.351789,1.023546 0.885937,1.21875 -0.160129,0.218272 -0.245632,0.477394 -0.246093,0.742969 0,0.722429 0.6214638,1.307582 1.3874997,1.307813 0.318874,-4.31e-4 0.6271025,-0.103081 0.8742189,-0.292969 0.2542692,0.216428 0.5845624,0.336807 0.9281248,0.337499 0.7662665,0 1.3851563,-0.587268 1.3851563,-1.310156 C 8.2144122,19.445496 8.1411927,19.205635 8.0039062,18.998436 8.5938921,18.834615 8.9997686,18.324593 9,17.744531 9,17.021872 8.538594,16.446639 7.4742187,16.436717 c -0.045223,0 -0.090943,4.87e-4 -0.1359375,0.0047 0.00554,-0.04453 0.00868,-0.0886 0.00937,-0.133593 0,-0.722889 -0.6203094,-1.308044 -1.3874999,-1.307814 z M 6,17.03906 A 1.08,1.08 0 0 1 7.0804686,18.11953 1.08,1.08 0 0 1 6,19.199998 1.08,1.08 0 0 1 4.9195313,18.11953 1.08,1.08 0 0 1 6,17.03906 Z"
+     id="path35"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     d="m 16.634799,17.997598 c 0.1908,0.234399 0.394401,0.524799 0.240801,0.836799 C 16.400001,19.799998 15,19.399999 15,20.999998 l 6,0 c 0,-1.599999 -1.400001,-1.2 -1.8756,-2.165601 -0.1536,-0.312 0.09,-0.5748 0.240801,-0.836799 0.9168,-1.590801 0.234798,-2.997999 -1.365201,-2.997999 -1.599999,0 -2.254401,1.9044 -1.365201,2.997999 z"
+     style="fill:#ffffff;fill-opacity:1"
+     id="path47" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;fill-opacity:1"
+     d="m 2.75,5.999999 1.25,0 0,3 1,0 0,-3 2,0 0,3 1,0 0,-3 1.25,0 -3.25,-3 z"
+     id="path6"
+     sodipodi:nodetypes="cccccccccccc" />
+</svg>

--- a/Numix/24x24/actions/slideshow-play.svg
+++ b/Numix/24x24/actions/slideshow-play.svg
@@ -1,0 +1,1 @@
+media-playback-start.svg

--- a/Numix/256x256/actions/eog-image-gallery.svg
+++ b/Numix/256x256/actions/eog-image-gallery.svg
@@ -1,0 +1,1 @@
+image-gallery.svg

--- a/Numix/256x256/actions/image-gallery.svg
+++ b/Numix/256x256/actions/image-gallery.svg
@@ -5,6 +5,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="256"
@@ -13,7 +14,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="image-gallery.svg">
+   sodipodi:docname="image-gallery2.svg">
   <metadata
      id="metadata10">
     <rdf:RDF>
@@ -27,7 +28,33 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs8" />
+     id="defs8">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4220"
+       id="linearGradient4226"
+       x1="2.250833"
+       y1="4.75"
+       x2="4.7508335"
+       y2="4.75"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4220">
+      <stop
+         style="stop-color:#e2d290;stop-opacity:0.70588237"
+         offset="0"
+         id="stop4222" />
+      <stop
+         id="stop4228"
+         offset="0.50504142"
+         style="stop-color:#e2d290;stop-opacity:1" />
+      <stop
+         style="stop-color:#e2d290;stop-opacity:0.70588237"
+         offset="1"
+         id="stop4224" />
+    </linearGradient>
+  </defs>
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -41,69 +68,116 @@
      inkscape:window-height="704"
      id="namedview6"
      showgrid="false"
-     inkscape:zoom="1"
+     inkscape:zoom="0.921875"
      inkscape:cx="-84.610169"
      inkscape:cy="128"
      inkscape:window-x="0"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2" />
-  <rect
-     style="opacity:1;fill:#b58900;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     id="rect4148"
-     width="112"
-     height="112"
-     x="8"
-     y="8"
-     rx="10"
-     ry="10" />
-  <rect
-     y="8"
-     x="136"
-     height="112"
-     width="112"
-     id="rect4150"
-     style="opacity:1;fill:#268bd2;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     ry="10"
-     rx="10" />
-  <rect
-     style="opacity:1;fill:#db3330;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     id="rect4152"
-     width="112"
-     height="112"
-     x="136"
-     y="136"
-     ry="10"
-     rx="10" />
-  <rect
-     y="136"
-     x="8"
-     height="112"
-     width="112"
-     id="rect4154"
-     style="opacity:1;fill:#4caf50;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     ry="10"
-     rx="10" />
-  <path
-     style="fill:#ffffff;fill-opacity:1"
-     d="M 174.39998,39.99999 152,74.68751 l 0,29.31247 79.99998,0 0,-22.39999 -16,-25.6 -16,16 z"
-     id="path85"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="cccccccc" />
-  <path
-     style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
-     d="m 63.468758,152.01598 c -10.21074,0 -18.5,7.80516 -18.5,17.43752 0,0.47376 0.02,0.96368 0.0624,1.43744 -1.43664,-0.3352 -2.89216,-0.52816 -4.37502,-0.5312 -8.98944,0.1008 -16.6563,7.83636 -16.6563,17.46876 0,7.20504 4.69052,13.64728 11.8125,16.25 -2.13506,2.91028 -3.2751,6.36524 -3.28126,9.90624 0,9.6324 8.2862,17.43444 18.5,17.43752 4.25166,-0.004 8.36136,-1.3744 11.65626,-3.90628 3.39026,2.88572 7.79416,4.49076 12.375,4.5 10.21688,0 18.46876,-7.83024 18.46876,-17.46876 -0.006,-3.25792 -0.98204,-6.45608 -2.81252,-9.21872 7.86648,-2.18428 13.278182,-8.98456 13.281262,-16.71876 0,-9.63544 -6.152082,-17.3052 -20.343742,-17.43748 -0.60296,0 -1.21258,0.008 -1.81252,0.0624 0.0736,-0.59376 0.1156,-1.18128 0.125,-1.78128 0,-9.63848 -8.27078,-17.44056 -18.5,-17.43748 z m 0.5312,27.18752 a 14.399999,14.399999 0 0 1 14.40624,14.40624 14.399999,14.399999 0 0 1 -14.40624,14.40624 14.399999,14.399999 0 0 1 -14.40626,-14.40624 14.399999,14.399999 0 0 1 14.40626,-14.40624 z"
-     id="path35"
-     inkscape:connector-curvature="0" />
-  <path
-     inkscape:connector-curvature="0"
-     d="m 173.79734,191.96798 c 2.544,3.12532 5.25864,6.99732 3.21064,11.15732 C 170.66666,215.99998 152,210.66666 152,231.99998 l 79.99998,0 c 0,-21.33332 -18.66668,-16 -25.008,-28.87468 -2.048,-4.16 1.2,-7.664 3.21068,-11.15732 12.224,-21.21068 3.13064,-39.97332 -18.20268,-39.97332 -21.33332,0 -30.05866,25.392 -18.20264,39.97332 z"
-     style="fill:#ffffff;fill-opacity:1"
-     id="path47" />
-  <path
-     inkscape:connector-curvature="0"
-     style="fill:#ffffff;fill-opacity:1"
-     d="m 23.999998,55.99999 16,0 0,47.99999 16,0 0,-47.99999 16,0 0,47.99999 16,0 0,-47.99999 16.000002,0 -40.000002,-32 z"
-     id="path6"
-     sodipodi:nodetypes="cccccccccccc" />
+  <g
+     id="g4193"
+     transform="matrix(16,0,0,16,-8,-8)">
+    <rect
+       y="9"
+       x="9"
+       height="7"
+       width="7"
+       id="rect4152"
+       style="opacity:1;fill:#b8ccd3;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061" />
+    <path
+       sodipodi:nodetypes="sccccccs"
+       inkscape:connector-curvature="0"
+       id="path47"
+       d="m 12.5,10.758559 c -1.333334,0 -1.877719,1.586714 -1.136719,2.498047 0.159,0.195333 0.327219,0.437266 0.199219,0.697265 -0.06464,0.131242 -0.152777,0.225729 -0.25,0.308594 0.33573,0.897327 1.930206,1.06583 2.375,0 -0.09722,-0.08286 -0.185358,-0.177352 -0.25,-0.308594 -0.128,-0.259999 0.07355,-0.478932 0.199219,-0.697265 0.764,-1.325667 0.196614,-2.498047 -1.136719,-2.498047 z"
+       style="fill:#e5b58b;fill-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccccsc"
+       inkscape:connector-curvature="0"
+       id="path4183"
+       d="M 11.3125,14.264 C 10.813633,14.757376 10,14.705201 10,16 l 5,0 c 0,-1.294799 -0.813633,-1.242624 -1.3125,-1.736 -0.359087,0.291488 -0.758149,0.476 -1.1875,0.476 -0.429351,0 -0.828413,-0.184512 -1.1875,-0.476 z"
+       style="opacity:1;fill:#cf362d;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061" />
+    <path
+       sodipodi:nodetypes="czcc"
+       inkscape:connector-curvature="0"
+       id="path75"
+       d="m 11,12.225356 c 0.465721,-0.324686 0.750318,-0.762784 1.5,-0.766797 0.749682,-0.004 1.066025,0.398033 1.5,0.655469 0.0332,-2.041425 -3.042969,-1.941397 -3,0.111328 z"
+       style="fill:#96413c;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+  </g>
+  <g
+     id="g4187"
+     transform="matrix(16,0,0,16,-8,8)">
+    <rect
+       style="opacity:1;fill:#3db2e1;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+       id="rect4150"
+       width="7"
+       height="7"
+       x="9"
+       y="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path85"
+       style="fill:#a2866a;fill-opacity:1"
+       d="M 13.943376,3.45 10,7 16,7 16,6 Z" />
+    <path
+       id="path87"
+       style="fill:#e5d740;fill-opacity:1"
+       d="m 13,2 c 0,0.5234285 -0.476572,1 -1,1 -0.523429,0 -1,-0.4765715 -1,-1 0,-0.5234286 0.476571,-1.00000011 1,-1.00000011 0.523428,0 1,0.47657151 1,1.00000011 z"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path91"
+       style="fill:#94785c;fill-opacity:1"
+       d="M 11.352941,2.5 9,5.4 9,7 14,7 Z" />
+  </g>
+  <g
+     id="g4199"
+     transform="matrix(16,0,0,16,8,-8)">
+    <rect
+       style="opacity:1;fill:#4fb45e;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+       id="rect4154"
+       width="7"
+       height="7"
+       x="0"
+       y="9" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path35"
+       d="m 3.4667969,9.901 c -0.6381705,0 -1.15625,0.487821 -1.15625,1.089844 0,0.02961 0.00121,0.06023 0.00391,0.08984 -0.089792,-0.02095 -0.1807596,-0.03301 -0.2734375,-0.0332 C 1.4791788,11.05383 1,11.537258 1,12.139281 c 0,0.450317 0.2931574,0.852956 0.7382812,1.015626 -0.133441,0.181893 -0.2046935,0.397828 -0.2050781,0.61914 0,0.602024 0.5178867,1.089652 1.15625,1.089844 0.2657283,-3.59e-4 0.5225854,-0.0859 0.7285157,-0.244141 0.211891,0.180357 0.4871354,0.280673 0.7734374,0.28125 0.6385554,0 1.1542969,-0.48939 1.1542969,-1.091797 C 5.3453435,13.605581 5.2843266,13.405697 5.1699219,13.233031 5.6615767,13.096514 5.9998072,12.671496 6,12.18811 6,11.585895 5.615495,11.106534 4.7285156,11.098266 c -0.037686,0 -0.075786,4.06e-4 -0.1132812,0.0039 0.00461,-0.03711 0.00723,-0.07383 0.00781,-0.111328 0,-0.602407 -0.5169246,-1.090036 -1.15625,-1.089844 z M 3.5,11.600219 A 0.89999998,0.89999998 0 0 1 4.4003906,12.50061 0.89999998,0.89999998 0 0 1 3.5,13.401 0.89999998,0.89999998 0 0 1 2.5996094,12.50061 0.89999998,0.89999998 0 0 1 3.5,11.600219 Z"
+       style="opacity:1;fill:#f1ef5d;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <circle
+       id="circle47"
+       style="fill:#9d8d6d;fill-opacity:1;stroke:none"
+       r="0.60000002"
+       cy="12.500218"
+       cx="3.5" />
+  </g>
+  <g
+     id="g4181"
+     transform="matrix(16,0,0,16,8,8)">
+    <rect
+       y="0"
+       x="0"
+       height="7"
+       width="7"
+       id="rect4148"
+       style="opacity:1;fill:#3c345d;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061" />
+    <path
+       id="path46"
+       style="opacity:1;fill:url(#linearGradient4226);fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 4.3645834,3.5 c -0.2702083,0.026873 -0.5589583,0.043674 -0.86375,0.043674 -0.305,0 -0.59375,-0.016801 -0.86375,-0.043674 L 2.250833,5.7830955 c 0.8416671,0.2996354 1.6770837,0.2785851 2.5000004,0 z"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path52"
+       style="opacity:1;fill:#787878;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="M 6,2.4454545 C 6,2.8220454 4.8806251,3.15 3.5000001,3.15 2.119375,3.15 1,2.8220454 1,2.4454545 1,2.0688637 2.119375,1.65 3.5000001,1.65 4.8806251,1.65 6,2.0688637 6,2.4454545 Z"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path54"
+       style="opacity:1;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 4.5416667,2.0499999 c 0,0.21 -0.4664583,0.399 -1.0416666,0.399 -0.5752084,0 -1.0416667,-0.189 -1.0416667,-0.399 C 2.4583334,1.4199999 2.8750001,1 3.5000001,1 c 0.625,0 1.0416666,0.4199999 1.0416666,1.0499999 z"
+       inkscape:connector-curvature="0" />
+  </g>
 </svg>

--- a/Numix/256x256/actions/image-gallery.svg
+++ b/Numix/256x256/actions/image-gallery.svg
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="256"
+   height="256"
+   viewBox="0 0 256 256"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="image-gallery.svg">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="-84.610169"
+     inkscape:cy="128"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <rect
+     style="opacity:1;fill:#b58900;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     id="rect4148"
+     width="112"
+     height="112"
+     x="8"
+     y="8"
+     rx="10"
+     ry="10" />
+  <rect
+     y="8"
+     x="136"
+     height="112"
+     width="112"
+     id="rect4150"
+     style="opacity:1;fill:#268bd2;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     ry="10"
+     rx="10" />
+  <rect
+     style="opacity:1;fill:#db3330;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     id="rect4152"
+     width="112"
+     height="112"
+     x="136"
+     y="136"
+     ry="10"
+     rx="10" />
+  <rect
+     y="136"
+     x="8"
+     height="112"
+     width="112"
+     id="rect4154"
+     style="opacity:1;fill:#4caf50;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     ry="10"
+     rx="10" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     d="M 174.39998,39.99999 152,74.68751 l 0,29.31247 79.99998,0 0,-22.39999 -16,-25.6 -16,16 z"
+     id="path85"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccc" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     d="m 63.468758,152.01598 c -10.21074,0 -18.5,7.80516 -18.5,17.43752 0,0.47376 0.02,0.96368 0.0624,1.43744 -1.43664,-0.3352 -2.89216,-0.52816 -4.37502,-0.5312 -8.98944,0.1008 -16.6563,7.83636 -16.6563,17.46876 0,7.20504 4.69052,13.64728 11.8125,16.25 -2.13506,2.91028 -3.2751,6.36524 -3.28126,9.90624 0,9.6324 8.2862,17.43444 18.5,17.43752 4.25166,-0.004 8.36136,-1.3744 11.65626,-3.90628 3.39026,2.88572 7.79416,4.49076 12.375,4.5 10.21688,0 18.46876,-7.83024 18.46876,-17.46876 -0.006,-3.25792 -0.98204,-6.45608 -2.81252,-9.21872 7.86648,-2.18428 13.278182,-8.98456 13.281262,-16.71876 0,-9.63544 -6.152082,-17.3052 -20.343742,-17.43748 -0.60296,0 -1.21258,0.008 -1.81252,0.0624 0.0736,-0.59376 0.1156,-1.18128 0.125,-1.78128 0,-9.63848 -8.27078,-17.44056 -18.5,-17.43748 z m 0.5312,27.18752 a 14.399999,14.399999 0 0 1 14.40624,14.40624 14.399999,14.399999 0 0 1 -14.40624,14.40624 14.399999,14.399999 0 0 1 -14.40626,-14.40624 14.399999,14.399999 0 0 1 14.40626,-14.40624 z"
+     id="path35"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     d="m 173.79734,191.96798 c 2.544,3.12532 5.25864,6.99732 3.21064,11.15732 C 170.66666,215.99998 152,210.66666 152,231.99998 l 79.99998,0 c 0,-21.33332 -18.66668,-16 -25.008,-28.87468 -2.048,-4.16 1.2,-7.664 3.21068,-11.15732 12.224,-21.21068 3.13064,-39.97332 -18.20268,-39.97332 -21.33332,0 -30.05866,25.392 -18.20264,39.97332 z"
+     style="fill:#ffffff;fill-opacity:1"
+     id="path47" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;fill-opacity:1"
+     d="m 23.999998,55.99999 16,0 0,47.99999 16,0 0,-47.99999 16,0 0,47.99999 16,0 0,-47.99999 16.000002,0 -40.000002,-32 z"
+     id="path6"
+     sodipodi:nodetypes="cccccccccccc" />
+</svg>

--- a/Numix/256x256/actions/slideshow-play.svg
+++ b/Numix/256x256/actions/slideshow-play.svg
@@ -1,0 +1,1 @@
+media-playback-start.svg

--- a/Numix/32x32/actions/eog-image-gallery.svg
+++ b/Numix/32x32/actions/eog-image-gallery.svg
@@ -1,0 +1,1 @@
+image-gallery.svg

--- a/Numix/32x32/actions/image-gallery.svg
+++ b/Numix/32x32/actions/image-gallery.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   height="32"
+   viewBox="0 0 32 32"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="eog-image-gallery.svg">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="11.313708"
+     inkscape:cx="9.1298572"
+     inkscape:cy="16"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4160" />
+  </sodipodi:namedview>
+  <rect
+     style="opacity:1;fill:#b58900;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     id="rect4148"
+     width="14"
+     height="14"
+     x="1"
+     y="1"
+     rx="2"
+     ry="2" />
+  <rect
+     y="1"
+     x="17"
+     height="14"
+     width="14"
+     id="rect4150"
+     style="opacity:1;fill:#268bd2;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     ry="2"
+     rx="2" />
+  <rect
+     style="opacity:1;fill:#db3330;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     id="rect4152"
+     width="14"
+     height="14"
+     x="17"
+     y="17"
+     ry="2"
+     rx="2" />
+  <rect
+     y="17"
+     x="1"
+     height="14"
+     width="14"
+     id="rect4154"
+     style="opacity:1;fill:#4caf50;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     ry="2"
+     rx="2" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     d="m 21.8,4.9999991 -2.8,4.3359378 0,3.6640621 9.999999,0 0,-2.8 -2,-3.2 -1.999999,2 z"
+     id="path85"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccc" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     d="m 7.9335948,19.002 c -1.276342,0 -2.3125,0.975642 -2.3125,2.179688 0,0.05922 0.0024,0.12046 0.0078,0.17968 -0.17958,-0.0419 -0.36152,-0.06602 -0.5468763,-0.0664 -1.12368,0.0126 -2.082038,0.979548 -2.082038,2.183594 0,0.900634 0.586314,1.705912 1.476562,2.031252 -0.266882,0.363786 -0.409386,0.795656 -0.410156,1.23828 0,1.204048 1.035774,2.179304 2.3125003,2.179688 0.531456,-7.18e-4 1.04517,-0.1718 1.457032,-0.488282 0.423782,0.360714 0.9742699,0.561346 1.5468739,0.5625 1.2771113,0 2.3085943,-0.97878 2.3085943,-2.183594 -7.2e-4,-0.407244 -0.122754,-0.807012 -0.351563,-1.152344 0.98331,-0.273034 1.659771,-1.12307 1.660156,-2.089842 0,-1.20443 -0.76901,-2.163152 -2.542968,-2.179688 -0.07537,0 -0.151572,8.12e-4 -0.226563,0.0078 0.0092,-0.07422 0.01446,-0.14766 0.01562,-0.222656 0,-1.204814 -1.0338483,-2.180072 -2.3125002,-2.179688 z m 0.0664,3.398438 A 1.7999999,1.7999999 0 0 1 9.8007757,24.20122 1.7999999,1.7999999 0 0 1 7.9999948,26.002 1.7999999,1.7999999 0 0 1 6.1992128,24.20122 1.7999999,1.7999999 0 0 1 7.9999948,22.400438 Z"
+     id="path35"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     d="m 21.724666,23.996 c 0.318,0.390666 0.657334,0.874666 0.401334,1.394666 C 21.333334,27 19,26.333334 19,29 l 9.999999,0 c 0,-2.666666 -2.333334,-2 -3.126,-3.609334 -0.256,-0.52 0.15,-0.958 0.401334,-1.394666 1.528,-2.651334 0.391332,-4.996666 -2.275333,-4.996666 -2.666666,0 -3.757334,3.174 -2.275334,4.996666 z"
+     style="fill:#ffffff;fill-opacity:1"
+     id="path47" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;fill-opacity:1"
+     d="m 3.0000005,6.999999 2,0 0,6 2.0000003,0 0,-6 1.9999999,0 0,6 1.9999993,0 0,-6 2,0 -4.9999992,-3.9999998 z"
+     id="path6"
+     sodipodi:nodetypes="cccccccccccc" />
+</svg>

--- a/Numix/32x32/actions/image-gallery.svg
+++ b/Numix/32x32/actions/image-gallery.svg
@@ -5,6 +5,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="32"
@@ -13,7 +14,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="eog-image-gallery.svg">
+   sodipodi:docname="eog-image-gallery1.svg">
   <metadata
      id="metadata12">
     <rdf:RDF>
@@ -27,7 +28,33 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs10" />
+     id="defs10">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4220"
+       id="linearGradient4226"
+       x1="2.250833"
+       y1="4.75"
+       x2="4.7508335"
+       y2="4.75"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4220">
+      <stop
+         style="stop-color:#e2d290;stop-opacity:0.70588237"
+         offset="0"
+         id="stop4222" />
+      <stop
+         id="stop4228"
+         offset="0.50504142"
+         style="stop-color:#e2d290;stop-opacity:1" />
+      <stop
+         style="stop-color:#e2d290;stop-opacity:0.70588237"
+         offset="1"
+         id="stop4224" />
+    </linearGradient>
+  </defs>
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -52,62 +79,109 @@
        type="xygrid"
        id="grid4160" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#b58900;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     id="rect4148"
-     width="14"
-     height="14"
-     x="1"
-     y="1"
-     rx="2"
-     ry="2" />
-  <rect
-     y="1"
-     x="17"
-     height="14"
-     width="14"
-     id="rect4150"
-     style="opacity:1;fill:#268bd2;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     ry="2"
-     rx="2" />
-  <rect
-     style="opacity:1;fill:#db3330;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     id="rect4152"
-     width="14"
-     height="14"
-     x="17"
-     y="17"
-     ry="2"
-     rx="2" />
-  <rect
-     y="17"
-     x="1"
-     height="14"
-     width="14"
-     id="rect4154"
-     style="opacity:1;fill:#4caf50;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     ry="2"
-     rx="2" />
-  <path
-     style="fill:#ffffff;fill-opacity:1"
-     d="m 21.8,4.9999991 -2.8,4.3359378 0,3.6640621 9.999999,0 0,-2.8 -2,-3.2 -1.999999,2 z"
-     id="path85"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="cccccccc" />
-  <path
-     style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
-     d="m 7.9335948,19.002 c -1.276342,0 -2.3125,0.975642 -2.3125,2.179688 0,0.05922 0.0024,0.12046 0.0078,0.17968 -0.17958,-0.0419 -0.36152,-0.06602 -0.5468763,-0.0664 -1.12368,0.0126 -2.082038,0.979548 -2.082038,2.183594 0,0.900634 0.586314,1.705912 1.476562,2.031252 -0.266882,0.363786 -0.409386,0.795656 -0.410156,1.23828 0,1.204048 1.035774,2.179304 2.3125003,2.179688 0.531456,-7.18e-4 1.04517,-0.1718 1.457032,-0.488282 0.423782,0.360714 0.9742699,0.561346 1.5468739,0.5625 1.2771113,0 2.3085943,-0.97878 2.3085943,-2.183594 -7.2e-4,-0.407244 -0.122754,-0.807012 -0.351563,-1.152344 0.98331,-0.273034 1.659771,-1.12307 1.660156,-2.089842 0,-1.20443 -0.76901,-2.163152 -2.542968,-2.179688 -0.07537,0 -0.151572,8.12e-4 -0.226563,0.0078 0.0092,-0.07422 0.01446,-0.14766 0.01562,-0.222656 0,-1.204814 -1.0338483,-2.180072 -2.3125002,-2.179688 z m 0.0664,3.398438 A 1.7999999,1.7999999 0 0 1 9.8007757,24.20122 1.7999999,1.7999999 0 0 1 7.9999948,26.002 1.7999999,1.7999999 0 0 1 6.1992128,24.20122 1.7999999,1.7999999 0 0 1 7.9999948,22.400438 Z"
-     id="path35"
-     inkscape:connector-curvature="0" />
-  <path
-     inkscape:connector-curvature="0"
-     d="m 21.724666,23.996 c 0.318,0.390666 0.657334,0.874666 0.401334,1.394666 C 21.333334,27 19,26.333334 19,29 l 9.999999,0 c 0,-2.666666 -2.333334,-2 -3.126,-3.609334 -0.256,-0.52 0.15,-0.958 0.401334,-1.394666 1.528,-2.651334 0.391332,-4.996666 -2.275333,-4.996666 -2.666666,0 -3.757334,3.174 -2.275334,4.996666 z"
-     style="fill:#ffffff;fill-opacity:1"
-     id="path47" />
-  <path
-     inkscape:connector-curvature="0"
-     style="fill:#ffffff;fill-opacity:1"
-     d="m 3.0000005,6.999999 2,0 0,6 2.0000003,0 0,-6 1.9999999,0 0,6 1.9999993,0 0,-6 2,0 -4.9999992,-3.9999998 z"
-     id="path6"
-     sodipodi:nodetypes="cccccccccccc" />
+  <g
+     id="g4193"
+     transform="matrix(2,0,0,2,-1,-1)">
+    <rect
+       y="9"
+       x="9"
+       height="7"
+       width="7"
+       id="rect4152"
+       style="opacity:1;fill:#b8ccd3;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061" />
+    <path
+       sodipodi:nodetypes="sccccccs"
+       inkscape:connector-curvature="0"
+       id="path47"
+       d="m 12.5,10.758559 c -1.333334,0 -1.877719,1.586714 -1.136719,2.498047 0.159,0.195333 0.327219,0.437266 0.199219,0.697265 -0.06464,0.131242 -0.152777,0.225729 -0.25,0.308594 0.33573,0.897327 1.930206,1.06583 2.375,0 -0.09722,-0.08286 -0.185358,-0.177352 -0.25,-0.308594 -0.128,-0.259999 0.07355,-0.478932 0.199219,-0.697265 0.764,-1.325667 0.196614,-2.498047 -1.136719,-2.498047 z"
+       style="fill:#e5b58b;fill-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccccsc"
+       inkscape:connector-curvature="0"
+       id="path4183"
+       d="M 11.3125,14.264 C 10.813633,14.757376 10,14.705201 10,16 l 5,0 c 0,-1.294799 -0.813633,-1.242624 -1.3125,-1.736 -0.359087,0.291488 -0.758149,0.476 -1.1875,0.476 -0.429351,0 -0.828413,-0.184512 -1.1875,-0.476 z"
+       style="opacity:1;fill:#cf362d;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061" />
+    <path
+       sodipodi:nodetypes="czcc"
+       inkscape:connector-curvature="0"
+       id="path75"
+       d="m 11,12.225356 c 0.465721,-0.324686 0.750318,-0.762784 1.5,-0.766797 0.749682,-0.004 1.066025,0.398033 1.5,0.655469 0.0332,-2.041425 -3.042969,-1.941397 -3,0.111328 z"
+       style="fill:#96413c;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+  </g>
+  <g
+     id="g4187"
+     transform="matrix(2,0,0,2,-1,1)">
+    <rect
+       style="opacity:1;fill:#3db2e1;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+       id="rect4150"
+       width="7"
+       height="7"
+       x="9"
+       y="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path85"
+       style="fill:#a2866a;fill-opacity:1"
+       d="M 13.943376,3.45 10,7 16,7 16,6 Z" />
+    <path
+       id="path87"
+       style="fill:#e5d740;fill-opacity:1"
+       d="m 13,2 c 0,0.5234285 -0.476572,1 -1,1 -0.523429,0 -1,-0.4765715 -1,-1 0,-0.5234286 0.476571,-1.00000011 1,-1.00000011 0.523428,0 1,0.47657151 1,1.00000011 z"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path91"
+       style="fill:#94785c;fill-opacity:1"
+       d="M 11.352941,2.5 9,5.4 9,7 14,7 Z" />
+  </g>
+  <g
+     id="g4199"
+     transform="matrix(2,0,0,2,1,-1)">
+    <rect
+       style="opacity:1;fill:#4fb45e;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+       id="rect4154"
+       width="7"
+       height="7"
+       x="0"
+       y="9" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path35"
+       d="m 3.4667969,9.901 c -0.6381705,0 -1.15625,0.487821 -1.15625,1.089844 0,0.02961 0.00121,0.06023 0.00391,0.08984 -0.089792,-0.02095 -0.1807596,-0.03301 -0.2734375,-0.0332 C 1.4791788,11.05383 1,11.537258 1,12.139281 c 0,0.450317 0.2931574,0.852956 0.7382812,1.015626 -0.133441,0.181893 -0.2046935,0.397828 -0.2050781,0.61914 0,0.602024 0.5178867,1.089652 1.15625,1.089844 0.2657283,-3.59e-4 0.5225854,-0.0859 0.7285157,-0.244141 0.211891,0.180357 0.4871354,0.280673 0.7734374,0.28125 0.6385554,0 1.1542969,-0.48939 1.1542969,-1.091797 C 5.3453435,13.605581 5.2843266,13.405697 5.1699219,13.233031 5.6615767,13.096514 5.9998072,12.671496 6,12.18811 6,11.585895 5.615495,11.106534 4.7285156,11.098266 c -0.037686,0 -0.075786,4.06e-4 -0.1132812,0.0039 0.00461,-0.03711 0.00723,-0.07383 0.00781,-0.111328 0,-0.602407 -0.5169246,-1.090036 -1.15625,-1.089844 z M 3.5,11.600219 A 0.89999998,0.89999998 0 0 1 4.4003906,12.50061 0.89999998,0.89999998 0 0 1 3.5,13.401 0.89999998,0.89999998 0 0 1 2.5996094,12.50061 0.89999998,0.89999998 0 0 1 3.5,11.600219 Z"
+       style="opacity:1;fill:#f1ef5d;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <circle
+       id="circle47"
+       style="fill:#9d8d6d;fill-opacity:1;stroke:none"
+       r="0.60000002"
+       cy="12.500218"
+       cx="3.5" />
+  </g>
+  <g
+     id="g4181"
+     transform="matrix(2,0,0,2,1,1)">
+    <rect
+       y="0"
+       x="0"
+       height="7"
+       width="7"
+       id="rect4148"
+       style="opacity:1;fill:#3c345d;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061" />
+    <path
+       id="path46"
+       style="opacity:1;fill:url(#linearGradient4226);fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 4.3645834,3.5 c -0.2702083,0.026873 -0.5589583,0.043674 -0.86375,0.043674 -0.305,0 -0.59375,-0.016801 -0.86375,-0.043674 L 2.250833,5.7830955 c 0.8416671,0.2996354 1.6770837,0.2785851 2.5000004,0 z"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path52"
+       style="opacity:1;fill:#787878;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="M 6,2.4454545 C 6,2.8220454 4.8806251,3.15 3.5000001,3.15 2.119375,3.15 1,2.8220454 1,2.4454545 1,2.0688637 2.119375,1.65 3.5000001,1.65 4.8806251,1.65 6,2.0688637 6,2.4454545 Z"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path54"
+       style="opacity:1;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 4.5416667,2.0499999 c 0,0.21 -0.4664583,0.399 -1.0416666,0.399 -0.5752084,0 -1.0416667,-0.189 -1.0416667,-0.399 C 2.4583334,1.4199999 2.8750001,1 3.5000001,1 c 0.625,0 1.0416666,0.4199999 1.0416666,1.0499999 z"
+       inkscape:connector-curvature="0" />
+  </g>
 </svg>

--- a/Numix/32x32/actions/slideshow-play.svg
+++ b/Numix/32x32/actions/slideshow-play.svg
@@ -1,0 +1,1 @@
+media-playback-start.svg

--- a/Numix/48x48/actions/eog-image-gallery.svg
+++ b/Numix/48x48/actions/eog-image-gallery.svg
@@ -1,0 +1,1 @@
+image-gallery.svg

--- a/Numix/48x48/actions/image-gallery.svg
+++ b/Numix/48x48/actions/image-gallery.svg
@@ -5,6 +5,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="48"
@@ -13,7 +14,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="eog-image-gallery1.svg">
+   sodipodi:docname="eog-image-gallery.svg">
   <metadata
      id="metadata18">
     <rdf:RDF>
@@ -27,7 +28,34 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs16" />
+     id="defs16">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4220"
+       id="linearGradient4226"
+       x1="2.250833"
+       y1="4.75"
+       x2="4.7508335"
+       y2="4.75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.97188003,0,0.16871985)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4220">
+      <stop
+         style="stop-color:#e2d290;stop-opacity:0.70588237"
+         offset="0"
+         id="stop4222" />
+      <stop
+         id="stop4228"
+         offset="0.50504142"
+         style="stop-color:#e2d290;stop-opacity:1" />
+      <stop
+         style="stop-color:#e2d290;stop-opacity:0.70588237"
+         offset="1"
+         id="stop4224" />
+    </linearGradient>
+  </defs>
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -40,7 +68,7 @@
      inkscape:window-width="1366"
      inkscape:window-height="704"
      id="namedview14"
-     showgrid="true"
+     showgrid="false"
      inkscape:zoom="1"
      inkscape:cx="14.673567"
      inkscape:cy="31.071068"
@@ -52,62 +80,110 @@
        type="xygrid"
        id="grid4146" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#b58900;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     id="rect4148"
-     width="20"
-     height="20"
-     x="2"
-     y="2.0000038"
-     rx="2"
-     ry="2" />
-  <rect
-     y="2.0000038"
-     x="26"
-     height="20"
-     width="20"
-     id="rect4150"
-     style="opacity:1;fill:#268bd2;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     ry="2"
-     rx="2" />
-  <rect
-     style="opacity:1;fill:#db3330;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     id="rect4152"
-     width="20"
-     height="20"
-     x="26"
-     y="26"
-     ry="2"
-     rx="2" />
-  <rect
-     y="26"
-     x="2"
-     height="20"
-     width="20"
-     id="rect4154"
-     style="opacity:1;fill:#4caf50;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     ry="2"
-     rx="2" />
-  <path
-     style="fill:#ffffff;fill-opacity:1"
-     d="m 33.6,7.399998 -3.6,5.203124 0,5.396876 12,0 0,-4.36 -2.4,-3.84 -2.4,2.4 z"
-     id="path85"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="cccccccc" />
-  <path
-     style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
-     d="m 11.920313,29.999996 c -1.53161,0 -2.775,1.170772 -2.775,2.615626 0,0.07106 0.0029,0.14456 0.0094,0.215616 C 8.939202,32.780958 8.72088,32.752018 8.498453,32.751558 7.15003,32.766678 6,33.927016 6,35.371872 c 0,1.08076 0.703578,2.047092 1.771874,2.4375 -0.320258,0.436544 -0.491264,0.954788 -0.492186,1.485938 0,1.444858 1.242928,2.615164 2.774999,2.615626 0.637748,-8.62e-4 1.254205,-0.206162 1.748438,-0.585938 0.508539,0.432856 1.169125,0.673614 1.85625,0.674998 1.532533,0 2.770313,-1.174536 2.770313,-2.620312 -8.64e-4,-0.488692 -0.1473,-0.968414 -0.421876,-1.382812 1.179972,-0.327642 1.991726,-1.347686 1.992188,-2.50781 0,-1.445318 -0.922812,-2.595784 -3.051562,-2.615628 -0.09044,0 -0.18188,9.74e-4 -0.271876,0.0094 0.011,-0.08906 0.0174,-0.1772 0.0188,-0.267186 0,-1.445778 -1.240618,-2.616088 -2.774999,-2.615628 z M 12,34.07812 A 2.16,2.16 0 0 1 14.160938,36.23906 2.16,2.16 0 0 1 12,38.399996 2.16,2.16 0 0 1 9.839063,36.23906 2.16,2.16 0 0 1 12,34.07812 Z"
-     id="path35"
-     inkscape:connector-curvature="0" />
-  <path
-     inkscape:connector-curvature="0"
-     d="m 33.269598,35.995196 c 0.3816,0.468798 0.788802,1.049598 0.481602,1.673598 C 32.800002,39.599996 30,38.799998 30,41.999996 l 12,0 c 0,-3.199998 -2.800002,-2.4 -3.7512,-4.331202 -0.3072,-0.624 0.18,-1.1496 0.481602,-1.673598 1.8336,-3.181602 0.469596,-5.995998 -2.730402,-5.995998 -3.199998,0 -4.508802,3.8088 -2.730402,5.995998 z"
-     style="fill:#ffffff;fill-opacity:1"
-     id="path47" />
-  <path
-     inkscape:connector-curvature="0"
-     style="fill:#ffffff;fill-opacity:1"
-     d="m 5.5,11.999998 2.5,0 0,6 2,0 0,-6 4,0 0,6 2,0 0,-6 2.5,0 -6.5,-6 z"
-     id="path6"
-     sodipodi:nodetypes="cccccccccccc" />
+  <g
+     id="g4193"
+     transform="matrix(2.8571429,0,0,2.8571429,0.285714,0.2857136)">
+    <rect
+       y="9"
+       x="9"
+       height="7"
+       width="7"
+       id="rect4152"
+       style="opacity:1;fill:#b8ccd3;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061" />
+    <path
+       sodipodi:nodetypes="sccccccs"
+       inkscape:connector-curvature="0"
+       id="path47"
+       d="m 12.5,10.758559 c -1.333334,0 -1.877719,1.586714 -1.136719,2.498047 0.159,0.195333 0.327219,0.437266 0.199219,0.697265 -0.06464,0.131242 -0.152777,0.225729 -0.25,0.308594 0.33573,0.897327 1.930206,1.06583 2.375,0 -0.09722,-0.08286 -0.185358,-0.177352 -0.25,-0.308594 -0.128,-0.259999 0.07355,-0.478932 0.199219,-0.697265 0.764,-1.325667 0.196614,-2.498047 -1.136719,-2.498047 z"
+       style="fill:#e5b58b;fill-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccccsc"
+       inkscape:connector-curvature="0"
+       id="path4183"
+       d="M 11.3125,14.264 C 10.813633,14.757376 10,14.705201 10,16 l 5,0 c 0,-1.294799 -0.813633,-1.242624 -1.3125,-1.736 -0.359087,0.291488 -0.758149,0.476 -1.1875,0.476 -0.429351,0 -0.828413,-0.184512 -1.1875,-0.476 z"
+       style="opacity:1;fill:#cf362d;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061" />
+    <path
+       sodipodi:nodetypes="czcc"
+       inkscape:connector-curvature="0"
+       id="path75"
+       d="m 11,12.225356 c 0.465721,-0.324686 0.750318,-0.762784 1.5,-0.766797 0.749682,-0.004 1.066025,0.398033 1.5,0.655469 0.0332,-2.041425 -3.042969,-1.941397 -3,0.111328 z"
+       style="fill:#96413c;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+  </g>
+  <g
+     id="g4187"
+     transform="matrix(2.8571429,0,0,2.8571429,0.285714,1.9999996)">
+    <rect
+       style="opacity:1;fill:#3db2e1;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+       id="rect4150"
+       width="7"
+       height="7"
+       x="9"
+       y="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path85"
+       style="fill:#a2866a;fill-opacity:1"
+       d="M 13.943376,3.45 10,7 16,7 16,6 Z" />
+    <path
+       id="path87"
+       style="fill:#e5d740;fill-opacity:1"
+       d="m 13,2 c 0,0.5234285 -0.476572,1 -1,1 -0.523429,0 -1,-0.4765715 -1,-1 0,-0.5234286 0.476571,-1.00000011 1,-1.00000011 0.523428,0 1,0.47657151 1,1.00000011 z"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path91"
+       style="fill:#94785c;fill-opacity:1"
+       d="M 11.352941,2.5 9,5.4 9,7 14,7 Z" />
+  </g>
+  <g
+     id="g4199"
+     transform="matrix(2.8571429,0,0,2.8571429,2,0.2857136)">
+    <rect
+       style="opacity:1;fill:#4fb45e;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+       id="rect4154"
+       width="7"
+       height="7"
+       x="0"
+       y="9" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path35"
+       d="m 3.4667969,9.901 c -0.6381705,0 -1.15625,0.487821 -1.15625,1.089844 0,0.02961 0.00121,0.06023 0.00391,0.08984 -0.089792,-0.02095 -0.1807596,-0.03301 -0.2734375,-0.0332 C 1.4791788,11.05383 1,11.537258 1,12.139281 c 0,0.450317 0.2931574,0.852956 0.7382812,1.015626 -0.133441,0.181893 -0.2046935,0.397828 -0.2050781,0.61914 0,0.602024 0.5178867,1.089652 1.15625,1.089844 0.2657283,-3.59e-4 0.5225854,-0.0859 0.7285157,-0.244141 0.211891,0.180357 0.4871354,0.280673 0.7734374,0.28125 0.6385554,0 1.1542969,-0.48939 1.1542969,-1.091797 C 5.3453435,13.605581 5.2843266,13.405697 5.1699219,13.233031 5.6615767,13.096514 5.9998072,12.671496 6,12.18811 6,11.585895 5.615495,11.106534 4.7285156,11.098266 c -0.037686,0 -0.075786,4.06e-4 -0.1132812,0.0039 0.00461,-0.03711 0.00723,-0.07383 0.00781,-0.111328 0,-0.602407 -0.5169246,-1.090036 -1.15625,-1.089844 z M 3.5,11.600219 A 0.89999998,0.89999998 0 0 1 4.4003906,12.50061 0.89999998,0.89999998 0 0 1 3.5,13.401 0.89999998,0.89999998 0 0 1 2.5996094,12.50061 0.89999998,0.89999998 0 0 1 3.5,11.600219 Z"
+       style="opacity:1;fill:#f1ef5d;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <circle
+       id="circle47"
+       style="fill:#9d8d6d;fill-opacity:1;stroke:none"
+       r="0.60000002"
+       cy="12.500218"
+       cx="3.5" />
+  </g>
+  <g
+     id="g4181"
+     transform="matrix(2.8571429,0,0,2.8571429,2,1.9999996)">
+    <rect
+       y="0"
+       x="0"
+       height="7"
+       width="7"
+       id="rect4148"
+       style="opacity:1;fill:#3c345d;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061" />
+    <path
+       id="path46"
+       style="opacity:1;fill:url(#linearGradient4226);fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 4.3645834,3.5702999 c -0.2702083,0.026117 -0.5589583,0.042446 -0.86375,0.042446 -0.305,0 -0.59375,-0.016328 -0.86375,-0.042446 L 2.250833,5.7891948 c 0.8416671,0.2912097 1.6770837,0.2707513 2.5000004,0 z"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path52"
+       style="opacity:1;fill:#787878;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="M 6,2.4637879 C 6,2.8679954 4.8806251,3.2900001 3.5000001,3.2900001 2.119375,3.2900001 1,2.8679954 1,2.4637879 1,2.0595805 2.119375,1.596 3.5000001,1.596 4.8806251,1.596 6,2.0595805 6,2.4637879 Z"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssss" />
+    <path
+       id="path54"
+       style="opacity:1;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 4.5416667,2.0499999 c 0,0.21 -0.4664583,0.399 -1.0416666,0.399 -0.5752084,0 -1.0416667,-0.189 -1.0416667,-0.399 C 2.4583334,1.4199999 2.8750001,1 3.5000001,1 c 0.625,0 1.0416666,0.4199999 1.0416666,1.0499999 z"
+       inkscape:connector-curvature="0" />
+  </g>
 </svg>

--- a/Numix/48x48/actions/image-gallery.svg
+++ b/Numix/48x48/actions/image-gallery.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="eog-image-gallery1.svg">
+  <metadata
+     id="metadata18">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs16" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview14"
+     showgrid="true"
+     inkscape:zoom="1"
+     inkscape:cx="14.673567"
+     inkscape:cy="31.071068"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4146" />
+  </sodipodi:namedview>
+  <rect
+     style="opacity:1;fill:#b58900;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     id="rect4148"
+     width="20"
+     height="20"
+     x="2"
+     y="2.0000038"
+     rx="2"
+     ry="2" />
+  <rect
+     y="2.0000038"
+     x="26"
+     height="20"
+     width="20"
+     id="rect4150"
+     style="opacity:1;fill:#268bd2;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     ry="2"
+     rx="2" />
+  <rect
+     style="opacity:1;fill:#db3330;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     id="rect4152"
+     width="20"
+     height="20"
+     x="26"
+     y="26"
+     ry="2"
+     rx="2" />
+  <rect
+     y="26"
+     x="2"
+     height="20"
+     width="20"
+     id="rect4154"
+     style="opacity:1;fill:#4caf50;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     ry="2"
+     rx="2" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     d="m 33.6,7.399998 -3.6,5.203124 0,5.396876 12,0 0,-4.36 -2.4,-3.84 -2.4,2.4 z"
+     id="path85"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccc" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     d="m 11.920313,29.999996 c -1.53161,0 -2.775,1.170772 -2.775,2.615626 0,0.07106 0.0029,0.14456 0.0094,0.215616 C 8.939202,32.780958 8.72088,32.752018 8.498453,32.751558 7.15003,32.766678 6,33.927016 6,35.371872 c 0,1.08076 0.703578,2.047092 1.771874,2.4375 -0.320258,0.436544 -0.491264,0.954788 -0.492186,1.485938 0,1.444858 1.242928,2.615164 2.774999,2.615626 0.637748,-8.62e-4 1.254205,-0.206162 1.748438,-0.585938 0.508539,0.432856 1.169125,0.673614 1.85625,0.674998 1.532533,0 2.770313,-1.174536 2.770313,-2.620312 -8.64e-4,-0.488692 -0.1473,-0.968414 -0.421876,-1.382812 1.179972,-0.327642 1.991726,-1.347686 1.992188,-2.50781 0,-1.445318 -0.922812,-2.595784 -3.051562,-2.615628 -0.09044,0 -0.18188,9.74e-4 -0.271876,0.0094 0.011,-0.08906 0.0174,-0.1772 0.0188,-0.267186 0,-1.445778 -1.240618,-2.616088 -2.774999,-2.615628 z M 12,34.07812 A 2.16,2.16 0 0 1 14.160938,36.23906 2.16,2.16 0 0 1 12,38.399996 2.16,2.16 0 0 1 9.839063,36.23906 2.16,2.16 0 0 1 12,34.07812 Z"
+     id="path35"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     d="m 33.269598,35.995196 c 0.3816,0.468798 0.788802,1.049598 0.481602,1.673598 C 32.800002,39.599996 30,38.799998 30,41.999996 l 12,0 c 0,-3.199998 -2.800002,-2.4 -3.7512,-4.331202 -0.3072,-0.624 0.18,-1.1496 0.481602,-1.673598 1.8336,-3.181602 0.469596,-5.995998 -2.730402,-5.995998 -3.199998,0 -4.508802,3.8088 -2.730402,5.995998 z"
+     style="fill:#ffffff;fill-opacity:1"
+     id="path47" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;fill-opacity:1"
+     d="m 5.5,11.999998 2.5,0 0,6 2,0 0,-6 4,0 0,6 2,0 0,-6 2.5,0 -6.5,-6 z"
+     id="path6"
+     sodipodi:nodetypes="cccccccccccc" />
+</svg>

--- a/Numix/48x48/actions/slideshow-play.svg
+++ b/Numix/48x48/actions/slideshow-play.svg
@@ -1,0 +1,1 @@
+media-playback-start.svg

--- a/Numix/64x64/actions/eog-image-gallery.svg
+++ b/Numix/64x64/actions/eog-image-gallery.svg
@@ -1,0 +1,1 @@
+image-gallery.svg

--- a/Numix/64x64/actions/image-gallery.svg
+++ b/Numix/64x64/actions/image-gallery.svg
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="eog-image-gallery.svg">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="-21.152542"
+     inkscape:cy="32"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <rect
+     style="opacity:1;fill:#b58900;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     id="rect4148"
+     width="28"
+     height="28"
+     x="2"
+     y="2"
+     rx="3"
+     ry="3" />
+  <rect
+     y="2"
+     x="34"
+     height="28"
+     width="28"
+     id="rect4150"
+     style="opacity:1;fill:#268bd2;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     ry="3"
+     rx="3" />
+  <rect
+     style="opacity:1;fill:#db3330;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     id="rect4152"
+     width="28"
+     height="28"
+     x="34"
+     y="34"
+     ry="3"
+     rx="3" />
+  <rect
+     y="34"
+     x="2"
+     height="28"
+     width="28"
+     id="rect4154"
+     style="opacity:1;fill:#4caf50;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+     ry="3"
+     rx="3" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     d="m 43.599998,9.999998 -5.6,8.671876 0,7.328124 19.999998,0 0,-5.6 -4,-6.4 -3.999998,4 z"
+     id="path85"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccc" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     d="m 15.867187,38.004 c -2.552684,0 -4.625,1.951284 -4.625,4.359376 0,0.11844 0.0048,0.24092 0.0156,0.35936 -0.35916,-0.0838 -0.72304,-0.13204 -1.093752,-0.1328 -2.2473602,0.0252 -4.1640762,1.959096 -4.1640762,4.367188 0,1.801268 1.172628,3.411824 2.953124,4.062504 -0.533764,0.727572 -0.818772,1.591312 -0.820312,2.47656 0,2.408096 2.0715482,4.358608 4.6250002,4.359376 1.062912,-0.0014 2.09034,-0.3436 2.914064,-0.976564 0.847564,0.721428 1.94854,1.122692 3.093747,1.125 2.554224,0 4.61719,-1.95756 4.61719,-4.367188 -0.0014,-0.814488 -0.245508,-1.614024 -0.703126,-2.304688 1.96662,-0.546068 3.319542,-2.24614 3.320312,-4.179684 0,-2.40886 -1.53802,-4.326304 -5.085936,-4.359376 -0.15074,0 -0.303144,0.0016 -0.453126,0.0156 0.0184,-0.14844 0.02892,-0.29532 0.03124,-0.445312 0,-2.409628 -2.067698,-4.360144 -4.625001,-4.359376 z m 0.1328,6.796876 a 3.5999998,3.5999998 0 0 1 3.601561,3.601564 3.5999998,3.5999998 0 0 1 -3.601561,3.60156 3.5999998,3.5999998 0 0 1 -3.601564,-3.60156 3.5999998,3.5999998 0 0 1 3.601564,-3.601564 z"
+     id="path35"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     d="m 43.44933,47.992 c 0.636,0.781332 1.314668,1.749332 0.802668,2.789332 C 42.666666,54 37.999998,52.666668 37.999998,58 l 19.999998,0 c 0,-5.333332 -4.666668,-4 -6.252,-7.218668 -0.512,-1.04 0.3,-1.916 0.802668,-2.789332 3.056,-5.302668 0.782664,-9.993332 -4.550666,-9.993332 -5.333332,0 -7.514668,6.348 -4.550668,9.993332 z"
+     style="fill:#ffffff;fill-opacity:1"
+     id="path47" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;fill-opacity:1"
+     d="m 5.9999988,13.999998 4,0 0,12 4.0000002,0 0,-12 4,0 0,12 3.999999,0 0,-12 4,0 -9.999999,-8 z"
+     id="path6"
+     sodipodi:nodetypes="cccccccccccc" />
+</svg>

--- a/Numix/64x64/actions/image-gallery.svg
+++ b/Numix/64x64/actions/image-gallery.svg
@@ -5,6 +5,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64"
@@ -13,7 +14,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="eog-image-gallery.svg">
+   sodipodi:docname="eog-image-gallery1.svg">
   <metadata
      id="metadata12">
     <rdf:RDF>
@@ -27,7 +28,33 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs10" />
+     id="defs10">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4220"
+       id="linearGradient4226"
+       x1="2.250833"
+       y1="4.75"
+       x2="4.7508335"
+       y2="4.75"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4220">
+      <stop
+         style="stop-color:#e2d290;stop-opacity:0.70588237"
+         offset="0"
+         id="stop4222" />
+      <stop
+         id="stop4228"
+         offset="0.50504142"
+         style="stop-color:#e2d290;stop-opacity:1" />
+      <stop
+         style="stop-color:#e2d290;stop-opacity:0.70588237"
+         offset="1"
+         id="stop4224" />
+    </linearGradient>
+  </defs>
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -48,62 +75,109 @@
      inkscape:window-y="27"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2" />
-  <rect
-     style="opacity:1;fill:#b58900;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     id="rect4148"
-     width="28"
-     height="28"
-     x="2"
-     y="2"
-     rx="3"
-     ry="3" />
-  <rect
-     y="2"
-     x="34"
-     height="28"
-     width="28"
-     id="rect4150"
-     style="opacity:1;fill:#268bd2;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     ry="3"
-     rx="3" />
-  <rect
-     style="opacity:1;fill:#db3330;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     id="rect4152"
-     width="28"
-     height="28"
-     x="34"
-     y="34"
-     ry="3"
-     rx="3" />
-  <rect
-     y="34"
-     x="2"
-     height="28"
-     width="28"
-     id="rect4154"
-     style="opacity:1;fill:#4caf50;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
-     ry="3"
-     rx="3" />
-  <path
-     style="fill:#ffffff;fill-opacity:1"
-     d="m 43.599998,9.999998 -5.6,8.671876 0,7.328124 19.999998,0 0,-5.6 -4,-6.4 -3.999998,4 z"
-     id="path85"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="cccccccc" />
-  <path
-     style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
-     d="m 15.867187,38.004 c -2.552684,0 -4.625,1.951284 -4.625,4.359376 0,0.11844 0.0048,0.24092 0.0156,0.35936 -0.35916,-0.0838 -0.72304,-0.13204 -1.093752,-0.1328 -2.2473602,0.0252 -4.1640762,1.959096 -4.1640762,4.367188 0,1.801268 1.172628,3.411824 2.953124,4.062504 -0.533764,0.727572 -0.818772,1.591312 -0.820312,2.47656 0,2.408096 2.0715482,4.358608 4.6250002,4.359376 1.062912,-0.0014 2.09034,-0.3436 2.914064,-0.976564 0.847564,0.721428 1.94854,1.122692 3.093747,1.125 2.554224,0 4.61719,-1.95756 4.61719,-4.367188 -0.0014,-0.814488 -0.245508,-1.614024 -0.703126,-2.304688 1.96662,-0.546068 3.319542,-2.24614 3.320312,-4.179684 0,-2.40886 -1.53802,-4.326304 -5.085936,-4.359376 -0.15074,0 -0.303144,0.0016 -0.453126,0.0156 0.0184,-0.14844 0.02892,-0.29532 0.03124,-0.445312 0,-2.409628 -2.067698,-4.360144 -4.625001,-4.359376 z m 0.1328,6.796876 a 3.5999998,3.5999998 0 0 1 3.601561,3.601564 3.5999998,3.5999998 0 0 1 -3.601561,3.60156 3.5999998,3.5999998 0 0 1 -3.601564,-3.60156 3.5999998,3.5999998 0 0 1 3.601564,-3.601564 z"
-     id="path35"
-     inkscape:connector-curvature="0" />
-  <path
-     inkscape:connector-curvature="0"
-     d="m 43.44933,47.992 c 0.636,0.781332 1.314668,1.749332 0.802668,2.789332 C 42.666666,54 37.999998,52.666668 37.999998,58 l 19.999998,0 c 0,-5.333332 -4.666668,-4 -6.252,-7.218668 -0.512,-1.04 0.3,-1.916 0.802668,-2.789332 3.056,-5.302668 0.782664,-9.993332 -4.550666,-9.993332 -5.333332,0 -7.514668,6.348 -4.550668,9.993332 z"
-     style="fill:#ffffff;fill-opacity:1"
-     id="path47" />
-  <path
-     inkscape:connector-curvature="0"
-     style="fill:#ffffff;fill-opacity:1"
-     d="m 5.9999988,13.999998 4,0 0,12 4.0000002,0 0,-12 4,0 0,12 3.999999,0 0,-12 4,0 -9.999999,-8 z"
-     id="path6"
-     sodipodi:nodetypes="cccccccccccc" />
+  <g
+     id="g4193"
+     transform="matrix(4,0,0,4,-2,-2)">
+    <rect
+       y="9"
+       x="9"
+       height="7"
+       width="7"
+       id="rect4152"
+       style="opacity:1;fill:#b8ccd3;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061" />
+    <path
+       sodipodi:nodetypes="sccccccs"
+       inkscape:connector-curvature="0"
+       id="path47"
+       d="m 12.5,10.758559 c -1.333334,0 -1.877719,1.586714 -1.136719,2.498047 0.159,0.195333 0.327219,0.437266 0.199219,0.697265 -0.06464,0.131242 -0.152777,0.225729 -0.25,0.308594 0.33573,0.897327 1.930206,1.06583 2.375,0 -0.09722,-0.08286 -0.185358,-0.177352 -0.25,-0.308594 -0.128,-0.259999 0.07355,-0.478932 0.199219,-0.697265 0.764,-1.325667 0.196614,-2.498047 -1.136719,-2.498047 z"
+       style="fill:#e5b58b;fill-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccccsc"
+       inkscape:connector-curvature="0"
+       id="path4183"
+       d="M 11.3125,14.264 C 10.813633,14.757376 10,14.705201 10,16 l 5,0 c 0,-1.294799 -0.813633,-1.242624 -1.3125,-1.736 -0.359087,0.291488 -0.758149,0.476 -1.1875,0.476 -0.429351,0 -0.828413,-0.184512 -1.1875,-0.476 z"
+       style="opacity:1;fill:#cf362d;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061" />
+    <path
+       sodipodi:nodetypes="czcc"
+       inkscape:connector-curvature="0"
+       id="path75"
+       d="m 11,12.225356 c 0.465721,-0.324686 0.750318,-0.762784 1.5,-0.766797 0.749682,-0.004 1.066025,0.398033 1.5,0.655469 0.0332,-2.041425 -3.042969,-1.941397 -3,0.111328 z"
+       style="fill:#96413c;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+  </g>
+  <g
+     id="g4187"
+     transform="matrix(4,0,0,4,-2,2)">
+    <rect
+       style="opacity:1;fill:#3db2e1;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+       id="rect4150"
+       width="7"
+       height="7"
+       x="9"
+       y="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path85"
+       style="fill:#a2866a;fill-opacity:1"
+       d="M 13.943376,3.45 10,7 16,7 16,6 Z" />
+    <path
+       id="path87"
+       style="fill:#e5d740;fill-opacity:1"
+       d="m 13,2 c 0,0.5234285 -0.476572,1 -1,1 -0.523429,0 -1,-0.4765715 -1,-1 0,-0.5234286 0.476571,-1.00000011 1,-1.00000011 0.523428,0 1,0.47657151 1,1.00000011 z"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path91"
+       style="fill:#94785c;fill-opacity:1"
+       d="M 11.352941,2.5 9,5.4 9,7 14,7 Z" />
+  </g>
+  <g
+     id="g4199"
+     transform="matrix(4,0,0,4,2,-2)">
+    <rect
+       style="opacity:1;fill:#4fb45e;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061"
+       id="rect4154"
+       width="7"
+       height="7"
+       x="0"
+       y="9" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path35"
+       d="m 3.4667969,9.901 c -0.6381705,0 -1.15625,0.487821 -1.15625,1.089844 0,0.02961 0.00121,0.06023 0.00391,0.08984 -0.089792,-0.02095 -0.1807596,-0.03301 -0.2734375,-0.0332 C 1.4791788,11.05383 1,11.537258 1,12.139281 c 0,0.450317 0.2931574,0.852956 0.7382812,1.015626 -0.133441,0.181893 -0.2046935,0.397828 -0.2050781,0.61914 0,0.602024 0.5178867,1.089652 1.15625,1.089844 0.2657283,-3.59e-4 0.5225854,-0.0859 0.7285157,-0.244141 0.211891,0.180357 0.4871354,0.280673 0.7734374,0.28125 0.6385554,0 1.1542969,-0.48939 1.1542969,-1.091797 C 5.3453435,13.605581 5.2843266,13.405697 5.1699219,13.233031 5.6615767,13.096514 5.9998072,12.671496 6,12.18811 6,11.585895 5.615495,11.106534 4.7285156,11.098266 c -0.037686,0 -0.075786,4.06e-4 -0.1132812,0.0039 0.00461,-0.03711 0.00723,-0.07383 0.00781,-0.111328 0,-0.602407 -0.5169246,-1.090036 -1.15625,-1.089844 z M 3.5,11.600219 A 0.89999998,0.89999998 0 0 1 4.4003906,12.50061 0.89999998,0.89999998 0 0 1 3.5,13.401 0.89999998,0.89999998 0 0 1 2.5996094,12.50061 0.89999998,0.89999998 0 0 1 3.5,11.600219 Z"
+       style="opacity:1;fill:#f1ef5d;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <circle
+       id="circle47"
+       style="fill:#9d8d6d;fill-opacity:1;stroke:none"
+       r="0.60000002"
+       cy="12.500218"
+       cx="3.5" />
+  </g>
+  <g
+     id="g4181"
+     transform="matrix(4,0,0,4,2,2)">
+    <rect
+       y="0"
+       x="0"
+       height="7"
+       width="7"
+       id="rect4148"
+       style="opacity:1;fill:#3c345d;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.61660061" />
+    <path
+       id="path46"
+       style="opacity:1;fill:url(#linearGradient4226);fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 4.3645834,3.5 c -0.2702083,0.026873 -0.5589583,0.043674 -0.86375,0.043674 -0.305,0 -0.59375,-0.016801 -0.86375,-0.043674 L 2.250833,5.7830955 c 0.8416671,0.2996354 1.6770837,0.2785851 2.5000004,0 z"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path52"
+       style="opacity:1;fill:#787878;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="M 6,2.4454545 C 6,2.8220454 4.8806251,3.15 3.5000001,3.15 2.119375,3.15 1,2.8220454 1,2.4454545 1,2.0688637 2.119375,1.65 3.5000001,1.65 4.8806251,1.65 6,2.0688637 6,2.4454545 Z"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path54"
+       style="opacity:1;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 4.5416667,2.0499999 c 0,0.21 -0.4664583,0.399 -1.0416666,0.399 -0.5752084,0 -1.0416667,-0.189 -1.0416667,-0.399 C 2.4583334,1.4199999 2.8750001,1 3.5000001,1 c 0.625,0 1.0416666,0.4199999 1.0416666,1.0499999 z"
+       inkscape:connector-curvature="0" />
+  </g>
 </svg>

--- a/Numix/64x64/actions/slideshow-play.svg
+++ b/Numix/64x64/actions/slideshow-play.svg
@@ -1,0 +1,1 @@
+media-playback-start.svg


### PR DESCRIPTION
Missing action icons for Eye of GNOME/MATE and other image viewers:
Original eog icons
``(eog)-image-gallery``
![eog-image-gallery-ori](https://cloud.githubusercontent.com/assets/7050624/9017350/986c4d68-37d6-11e5-8410-058057dd2664.png)
``slideshow-play``
![slideshow-play-ori](https://cloud.githubusercontent.com/assets/7050624/9017359/a552de34-37d6-11e5-9929-e9f67108af7b.png)

``slideshow-play`` pushed as symlink to ``media-playback-start``.


Pushed design for ``image-gallery``:

![design1](https://cloud.githubusercontent.com/assets/7050624/9017408/ea184a86-37d6-11e5-8ada-d827aaa506f8.png)

Alternative design:

![design2](https://cloud.githubusercontent.com/assets/7050624/9017458/f6bbf53a-37d6-11e5-9391-59b4c44e1702.png)



