### PR TITLE
Symlinks for calendar-go-today

### DIFF
--- a/Numix/128x128/actions/calendar-go-today.svg
+++ b/Numix/128x128/actions/calendar-go-today.svg
@@ -1,0 +1,1 @@
+go-today.svg

--- a/Numix/16x16/actions/calendar-go-today.svg
+++ b/Numix/16x16/actions/calendar-go-today.svg
@@ -1,0 +1,1 @@
+go-today.svg

--- a/Numix/22x22/actions/calendar-go-today.svg
+++ b/Numix/22x22/actions/calendar-go-today.svg
@@ -1,0 +1,1 @@
+go-today.svg

--- a/Numix/24x24/actions/calendar-go-today.svg
+++ b/Numix/24x24/actions/calendar-go-today.svg
@@ -1,0 +1,1 @@
+go-today.svg

--- a/Numix/256x256/actions/calendar-go-today.svg
+++ b/Numix/256x256/actions/calendar-go-today.svg
@@ -1,0 +1,1 @@
+go-today.svg

--- a/Numix/32x32/actions/calendar-go-today.svg
+++ b/Numix/32x32/actions/calendar-go-today.svg
@@ -1,0 +1,1 @@
+go-today.svg

--- a/Numix/48x48/actions/calendar-go-today.svg
+++ b/Numix/48x48/actions/calendar-go-today.svg
@@ -1,0 +1,1 @@
+go-today.svg

--- a/Numix/64x64/actions/calendar-go-today.svg
+++ b/Numix/64x64/actions/calendar-go-today.svg
@@ -1,0 +1,1 @@
+go-today.svg


### PR DESCRIPTION
Action icon used by elementary's Maya calendar app.
It's not part of the ``elementary`` theme but located in ``hicolor`` by default.