### PR TITLE
Symlinks for media-removable-symbolic fixes #702

### DIFF
--- a/Numix-Light/scalable/devices/media-removable-symbolic.svg
+++ b/Numix-Light/scalable/devices/media-removable-symbolic.svg
@@ -1,0 +1,1 @@
+drive-removable-media-usb-symbolic-1.svg

--- a/Numix/scalable/devices/media-removable-symbolic.svg
+++ b/Numix/scalable/devices/media-removable-symbolic.svg
@@ -1,0 +1,1 @@
+drive-removable-media-usb-symbolic-1.svg


### PR DESCRIPTION
I used the more generic "removable" icon because it fits better for a general usb-indicator icon. #702