### PR TITLE
Adds symlinks/files for preferences-system-windows fixes #659

### DIFF
--- a/Numix/128x128/categories/preferences-system-windows.svg
+++ b/Numix/128x128/categories/preferences-system-windows.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="128"
+   height="128"
+   viewBox="0 0 128 128"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="preferences-system-windows.svg">
+  <metadata
+     id="metadata20">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs18" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1056"
+     id="namedview16"
+     showgrid="true"
+     inkscape:zoom="3.6875"
+     inkscape:cx="56.071252"
+     inkscape:cy="10.533651"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2997" />
+  </sodipodi:namedview>
+  <path
+     sodipodi:nodetypes="ccsssssscsssssccccc"
+     inkscape:connector-curvature="0"
+     id="path4-4"
+     d="m 12.297072,14 c -2.3437432,0.234159 -4.3124841,2.431651 -4.2968601,4.789046 l -1.6e-6,90.421924 c 0,2.51352 2.2812397,4.78903 4.7968587,4.78903 l 102.405951,0 c 2.51562,0 4.79686,-2.27551 4.79686,-4.78903 l 0,-90.421924 C 119.99988,16.275531 117.71864,14 115.20302,14 Z m 95.702848,7.999969 c 2.20913,0 3.99999,1.790855 3.99999,3.999986 0,2.209132 -1.79086,3.999985 -3.99999,3.999985 -2.20913,0 -3.99998,-1.790853 -3.99998,-3.999985 0,-2.209131 1.79085,-3.999986 3.99998,-3.999986 z m -91.999738,11.999957 95.999728,0 0,71.859494 -95.999729,0 z"
+     style="fill:#85b9ab" />
+</svg>

--- a/Numix/16x16/categories/preferences-system-windows.svg
+++ b/Numix/16x16/categories/preferences-system-windows.svg
@@ -1,0 +1,1 @@
+../apps/window-manager.svg

--- a/Numix/22x22/categories/preferences-system-windows.svg
+++ b/Numix/22x22/categories/preferences-system-windows.svg
@@ -1,0 +1,1 @@
+../apps/window-manager.svg

--- a/Numix/24x24/categories/preferences-system-windows.svg
+++ b/Numix/24x24/categories/preferences-system-windows.svg
@@ -1,0 +1,1 @@
+../apps/window-manager.svg

--- a/Numix/256x256/categories/preferences-system-windows.svg
+++ b/Numix/256x256/categories/preferences-system-windows.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="256"
+   height="256"
+   viewBox="0 0 256 256"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="preferences-system-windows.svg">
+  <metadata
+     id="metadata20">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs18" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1056"
+     id="namedview16"
+     showgrid="true"
+     inkscape:zoom="1.3037281"
+     inkscape:cx="275.64037"
+     inkscape:cy="-36.705163"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2997" />
+  </sodipodi:namedview>
+  <path
+     sodipodi:nodetypes="ccsssssscsssssccccc"
+     inkscape:connector-curvature="0"
+     id="path4-4"
+     d="m 24.594144,28 c -4.687486,0.468318 -8.624967,4.863302 -8.593719,9.578092 l -4e-6,180.843848 c 0,5.02704 4.562479,9.57806 9.593717,9.57806 l 204.811902,0 c 5.03124,0 9.59372,-4.55102 9.59372,-9.57806 l 0,-180.843848 C 239.99976,32.551062 235.43728,28 230.40604,28 Z M 215.99984,43.999938 c 4.41826,0 7.99998,3.58171 7.99998,7.999972 0,4.418264 -3.58172,7.99997 -7.99998,7.99997 -4.41826,0 -7.99996,-3.581706 -7.99996,-7.99997 0,-4.418262 3.5817,-7.999972 7.99996,-7.999972 z m -183.999476,23.999914 191.999456,0 0,143.718988 -191.999458,0 z"
+     style="fill:#85b9ab" />
+</svg>

--- a/Numix/32x32/categories/preferences-system-windows.svg
+++ b/Numix/32x32/categories/preferences-system-windows.svg
@@ -1,0 +1,1 @@
+../apps/window-manager.svg

--- a/Numix/48x48/categories/preferences-system-windows.svg
+++ b/Numix/48x48/categories/preferences-system-windows.svg
@@ -1,0 +1,1 @@
+../apps/window-manager.svg

--- a/Numix/64x64/categories/preferences-system-windows.svg
+++ b/Numix/64x64/categories/preferences-system-windows.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="preferences-system-windows.svg">
+  <metadata
+     id="metadata20">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs18" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1056"
+     id="namedview16"
+     showgrid="true"
+     inkscape:zoom="3.6875"
+     inkscape:cx="56.071252"
+     inkscape:cy="10.533651"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2997" />
+  </sodipodi:namedview>
+  <path
+     sodipodi:nodetypes="ccsssssscsssssccccc"
+     inkscape:connector-curvature="0"
+     id="path4-4"
+     d="M 6.1484615,6.9999248 C 4.9765865,7.1170047 3.9922132,8.2157542 4.0000252,9.3944552 l -8e-7,45.2110928 c 0,1.256759 1.1406232,2.394527 2.3984362,2.394527 l 51.2031234,0 c 1.257813,0 2.398436,-1.137768 2.398436,-2.394528 l 10e-7,-45.2110918 c 0,-1.256761 -1.140623,-2.3945304 -2.398436,-2.3945304 z M 54.000026,10.999921 c 1.104569,0 1.999998,0.89543 1.999998,1.999999 0,1.104569 -0.895429,1.999998 -1.999998,1.999998 -1.104569,0 -1.999999,-0.895429 -1.999999,-1.999998 0,-1.104569 0.89543,-1.999999 1.999999,-1.999999 z m -46.0000039,5.999996 48.0000019,0 -1e-6,35.929849 -48.0000016,0 z"
+     style="fill:#85b9ab" />
+</svg>


### PR DESCRIPTION
Added a symlink to `apps/window-manager` for the smaller sizes, but I had to add files for larger sizes, because only sizes up to `48` were present