### PR TITLE
Added symlinks for .mo file mimetype

### DIFF
--- a/Numix/16/mimetypes/application-x-gettext-translation.svg
+++ b/Numix/16/mimetypes/application-x-gettext-translation.svg
@@ -1,0 +1,1 @@
+application-octet-stream.svg

--- a/Numix/22/mimetypes/application-x-gettext-translation.svg
+++ b/Numix/22/mimetypes/application-x-gettext-translation.svg
@@ -1,0 +1,1 @@
+application-octet-stream.svg

--- a/Numix/24/mimetypes/application-x-gettext-translation.svg
+++ b/Numix/24/mimetypes/application-x-gettext-translation.svg
@@ -1,0 +1,1 @@
+application-octet-stream.svg

--- a/Numix/32/mimetypes/application-x-gettext-translation.svg
+++ b/Numix/32/mimetypes/application-x-gettext-translation.svg
@@ -1,0 +1,1 @@
+application-octet-stream.svg

--- a/Numix/48/mimetypes/application-x-gettext-translation.svg
+++ b/Numix/48/mimetypes/application-x-gettext-translation.svg
@@ -1,0 +1,1 @@
+application-octet-stream.svg

--- a/Numix/64/mimetypes/application-x-gettext-translation.svg
+++ b/Numix/64/mimetypes/application-x-gettext-translation.svg
@@ -1,0 +1,1 @@
+application-octet-stream.svg


### PR DESCRIPTION
``application-x-gettext-translation`` (not to be confused with ``text-x-gettext-translation`` for ``.po`` files)

``.mo`` files are "compiled" gettext translation files. The files are binary so the visual representation with a symlink to ``application-octet-stream`` is better than the generic text mimetype icon.