### PR TITLE
Added gettext translation mimetype icons.

### DIFF
--- a/Numix/16/mimetypes/application-x-gettext-translation.svg
+++ b/Numix/16/mimetypes/application-x-gettext-translation.svg
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="application-gettext-translation.svg">
+  <metadata
+     id="metadata36">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs34" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview32"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="6.972398"
+     inkscape:cy="4.9743376"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3013" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#dda06a;fill-opacity:1"
+     d="M 2.667969,-4.46e-4 C 2.324219,-4.46e-4 2,0.337812 2,0.6964467 L 2,15.303108 C 2,15.641365 2.34375,16 2.667969,16 l 10.664062,0 C 13.65625,16 14,15.641365 14,15.303108 L 14,3.9995538 10,-4.46e-4 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssssccs" />
+  <path
+     style="fill:#000000;fill-opacity:0.19599998"
+     d="m 10.583223,3.3315848 0.0154,0.01953 0.04005,-0.01953 z m 0.02978,0.667969 3.387,3.664062 0,-3.664062 z"
+     id="path6"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccc" />
+  <path
+     style="fill:#ffffff;fill-opacity:0.39200003"
+     d="m 10,-4.46e-4 3.996396,3.9999998 -3.383784,0 C 10.313513,3.9995538 10,3.6824368 10,3.3833378 z"
+     id="path8"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccssc" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
+     d="M 5 5 L 5 7 L 6 7 L 6 5 L 5 5 z M 5 8 L 5 10 L 6 10 L 6 8 L 5 8 z M 7 8 L 7 10 L 9 10 L 9 8 L 7 8 z M 5 11 L 5 13 L 6 13 L 6 11 L 5 11 z M 7 11 L 7 13 L 9 13 L 9 11 L 7 11 z M 10 11 L 10 13 L 11 13 L 11 11 L 10 11 z "
+     id="rect3026" />
+</svg>

--- a/Numix/16/mimetypes/text-x-gettext-translation-template.svg
+++ b/Numix/16/mimetypes/text-x-gettext-translation-template.svg
@@ -13,7 +13,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="text-x-gettext-translation-template0.svg">
+   sodipodi:docname="text-x-gettext-translation-template.svg">
   <metadata
      id="metadata28">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -41,8 +41,8 @@
      inkscape:window-height="704"
      id="namedview24"
      showgrid="false"
-     inkscape:zoom="8.8659971"
-     inkscape:cx="-5.539855"
+     inkscape:zoom="11.313708"
+     inkscape:cx="-2.8264807"
      inkscape:cy="5.9794968"
      inkscape:window-x="0"
      inkscape:window-y="27"
@@ -60,7 +60,7 @@
      sodipodi:nodetypes="sssssssss" />
   <path
      style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.1375"
-     d="m 5,5 0,9 1,0 0,-4 5.5,0 C 10.833333,9.333333 10.166667,8.666667 9.5,8 10.166667,7.333333 10.833333,6.666667 11.5,6 L 6,6 6,5 Z"
+     d="m 5,4 0,9 1,0 0,-4 5.5,0 C 10.833333,8.333333 10.166667,7.666667 9.5,7 10.166667,6.333333 10.833333,5.666667 11.5,5 L 6,5 6,4 Z"
      id="rect4148"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cccccccccc" />

--- a/Numix/16/mimetypes/text-x-gettext-translation-template.svg
+++ b/Numix/16/mimetypes/text-x-gettext-translation-template.svg
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="text-x-gettext-translation-template0.svg">
+  <metadata
+     id="metadata28">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs26" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview24"
+     showgrid="false"
+     inkscape:zoom="8.8659971"
+     inkscape:cx="-5.539855"
+     inkscape:cy="5.9794968"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3020" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#dda06a;fill-opacity:1"
+     d="M 2.667969,2e-7 C 2.324219,2e-7 2,-0.0097698 2,0.3339847 L 2,15.332031 C 2,15.65625 2.34375,16 2.667969,16 l 10.664062,0 C 13.65625,16 14,15.65625 14,15.332031 L 14,0.6679692 C 14,0.3242192 13.675781,2e-7 13.332031,2e-7 z"
+     id="path2991"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="sssssssss" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.1375"
+     d="m 5,5 0,9 1,0 0,-4 5.5,0 C 10.833333,9.333333 10.166667,8.666667 9.5,8 10.166667,7.333333 10.833333,6.666667 11.5,6 L 6,6 6,5 Z"
+     id="rect4148"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccc" />
+</svg>

--- a/Numix/16/mimetypes/text-x-gettext-translation.svg
+++ b/Numix/16/mimetypes/text-x-gettext-translation.svg
@@ -1,0 +1,1 @@
+text-x-po.svg

--- a/Numix/16/mimetypes/text-x-po.svg
+++ b/Numix/16/mimetypes/text-x-po.svg
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="text-x-po0.svg">
+  <metadata
+     id="metadata18">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs16" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview14"
+     showgrid="false"
+     inkscape:object-nodes="true"
+     inkscape:zoom="1"
+     inkscape:cx="7.5613822"
+     inkscape:cy="8.2034761"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4146" />
+  </sodipodi:namedview>
+  <path
+     d="m 2.668 0 c -0.344 0 -0.668 0.338 -0.668 0.697 l 0 14.607 c 0 0.338 0.344 0.697 0.668 0.697 l 10.664 0 c 0.324 0 0.668 -0.359 0.668 -0.697 l 0 -11.304 -4 -4 z"
+     style="fill:#dda06a;fill-opacity:1"
+     id="path4" />
+  <path
+     d="m 10.583 3.332 0.015 0.02 0.04 -0.02 z m 0.03 0.668 3.387 3.664 0 -3.664 z"
+     style="fill:#000;fill-opacity:0.196"
+     id="path6" />
+  <path
+     d="m 10 0 3.996 4 -3.384 0 c -0.299 0 -0.613 -0.317 -0.613 -0.616 z"
+     style="fill:#fff;fill-opacity:0.392"
+     id="path8" />
+  <g
+     transform="matrix(1.0912094,0,0,1.0898747,-0.1690147,-1.3902146)"
+     style="fill:#888"
+     id="g10" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.1375"
+     d="m 5,5 0,9 1,0 0,-4 5.5,0 C 10.833333,9.3333333 10.166667,8.6666667 9.5,8 10.166667,7.3333333 10.833333,6.6666667 11.5,6 L 6,6 6,5 Z"
+     id="rect4148"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccc" />
+</svg>

--- a/Numix/22/mimetypes/application-x-gettext-translation.svg
+++ b/Numix/22/mimetypes/application-x-gettext-translation.svg
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   viewBox="0 0 22 22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="application-x-gettext-translation.svg">
+  <metadata
+     id="metadata36">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs34" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview32"
+     showgrid="true"
+     inkscape:zoom="46.235401"
+     inkscape:cx="4.5994857"
+     inkscape:cy="4.3175124"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3013"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#dda06a;fill-opacity:1"
+     d="m 4,-3e-7 c -0.472657,0 -1,0.527344 -1,1 L 3,21 c 0,0.445312 0.554687,1 1,1 l 14,0 c 0.445313,0 0.992367,-0.554753 1,-1 l 0,-15.0000003 -6,-6 z"
+     id="path4-6"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssssccs" />
+  <path
+     style="fill:#000000;fill-opacity:0.19599998"
+     d="M 14,5.9999997 19,11 19,5.9999997 z"
+     id="path6-5"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccc" />
+  <path
+     style="fill:#ffffff;fill-opacity:0.39200003"
+     d="m 13,-3e-7 6,6 -5,0 c -0.445312,0 -1,-0.554688 -1,-1 z"
+     id="path8-3"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccssc" />
+  <g
+     id="g4142"
+     style="fill:#ffffff">
+    <rect
+       y="6"
+       x="8"
+       height="3"
+       width="1"
+       id="rect3026"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none" />
+    <rect
+       y="10"
+       x="8"
+       height="3"
+       width="1"
+       id="rect3028"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none" />
+    <path
+       inkscape:connector-curvature="0"
+       id="rect3034"
+       d="m 10,10 0,3 3,0 0,-3 -3,0 z m 1,1 1,0 0,1 -1,0 0,-1 z"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none" />
+    <rect
+       y="14"
+       x="8"
+       height="3"
+       width="1"
+       id="rect3028-6"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none" />
+    <path
+       id="rect3034-5"
+       d="m 10,14 0,3 3,0 0,-3 -3,0 z m 1,1 1,0 0,1 -1,0 0,-1 z"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       inkscape:connector-curvature="0" />
+    <rect
+       y="14"
+       x="14"
+       height="3"
+       width="1"
+       id="rect3028-0"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none" />
+  </g>
+</svg>

--- a/Numix/22/mimetypes/text-x-gettext-translation-template.svg
+++ b/Numix/22/mimetypes/text-x-gettext-translation-template.svg
@@ -13,7 +13,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="text-x-gettext-translation-template0.svg">
+   sodipodi:docname="text-x-gettext-translation-template.svg">
   <metadata
      id="metadata28">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -41,8 +41,8 @@
      inkscape:window-height="704"
      id="namedview24"
      showgrid="false"
-     inkscape:zoom="1"
-     inkscape:cx="7.0611217"
+     inkscape:zoom="16"
+     inkscape:cx="3.8534354"
      inkscape:cy="9.4452388"
      inkscape:window-x="0"
      inkscape:window-y="27"
@@ -60,7 +60,7 @@
      sodipodi:nodetypes="sssssssss" />
   <path
      style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.1375"
-     d="M 7,7.9999998 7,19 l 1,0 0,-5 7,0 -3,-2.5 3,-2.5000002 -7,0 0,-1 z"
+     d="M 7,5.9999998 7,17 l 1,0 0,-5 7,0 -3,-2.5 3,-2.5000002 -7,0 0,-1 z"
      id="rect4148"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cccccccccc" />

--- a/Numix/22/mimetypes/text-x-gettext-translation-template.svg
+++ b/Numix/22/mimetypes/text-x-gettext-translation-template.svg
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   viewBox="0 0 22 22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="text-x-gettext-translation-template0.svg">
+  <metadata
+     id="metadata28">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs26" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview24"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="7.0611217"
+     inkscape:cy="9.4452388"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3005" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#dda06a;fill-opacity:1"
+     d="M 4,0 C 3.527343,0 3,0.527344 3,1 l 0,20 c 0,0.445312 0.554687,1 1,1 l 14,0 c 0.445313,0 1,-0.554688 1,-1 L 19,1 C 19,0.527344 18.472657,0 18,0 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="sssssssss" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.1375"
+     d="M 7,7.9999998 7,19 l 1,0 0,-5 7,0 -3,-2.5 3,-2.5000002 -7,0 0,-1 z"
+     id="rect4148"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccc" />
+</svg>

--- a/Numix/22/mimetypes/text-x-gettext-translation.svg
+++ b/Numix/22/mimetypes/text-x-gettext-translation.svg
@@ -1,0 +1,1 @@
+text-x-po.svg

--- a/Numix/22/mimetypes/text-x-po.svg
+++ b/Numix/22/mimetypes/text-x-po.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 22 22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="text-x-po0.svg">
+  <metadata
+     id="metadata18">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs16" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview14"
+     showgrid="false"
+     inkscape:object-nodes="true"
+     inkscape:zoom="1"
+     inkscape:cx="4.0374565"
+     inkscape:cy="7.817868"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4146" />
+  </sodipodi:namedview>
+  <path
+     d="m 4 0 c -0.473 0 -1 0.527 -1 1 l 0 20 c 0 0.445 0.555 1 1 1 l 14 0 c 0.445 0 0.992 -0.555 1 -1 l 0 -15 -6 -6 z"
+     style="fill:#dda06a;fill-opacity:1"
+     id="path4" />
+  <path
+     d="m 14 6 5 5 0 -5 z"
+     style="fill:#000;fill-opacity:0.196"
+     id="path6" />
+  <path
+     d="m 13 0 6 6 -5 0 c -0.445 0 -1 -0.555 -1 -1 z"
+     style="fill:#fff;fill-opacity:0.392"
+     id="path8" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.1375"
+     d="m 7,8 0,11 1,0 0,-5 7,0 L 12,11.5 15,9 8,9 8,8 Z"
+     id="rect4148"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccc" />
+</svg>

--- a/Numix/24/mimetypes/application-x-gettext-translation.svg
+++ b/Numix/24/mimetypes/application-x-gettext-translation.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="application-x-gettext-translation.svg">
+  <metadata
+     id="metadata36">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs34" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview32"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="13.971209"
+     inkscape:cy="9.0300804"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3013"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#dda06a;fill-opacity:1"
+     d="m 5,0.9999997 c -0.472657,0 -1,0.527344 -1,1 L 4,22 c 0,0.445312 0.554687,1 1,1 l 14,0 c 0.445313,0 0.992367,-0.554753 1,-1 l 0,-15.0000003 -6,-6 z"
+     id="path4-6"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssssccs" />
+  <path
+     style="fill:#000000;fill-opacity:0.19599998"
+     d="M 15,6.9999997 20,12 20,6.9999997 z"
+     id="path6-5"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccc" />
+  <path
+     style="fill:#ffffff;fill-opacity:0.39200003"
+     d="m 14,0.9999997 6,6 -5,0 c -0.445312,0 -1,-0.554688 -1,-1 z"
+     id="path8-3"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccssc" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
+     id="rect3026"
+     width="1"
+     height="3"
+     x="9"
+     y="7" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
+     id="rect3028"
+     width="1"
+     height="3"
+     x="9"
+     y="11" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
+     d="m 11,11 0,3 3,0 0,-3 -3,0 z m 1,1 1,0 0,1 -1,0 0,-1 z"
+     id="rect3034"
+     inkscape:connector-curvature="0" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
+     id="rect3028-6"
+     width="1"
+     height="3"
+     x="9"
+     y="15" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
+     d="m 11,15 0,3 3,0 0,-3 -3,0 z m 1,1 1,0 0,1 -1,0 0,-1 z"
+     id="rect3034-5" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
+     id="rect3028-0"
+     width="1"
+     height="3"
+     x="15"
+     y="15" />
+</svg>

--- a/Numix/24/mimetypes/text-x-gettext-translation-template.svg
+++ b/Numix/24/mimetypes/text-x-gettext-translation-template.svg
@@ -13,7 +13,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="text-x-gettext-translation-template0.svg">
+   sodipodi:docname="text-x-gettext-translation-template.svg">
   <metadata
      id="metadata28">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -41,8 +41,8 @@
      inkscape:window-height="704"
      id="namedview24"
      showgrid="false"
-     inkscape:zoom="17.69949"
-     inkscape:cx="13.742124"
+     inkscape:zoom="13.175423"
+     inkscape:cx="8.0532501"
      inkscape:cy="10.010106"
      inkscape:window-x="0"
      inkscape:window-y="27"
@@ -64,7 +64,7 @@
      sodipodi:nodetypes="sssssssss" />
   <path
      style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.1375"
-     d="m 8,9 0,11 1,0 0,-5 7,0 -3,-2.5 3,-2.5 -7,0 0,-1 z"
+     d="m 8,7 0,11 1,0 0,-5 7,0 L 13,10.5 16,8 9,8 9,7 Z"
      id="rect4148"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cccccccccc" />

--- a/Numix/24/mimetypes/text-x-gettext-translation-template.svg
+++ b/Numix/24/mimetypes/text-x-gettext-translation-template.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="text-x-gettext-translation-template0.svg">
+  <metadata
+     id="metadata28">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs26" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview24"
+     showgrid="false"
+     inkscape:zoom="17.69949"
+     inkscape:cx="13.742124"
+     inkscape:cy="10.010106"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3005"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#dda06a;fill-opacity:1"
+     d="M 5,1 C 4.527343,1 4,1.527344 4,2 l 0,20 c 0,0.445312 0.554687,1 1,1 l 14,0 c 0.445313,0 1,-0.554688 1,-1 L 20,2 C 20,1.527344 19.472657,1 19,1 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="sssssssss" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.1375"
+     d="m 8,9 0,11 1,0 0,-5 7,0 -3,-2.5 3,-2.5 -7,0 0,-1 z"
+     id="rect4148"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccc" />
+</svg>

--- a/Numix/24/mimetypes/text-x-gettext-translation.svg
+++ b/Numix/24/mimetypes/text-x-gettext-translation.svg
@@ -1,0 +1,1 @@
+text-x-po.svg

--- a/Numix/24/mimetypes/text-x-po.svg
+++ b/Numix/24/mimetypes/text-x-po.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 24 24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="text-x-po0.svg">
+  <metadata
+     id="metadata18">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs16" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview14"
+     showgrid="false"
+     inkscape:zoom="8.8659974"
+     inkscape:cx="10.753748"
+     inkscape:cy="12"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4152" />
+  </sodipodi:namedview>
+  <path
+     d="m 5 1 c -0.473 0 -1 0.527 -1 1 l 0 20 c 0 0.445 0.555 1 1 1 l 14 0 c 0.445 0 0.992 -0.555 1 -1 l 0 -15 -6 -6 z"
+     style="fill:#dda06a;fill-opacity:1"
+     id="path4" />
+  <path
+     d="m 15 7 5 5 0 -5 z"
+     style="fill:#000;fill-opacity:0.196"
+     id="path6" />
+  <path
+     d="m 14 1 6 6 -5 0 c -0.445 0 -1 -0.555 -1 -1 z"
+     style="fill:#fff;fill-opacity:0.392"
+     id="path8" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.1375"
+     d="M 8,8.9999998 8,20 l 1,0 0,-5 7,0 -3,-2.5 3,-2.5000002 -7,0 0,-1 z"
+     id="rect4148"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccc" />
+</svg>

--- a/Numix/32/mimetypes/application-x-gettext-translation.svg
+++ b/Numix/32/mimetypes/application-x-gettext-translation.svg
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   height="32"
+   viewBox="0 0 32 32"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="application-x-gettext-translation.svg">
+  <metadata
+     id="metadata36">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs34" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview32"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="14.459594"
+     inkscape:cy="13.905148"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3024" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#dda06a;fill-opacity:1"
+     d="M 5.335888,2.972e-4 C 4.648414,3.122e-4 4,0.6767881 4,1.3940314 L 4,30.606268 C 4,31.282757 4.687474,32 5.335888,32 l 21.327332,0 c 0.648414,0 1.335888,-0.717243 1.335888,-1.393732 L 28,8.9999999 l -9,-9 z"
+     id="path4-1"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssssccs" />
+  <path
+     style="fill:#000000;fill-opacity:0.19599998"
+     d="M 21,8.9999999 28,16 28,8.9999999 z"
+     id="path6-4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccc" />
+  <path
+     style="fill:#ffffff;fill-opacity:0.39200003"
+     d="m 19.000306,2.972e-4 8.991594,8.9997027 -7.613262,0 c -0.672951,0 -1.378332,-0.7134896 -1.378332,-1.3864402 z"
+     id="path8-6"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccssc" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
+     d="M 10 11 L 10 12 L 11 12 L 11 15 L 12 15 L 12 11 L 11 11 L 10 11 z M 10 16 L 10 17 L 11 17 L 11 20 L 12 20 L 12 17 L 12 16 L 10 16 z M 13 16 L 13 20 L 14 20 L 15 20 L 16 20 L 16 16 L 15 16 L 14 16 L 13 16 z M 14 17 L 15 17 L 15 19 L 14 19 L 14 17 z M 10 21 L 10 22 L 11 22 L 11 25 L 12 25 L 12 22 L 12 21 L 10 21 z M 13 21 L 13 25 L 14 25 L 15 25 L 16 25 L 16 21 L 15 21 L 14 21 L 13 21 z M 17 21 L 17 22 L 18 22 L 18 25 L 19 25 L 19 22 L 19 21 L 17 21 z M 14 22 L 15 22 L 15 24 L 14 24 L 14 22 z "
+     id="rect3026" />
+</svg>

--- a/Numix/32/mimetypes/text-x-gettext-translation-template.svg
+++ b/Numix/32/mimetypes/text-x-gettext-translation-template.svg
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   height="32"
+   viewBox="0 0 32 32"
+   id="svg2993"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="text-x-gettext-translation-template0.svg">
+  <metadata
+     id="metadata3019">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3017" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview3015"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="9.0057212"
+     inkscape:cy="13.078622"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2993">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3039" />
+  </sodipodi:namedview>
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#dda06a;fill-opacity:1"
+     d="M 5.34375,0 C 4.6562764,1.5e-5 4,0.689007 4,1.40625 l 0,29.1875 C 4,31.270239 4.6953364,32 5.34375,32 l 21.3125,0 C 27.304664,32 28,31.270239 28,30.59375 L 28,8.9999996 28,1.375 C 28,0.702049 27.297951,0 26.625,0 L 19,0 5.34375,0 z"
+     id="path4-1" />
+  <path
+     style="fill:#000000;fill-opacity:0.19599998"
+     d="m 4,24 0,6.667969 C 4,31.316407 4.6875,32 5.332031,32 l 21.335938,0 C 27.3125,32 28,31.316407 28,30.667969 L 28,24 Z"
+     id="path3025"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;fill-opacity:1"
+     d="m 16.099609,26 c -0.58064,1e-6 -1.034943,0.207912 -1.363281,0.632812 C 14.411446,27.050384 14.25,27.673888 14.25,28.498047 c 0,0.827822 0.156191,1.450101 0.470703,1.875 C 15.042129,30.79062 15.504542,31 16.109375,31 c 0.584096,0 1.039902,-0.20938 1.361328,-0.626953 0.317971,-0.424899 0.480469,-1.047178 0.480469,-1.875 -1e-6,-0.824158 -0.158145,-1.447663 -0.472656,-1.865235 C 17.164001,26.207913 16.704441,26 16.099609,26 Z M 18.5,26 l 0,1.001953 1.287109,0 0,4.003906 0.964844,0 0,-4.003906 1.248047,0 L 22,26 18.5,26 Z m -7.085938,0.0059 C 10.93179,26.0022 10.468948,26.06358 10,26.121094 l 0,4.884765 1,0 0,-1.625 0.386719,0 c 0.667044,0 1.177666,-0.168096 1.537109,-0.427734 0.366356,-0.263398 0.546875,-0.694247 0.546875,-1.28125 -1e-6,-0.583241 -0.181571,-1.017565 -0.541015,-1.273437 C 12.570246,26.1388 12.067262,26.01088 11.414062,26.005859 Z m 4.685547,0.822266 c 0.176266,0 0.318642,0.04295 0.425782,0.130859 0.103686,0.08791 0.182984,0.205289 0.238281,0.355469 0.06222,0.150182 0.0999,0.326368 0.117187,0.535156 0.02073,0.201461 0.03516,0.417674 0.03516,0.648438 0,0.234428 -0.01442,0.450882 -0.03516,0.652344 -0.01728,0.201461 -0.05497,0.377652 -0.117187,0.535156 -0.0553,0.150182 -0.139402,0.267557 -0.25,0.355469 -0.103685,0.08791 -0.241254,0.130859 -0.414063,0.130859 -0.176266,0 -0.318189,-0.04295 -0.421875,-0.130859 -0.107142,-0.08791 -0.191238,-0.205289 -0.25,-0.355469 -0.05531,-0.150178 -0.0945,-0.325882 -0.115234,-0.527344 -0.01728,-0.205124 -0.02539,-0.425728 -0.02539,-0.660156 0,-0.230764 0.0081,-0.446977 0.02539,-0.648438 0.02074,-0.201462 0.05994,-0.377163 0.115234,-0.527343 0.05875,-0.153844 0.142858,-0.27537 0.25,-0.363282 0.103686,-0.08792 0.245609,-0.130859 0.421875,-0.130859 z m -4.572265,0.08203 c 0.273029,-0.0023 0.48795,0.05928 0.65039,0.179688 0.165896,0.116648 0.248047,0.290196 0.248047,0.576172 0,0.301028 -0.08215,0.483392 -0.248047,0.611328 -0.165896,0.120405 -0.41626,0.161261 -0.740234,0.185547 l -0.4375,0 0,-1.541016 c 0.179305,-0.0099 0.380857,-0.01052 0.527344,-0.01172 z"
+     id="path20" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.1375"
+     d="m 12,10 0,12 1,0 0,-5 8.999916,0 -3.499833,-3 3.499833,-3 L 13,11 13,10 Z"
+     id="rect4148"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccc" />
+</svg>

--- a/Numix/32/mimetypes/text-x-gettext-translation-template.svg
+++ b/Numix/32/mimetypes/text-x-gettext-translation-template.svg
@@ -13,7 +13,7 @@
    id="svg2993"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="text-x-gettext-translation-template0.svg">
+   sodipodi:docname="text-x-gettext-translation-template.svg">
   <metadata
      id="metadata3019">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -41,8 +41,8 @@
      inkscape:window-height="704"
      id="namedview3015"
      showgrid="false"
-     inkscape:zoom="1"
-     inkscape:cx="9.0057212"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="11.808219"
      inkscape:cy="13.078622"
      inkscape:window-x="0"
      inkscape:window-y="27"
@@ -69,7 +69,7 @@
      id="path20" />
   <path
      style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.1375"
-     d="m 12,10 0,12 1,0 0,-5 8.999916,0 -3.499833,-3 3.499833,-3 L 13,11 13,10 Z"
+     d="m 12,8 0,12 1,0 0,-5 8.999916,0 L 18.500083,12 21.999916,9 13,9 13,8 Z"
      id="rect4148"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cccccccccc" />

--- a/Numix/32/mimetypes/text-x-gettext-translation.svg
+++ b/Numix/32/mimetypes/text-x-gettext-translation.svg
@@ -1,0 +1,1 @@
+text-x-po.svg

--- a/Numix/32/mimetypes/text-x-po.svg
+++ b/Numix/32/mimetypes/text-x-po.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 32 32"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="text-x-po0.svg">
+  <metadata
+     id="metadata18">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs16" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview14"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="10.146504"
+     inkscape:cy="11.700785"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:object-nodes="true"
+     showguides="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4154" />
+  </sodipodi:namedview>
+  <path
+     d="m 5.336 0 c -0.687 0 -1.336 0.676 -1.336 1.394 l 0 29.21 c 0 0.676 0.687 1.394 1.336 1.394 l 21.327 0 c 0.648 0 1.336 -0.717 1.336 -1.394 l 0.001 -21.606 l -9 -9 z"
+     style="fill:#dda06a;fill-opacity:1"
+     id="path4" />
+  <path
+     d="m 21 9 7 7 0 -7 z"
+     style="fill:#000;fill-opacity:0.196"
+     id="path6" />
+  <path
+     d="m 19 0 8.992 9 -7.613 0 c -0.673 0 -1.378 -0.713 -1.378 -1.386 z"
+     style="fill:#fff;fill-opacity:0.392"
+     id="path8" />
+  <path
+     style="fill:#000000;fill-opacity:0.19599998"
+     d="m 4,24 0,6.667969 C 4,31.316407 4.6875,32 5.332031,32 l 21.335938,0 C 27.3125,32 28,31.316407 28,30.667969 L 28,24 Z"
+     id="path3025"
+     inkscape:connector-curvature="0" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     d="M 18.074219 26 C 17.470418 26.000001 16.997685 26.207912 16.65625 26.632812 C 16.318409 27.050384 16.150391 27.673888 16.150391 28.498047 C 16.150391 29.325869 16.313568 29.948148 16.640625 30.373047 C 16.974873 30.79062 17.455028 31 18.083984 31 C 18.691379 31 19.165751 30.79062 19.5 30.373047 C 19.830653 29.948148 20 29.325869 20 28.498047 C 19.999999 27.673889 19.834868 27.050384 19.507812 26.632812 C 19.180751 26.207912 18.703177 26 18.074219 26 z M 13.466797 26.005859 C 12.966363 26.00211 12.486608 26.06358 12 26.121094 L 12 31.005859 L 13 31.005859 L 13 29.380859 L 13.4375 29.380859 C 14.129664 29.380859 14.660226 29.212763 15.033203 28.953125 C 15.413356 28.689727 15.599609 28.258878 15.599609 27.671875 C 15.599608 27.088634 15.412043 26.65431 15.039062 26.398438 C 14.666085 26.1388 14.144593 26.01088 13.466797 26.005859 z M 18.074219 26.828125 C 18.257516 26.828125 18.425697 26.871075 18.537109 26.958984 C 18.644932 27.046894 18.727653 27.164273 18.785156 27.314453 C 18.849856 27.464635 18.888279 27.640821 18.90625 27.849609 C 18.9278 28.05107 18.941406 28.267283 18.941406 28.498047 C 18.941406 28.732475 18.92782 28.948929 18.90625 29.150391 C 18.8883 29.351852 18.849858 29.528043 18.785156 29.685547 C 18.727646 29.835729 18.638445 29.953104 18.523438 30.041016 C 18.415613 30.128926 18.253922 30.171875 18.074219 30.171875 C 17.890922 30.171875 17.7211 30.128925 17.613281 30.041016 C 17.501864 29.953106 17.416576 29.835727 17.355469 29.685547 C 17.297949 29.535369 17.255938 29.359665 17.234375 29.158203 C 17.216415 28.953079 17.208984 28.732475 17.208984 28.498047 C 17.208984 28.267283 17.216425 28.05107 17.234375 27.849609 C 17.255935 27.648147 17.297976 27.472446 17.355469 27.322266 C 17.416549 27.168422 17.501865 27.046896 17.613281 26.958984 C 17.7211 26.871064 17.890922 26.828125 18.074219 26.828125 z M 13.585938 26.910156 C 13.86925 26.907856 14.091208 26.969436 14.259766 27.089844 C 14.43191 27.206492 14.517578 27.38004 14.517578 27.666016 C 14.517578 27.967044 14.431908 28.149408 14.259766 28.277344 C 14.087623 28.397749 13.826409 28.438605 13.490234 28.462891 L 13 28.462891 L 13 26.921875 C 13.186057 26.911975 13.433936 26.911356 13.585938 26.910156 z "
+     id="path20" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.1375"
+     d="m 12,10 0,12 1,0 0,-5 8.999916,0 -3.499833,-3 3.499833,-3 L 13,11 13,10 Z"
+     id="rect4148"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccc" />
+</svg>

--- a/Numix/48/mimetypes/application-x-gettext-translation.svg
+++ b/Numix/48/mimetypes/application-x-gettext-translation.svg
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   viewBox="0 0 48 48"
+   height="48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="application-x-gettext-translation.svg">
+  <metadata
+     id="metadata36">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs34" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview32"
+     showgrid="true"
+     inkscape:zoom="11.91033"
+     inkscape:cx="3.574075"
+     inkscape:cy="16.751926"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3013" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#dda06a;fill-opacity:1"
+     d="M 8,1 C 6.9714285,1 6,1.9714285 6,3 l 0,42 c 0,0.971429 1.0285714,2 2,2 l 32,0 c 0.971429,0 2,-1.028571 2,-2 L 42,14 29,1 z"
+     id="path4" />
+  <path
+     style="fill-opacity:.196"
+     d="M 29,12 29.0625,12.0625 29.21875,12 29,12 z m 2,2 11,11 0,-11 -11,0 z"
+     id="path6" />
+  <path
+     style="fill:#fff;fill-opacity:.392"
+     d="m 29,1 13,13 -11,0 c -0.971429,0 -2,-1.028571 -2,-2 L 29,1 z"
+     id="path8" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke:none"
+     d="M 16 12 L 16 13 L 17 13 L 17 17 L 18 17 L 18 12 L 17 12 L 16 12 z "
+     id="rect3015" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke:none"
+     d="m 16,19 0,1 1,0 0,4 1,0 0,-4 0,-1 -2,0 z"
+     id="rect3019"
+     inkscape:connector-curvature="0" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke:none"
+     d="m 19,19 0,1 0,4 1,0 1,0 1,0 0,-4 0,-1 -3,0 z m 1,1 1,0 0,3 -1,0 0,-3 z"
+     id="rect3023"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;fill-opacity:1;stroke:none"
+     d="m 16,26 0,1 1,0 0,4 1,0 0,-4 0,-1 -2,0 z"
+     id="rect3019-6" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;fill-opacity:1;stroke:none"
+     d="m 19,26 0,1 0,4 1,0 1,0 1,0 0,-4 0,-1 -3,0 z m 1,1 1,0 0,3 -1,0 0,-3 z"
+     id="rect3023-4" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;fill-opacity:1;stroke:none"
+     d="m 16,33 0,1 1,0 0,4 1,0 0,-4 0,-1 -2,0 z"
+     id="rect3019-6-6" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;fill-opacity:1;stroke:none"
+     d="m 19,33 0,1 0,4 1,0 1,0 1,0 0,-4 0,-1 -3,0 z m 1,1 1,0 0,3 -1,0 0,-3 z"
+     id="rect3023-4-3" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;fill-opacity:1;stroke:none"
+     d="m 23,33 0,1 1,0 0,4 1,0 0,-4 0,-1 -2,0 z"
+     id="rect3019-6-6-7" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;fill-opacity:1;stroke:none"
+     d="m 26,33 0,1 0,4 1,0 1,0 1,0 0,-4 0,-1 -3,0 z m 1,1 1,0 0,3 -1,0 0,-3 z"
+     id="rect3023-4-3-2" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;fill-opacity:1;stroke:none"
+     d="m 23,26 0,1 1,0 0,4 1,0 0,-4 0,-1 -2,0 z"
+     id="rect3019-6-6-7-5" />
+</svg>

--- a/Numix/48/mimetypes/text-x-gettext-translation-template.svg
+++ b/Numix/48/mimetypes/text-x-gettext-translation-template.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   viewBox="0 0 48 48"
+   height="48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="text-x-gettext-translation-template0.svg">
+  <metadata
+     id="metadata30">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs28" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview26"
+     showgrid="false"
+     inkscape:zoom="2.1054688"
+     inkscape:cx="-90.917842"
+     inkscape:cy="26.745379"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3030" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#dda06a;fill-opacity:1"
+     d="M 8 1 C 6.9714285 1 6 1.9714285 6 3 L 6 14 L 6 45 C 6 45.971429 7.0285714 47 8 47 L 40 47 C 40.971429 47 42 45.971429 42 45 L 42 14 L 42 3 C 42 1.9714285 41.028571 1 40 1 L 29 1 L 19 1 L 8 1 z "
+     id="path4" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#000000;fill-opacity:0.19607843"
+     d="m 6,35 0,10 c 0,0.971429 1.028571,2 2,2 l 32,0 c 0.971429,0 2,-1.028571 2,-2 l 0,-10 z"
+     id="path20" />
+  <path
+     style="line-height:125%;letter-spacing:0;word-spacing:0;fill:#ffffff;fill-opacity:1"
+     d="m 17.152344,38 c -0.143563,8e-6 -0.306405,0.0044 -0.492188,0.01172 -0.185786,0.0073 -0.376083,0.01859 -0.570312,0.0332 -0.194232,0.0073 -0.389757,0.02106 -0.583985,0.04297 C 15.320073,38.10981 15.152005,38.13679 15,38.16602 L 15,45 l 1.556641,0 0,-2.431641 0.558593,0 c 1.013368,2e-6 1.794836,-0.179288 2.34375,-0.537109 0.557348,-0.365118 0.835933,-0.9531 0.835938,-1.763672 -6e-6,-0.80326 -0.273361,-1.379947 -0.822266,-1.730469 C 18.923742,38.179298 18.148823,38.000014 17.152344,38 Z m 10.146484,0 0,1.292969 2.066406,0 0,5.707031 1.570313,0 0,-5.707031 2.064453,0 L 33,38 27.298828,38 Z m -3.482422,0.04102 c -0.886703,7e-6 -1.577933,0.295952 -2.076172,0.884765 -0.498243,0.581644 -0.748048,1.446792 -0.748046,2.595703 -2e-6,1.148918 0.239349,2.016651 0.720703,2.605469 C 22.202685,44.708591 22.909595,45 23.830078,45 c 0.89514,0 1.588323,-0.291409 2.078125,-0.873047 0.489791,-0.588818 0.73437,-1.456551 0.734375,-2.605469 -5e-6,-1.148911 -0.24131,-2.014059 -0.722656,-2.595703 -0.481357,-0.588813 -1.18304,-0.884758 -2.103516,-0.884765 z m -6.486328,1.132812 c 0.413792,6e-6 0.743379,0.084 0.988281,0.251953 0.25334,0.160657 0.380856,0.437706 0.38086,0.832031 -4e-6,0.416242 -0.12752,0.711465 -0.38086,0.886719 -0.253347,0.167959 -0.628716,0.251956 -1.126953,0.251953 l -0.634765,0 0,-2.191406 c 0.09289,-0.01456 0.222358,-0.02148 0.382812,-0.02148 0.168893,-0.0073 0.297729,-0.0098 0.390625,-0.0098 z m 6.486328,0.02148 c 0.270229,6e-6 0.486031,0.05957 0.646485,0.181641 0.160446,0.122077 0.28273,0.287858 0.367187,0.496094 0.09288,0.208245 0.15239,0.454963 0.177734,0.742187 0.03377,0.280052 0.05078,0.583121 0.05078,0.90625 -9e-6,0.323136 -0.01701,0.624251 -0.05078,0.904297 -0.02534,0.28005 -0.08485,0.526768 -0.177734,0.742188 -0.08445,0.208243 -0.211967,0.374023 -0.380859,0.496093 -0.160454,0.122079 -0.371027,0.183595 -0.632813,0.183594 -0.270235,10e-7 -0.486036,-0.06152 -0.646484,-0.183594 -0.160454,-0.12207 -0.28602,-0.28785 -0.378906,-0.496093 -0.08446,-0.208239 -0.143958,-0.450419 -0.177735,-0.730469 -0.02534,-0.287227 -0.03906,-0.59288 -0.03906,-0.916016 0,-0.323129 0.01373,-0.626198 0.03906,-0.90625 0.03377,-0.280043 0.09328,-0.524178 0.177735,-0.732422 0.09289,-0.215417 0.218452,-0.383782 0.378906,-0.505859 0.160448,-0.122069 0.376249,-0.181635 0.646484,-0.181641 z"
+     id="path24"
+     inkscape:connector-curvature="0" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.1375"
+     d="m 18,14 0,19 2,0 0,-8 12,0 -5.5,-4.5 5.499999,-4.500001 L 20,15.999999 20,14 Z"
+     id="rect4148"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccc" />
+</svg>

--- a/Numix/48/mimetypes/text-x-gettext-translation-template.svg
+++ b/Numix/48/mimetypes/text-x-gettext-translation-template.svg
@@ -13,7 +13,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="text-x-gettext-translation-template0.svg">
+   sodipodi:docname="text-x-gettext-translation-template.svg">
   <metadata
      id="metadata30">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -41,8 +41,8 @@
      inkscape:window-height="704"
      id="namedview26"
      showgrid="false"
-     inkscape:zoom="2.1054688"
-     inkscape:cx="-90.917842"
+     inkscape:zoom="1"
+     inkscape:cx="12.515256"
      inkscape:cy="26.745379"
      inkscape:window-x="0"
      inkscape:window-y="27"
@@ -68,7 +68,7 @@
      inkscape:connector-curvature="0" />
   <path
      style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.1375"
-     d="m 18,14 0,19 2,0 0,-8 12,0 -5.5,-4.5 5.499999,-4.500001 L 20,15.999999 20,14 Z"
+     d="m 18,11 0,19 2,0 0,-8 12,0 -5.5,-4.5 5.499999,-4.500001 L 20,12.999999 20,11 Z"
      id="rect4148"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cccccccccc" />

--- a/Numix/48/mimetypes/text-x-gettext-translation.svg
+++ b/Numix/48/mimetypes/text-x-gettext-translation.svg
@@ -1,0 +1,1 @@
+text-x-po.svg

--- a/Numix/48/mimetypes/text-x-po.svg
+++ b/Numix/48/mimetypes/text-x-po.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="text-x-po0.svg">
+  <metadata
+     id="metadata18">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs16" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview14"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="14.144574"
+     inkscape:cy="22.356354"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:object-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4158" />
+  </sodipodi:namedview>
+  <path
+     d="m 8 1 c -1.029 0 -2 0.971 -2 2 l 0 42 c 0 0.971 1.029 2 2 2 l 32 0 c 0.971 0 2 -1.029 2 -2 l 0 -31 -13 -13 z"
+     style="fill:#dda06a;fill-opacity:1"
+     id="path4" />
+  <path
+     d="m 29 12 0.063 0.063 0.156 -0.063 -0.219 0 z m 2 2 11 11 0 -11 -11 0 z"
+     style="fill-opacity:0.196"
+     id="path6" />
+  <path
+     d="m 29 1 13 13 -11 0 c -0.971 0 -2 -1.029 -2 -2 l 0 -11 z"
+     style="fill:#fff;fill-opacity:0.392"
+     id="path8" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill-opacity:0.19607843;fill:#000000"
+     d="m 6,35 0,10 c 0,0.971429 1.028571,2 2,2 l 32,0 c 0.971429,0 2,-1.028571 2,-2 l 0,-10 z"
+     id="path20" />
+  <path
+     style="line-height:125%;letter-spacing:0;word-spacing:0;fill:#ffffff;fill-opacity:1"
+     d="m 20.21842,38 c -0.14797,8e-6 -0.315811,0.0044 -0.507298,0.01172 -0.191489,0.0073 -0.387629,0.01859 -0.58782,0.0332 -0.200195,0.0073 -0.401723,0.02106 -0.601913,0.04297 C 18.329899,38.10981 18.156671,38.13679 18,38.16602 L 18,45 l 1.604429,0 0,-2.431641 0.575742,0 c 1.044478,2e-6 1.849936,-0.179288 2.415702,-0.537109 0.574458,-0.365118 0.861596,-0.9531 0.861601,-1.763672 -6e-6,-0.80326 -0.281753,-1.379947 -0.847509,-1.730469 C 22.044199,38.179298 21.24549,38.000014 20.21842,38 Z m 6.868646,0.04102 c -0.913925,7e-6 -1.626375,0.295952 -2.13991,0.884765 -0.513539,0.581644 -0.771013,1.446792 -0.77101,2.595703 -3e-6,1.148918 0.246696,2.016651 0.742828,2.605469 C 25.423804,44.708591 26.152416,45 27.101157,45 28.023778,45 28.738241,44.708591 29.24308,44.126953 29.747907,43.538135 29.999995,42.670402 30,41.521484 29.999995,40.372573 29.751282,39.507425 29.255159,38.925781 28.759024,38.336968 28.0358,38.041023 27.087066,38.04102 Z m -6.685456,1.132812 c 0.426496,6e-6 0.766201,0.084 1.018621,0.251953 0.261118,0.160657 0.392548,0.437706 0.392552,0.832031 -4e-6,0.416242 -0.131434,0.711465 -0.392552,0.886719 -0.261124,0.167959 -0.648017,0.251956 -1.16155,0.251953 l -0.654252,0 0,-2.191406 c 0.09574,-0.01456 0.229184,-0.02148 0.394564,-0.02148 0.174078,-0.0073 0.306869,-0.0098 0.402617,-0.0098 z m 6.685456,0.02148 c 0.278525,6e-6 0.500952,0.05957 0.666332,0.181641 0.165371,0.122077 0.291409,0.287858 0.378459,0.496094 0.09573,0.208245 0.157068,0.454963 0.18319,0.742187 0.03481,0.280052 0.05234,0.583121 0.05234,0.90625 -9e-6,0.323136 -0.01753,0.624251 -0.05234,0.904297 -0.02612,0.28005 -0.08745,0.526768 -0.18319,0.742188 -0.08704,0.208243 -0.218474,0.374023 -0.392551,0.496093 -0.16538,0.122079 -0.382418,0.183595 -0.65224,0.183594 -0.278531,10e-7 -0.500957,-0.06152 -0.666331,-0.183594 -0.16538,-0.12207 -0.294801,-0.28785 -0.390538,-0.496093 -0.08705,-0.208239 -0.148378,-0.450419 -0.183192,-0.730469 -0.02612,-0.287227 -0.04026,-0.59288 -0.04026,-0.916016 0,-0.323129 0.01415,-0.626198 0.04026,-0.90625 0.03481,-0.280043 0.09614,-0.524178 0.183192,-0.732422 0.09574,-0.215417 0.225158,-0.383782 0.390538,-0.505859 0.165374,-0.122069 0.3878,-0.181635 0.666331,-0.181641 z"
+     id="path24"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccccccsccccccscscsccccccscccccccccccccscccscccc" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.1375"
+     d="m 18,14 0,19 2,0 0,-8 12,0 -5.5,-4.5 5.499999,-4.500001 L 20,15.999999 20,14 Z"
+     id="rect4148"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccc" />
+</svg>

--- a/Numix/64/mimetypes/application-x-gettext-translation.svg
+++ b/Numix/64/mimetypes/application-x-gettext-translation.svg
@@ -13,7 +13,7 @@
    version="1.1"
    id="svg2"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="application-octet-stream2.svg">
+   sodipodi:docname="application-x-gettext-translation.svg">
   <metadata
      id="metadata17">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -41,8 +41,8 @@
      inkscape:window-height="704"
      id="namedview13"
      showgrid="false"
-     inkscape:zoom="1"
-     inkscape:cx="25.914399"
+     inkscape:zoom="4.4329987"
+     inkscape:cx="0.45735823"
      inkscape:cy="24.102104"
      inkscape:window-x="0"
      inkscape:window-y="27"
@@ -55,7 +55,7 @@
   <g
      id="surface1">
     <path
-       style=" stroke:none;fill-rule:nonzero;fill:rgb(86.27451%,86.27451%,86.27451%);fill-opacity:1;"
+       style="stroke:none;fill-rule:nonzero;fill:#dda06a;fill-opacity:1"
        d="M 10.671875 0 C 9.296875 0 8 1.355469 8 2.789062 L 8 61.210938 C 8 62.566406 9.375 64 10.671875 64 L 53.328125 64 C 54.625 64 56 62.566406 56 61.210938 L 56 18 L 38 0 Z M 10.671875 0 "
        id="path5" />
     <path
@@ -67,7 +67,7 @@
        d="M 38 0 L 55.984375 18 L 40.757812 18 C 39.410156 18 38 16.574219 38 15.226562 Z M 38 0 "
        id="path9" />
     <path
-       style="fill:#515151;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
        d="m 19,15 0,2 2,0 0,6 2,0 0,-8 z m 0,10 0,2 2,0 0,6 2,0 0,-8 z m 6,0 0,8 6,0 0,-8 z m 2,2 2,0 0,4 -2,0 z m -8,8 0,2 2,0 0,6 2,0 0,-8 z m 6,0 0,8 6,0 0,-8 z m 8,0 0,2 2,0 0,6 2,0 0,-8 z m -6,2 2,0 0,4 -2,0 z m -8,8 0,2 2,0 0,6 2,0 0,-8 z m 6,0 0,8 6,0 0,-8 z m 8,0 0,2 2,0 0,6 2,0 0,-8 z m 6,0 0,8 6,0 0,-8 z m -12,2 2,0 0,4 -2,0 z m 14,0 2,0 0,4 -2,0 z"
        id="path11"
        inkscape:connector-curvature="0"

--- a/Numix/64/mimetypes/text-x-gettext-translation-template.svg
+++ b/Numix/64/mimetypes/text-x-gettext-translation-template.svg
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   viewBox="0 0 64 64"
+   version="1.1"
+   id="svg2"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="text-x-gettext-translation-template0.svg">
+  <metadata
+     id="metadata27">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs25" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview23"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="6.9922657"
+     inkscape:cy="32"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4143" />
+  </sodipodi:namedview>
+  <g
+     id="surface1">
+    <path
+       style="stroke:none;fill-rule:nonzero;fill:#dda06a;fill-opacity:1"
+       d="M 10.6875 0 C 9.3125 0 8 1.378906 8 2.8125 L 8 61.1875 C 8 62.539062 9.390625 64 10.6875 64 L 53.3125 64 C 54.609375 64 56 62.539062 56 61.1875 L 56 2.75 C 56 1.402344 54.597656 0 53.25 0 Z M 10.6875 0 "
+       id="path5" />
+  </g>
+  <path
+     style="fill:#000000;fill-opacity:0.19599998"
+     d="M 8,48 8,61.335938 C 8,62.632814 9.375,64 10.664062,64 l 42.671876,0 C 54.625,64 56,62.632814 56,61.335938 L 56,48 Z"
+     id="path3025"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;fill-opacity:1"
+     d="m 32.199218,52 c -1.16128,2e-6 -2.069886,0.415824 -2.726562,1.265624 C 28.822892,54.100768 28.5,55.347776 28.5,56.996094 c 0,1.655644 0.312382,2.900202 0.941406,3.75 C 30.084258,61.58124 31.009084,62 32.21875,62 c 1.168192,0 2.079804,-0.41876 2.722656,-1.253906 0.635942,-0.849798 0.960938,-2.094356 0.960938,-3.75 -2e-6,-1.648316 -0.31629,-2.895326 -0.945312,-3.73047 C 34.328002,52.415826 33.408882,52 32.199218,52 Z M 37,52 l 0,2.003906 2.5,0 0,8.007812 2,0 0,-8.007812 2.5,0 L 44,52 Z M 22.828124,52.0118 C 21.86358,52.0044 20.937896,52.12716 20,52.242188 l 0,9.76953 2,0 0,-3.25 0.773438,0 c 1.334088,0 2.355332,-0.336192 3.074218,-0.855468 0.732712,-0.526796 1.09375,-1.388494 1.09375,-2.5625 -2e-6,-1.166482 -0.363142,-2.03513 -1.08203,-2.546874 C 25.140492,52.2776 24.134524,52.02176 22.828124,52.011718 Z m 9.371094,1.644532 c 0.352532,0 0.637284,0.0859 0.851564,0.261718 0.207372,0.17582 0.365968,0.410578 0.476562,0.710938 0.12444,0.300364 0.1998,0.652736 0.234374,1.070312 0.04146,0.402922 0.07032,0.835348 0.07032,1.296876 0,0.468856 -0.02884,0.901764 -0.07032,1.304688 -0.03456,0.402922 -0.10994,0.755304 -0.234374,1.070312 -0.1106,0.300364 -0.278804,0.535114 -0.5,0.710938 -0.20737,0.17582 -0.482508,0.261718 -0.828126,0.261718 -0.352532,0 -0.636378,-0.0859 -0.84375,-0.261718 -0.214284,-0.17582 -0.382476,-0.410578 -0.5,-0.710938 -0.11062,-0.300356 -0.189,-0.651764 -0.230468,-1.054688 -0.03456,-0.410248 -0.05078,-0.851456 -0.05078,-1.320312 0,-0.461528 0.0162,-0.893954 0.05078,-1.296876 0.04148,-0.402924 0.11988,-0.754326 0.230468,-1.054686 0.1175,-0.307688 0.285716,-0.55074 0.5,-0.726564 0.207372,-0.17584 0.491218,-0.261718 0.84375,-0.261718 z m -9.14453,0.16406 c 0.546058,-0.0046 0.9759,0.11856 1.30078,0.359376 0.331792,0.233296 0.496094,0.580392 0.496094,1.152344 0,0.602056 -0.1643,0.966784 -0.496094,1.222656 -0.331792,0.24081 -0.83252,0.322522 -1.480468,0.371094 l -0.875,0 0,-3.082032 c 0.35861,-0.0198 0.761714,-0.02104 1.054688,-0.02344 z"
+     id="path20"
+     sodipodi:nodetypes="scscscscsccccccccccccccscscccscccscccscccscccsccsccccc" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.1375"
+     d="m 24,19 0,25 2,0 0,-12 15.999999,0 L 35.500042,26.5 42,21 26,21 26,19 Z"
+     id="rect4148"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccc" />
+</svg>

--- a/Numix/64/mimetypes/text-x-gettext-translation-template.svg
+++ b/Numix/64/mimetypes/text-x-gettext-translation-template.svg
@@ -13,7 +13,7 @@
    version="1.1"
    id="svg2"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="text-x-gettext-translation-template0.svg">
+   sodipodi:docname="text-x-gettext-translation-template.svg">
   <metadata
      id="metadata27">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -41,8 +41,8 @@
      inkscape:window-height="704"
      id="namedview23"
      showgrid="false"
-     inkscape:zoom="1"
-     inkscape:cx="6.9922657"
+     inkscape:zoom="5.9551649"
+     inkscape:cx="18.011442"
      inkscape:cy="32"
      inkscape:window-x="0"
      inkscape:window-y="27"
@@ -72,7 +72,7 @@
      sodipodi:nodetypes="scscscscsccccccccccccccscscccscccscccscccscccsccsccccc" />
   <path
      style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.1375"
-     d="m 24,19 0,25 2,0 0,-12 15.999999,0 L 35.500042,26.5 42,21 26,21 26,19 Z"
+     d="m 24,15 0,25 2,0 0,-12 15.999999,0 L 35.500042,22.5 42,17 26,17 26,15 Z"
      id="rect4148"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cccccccccc" />

--- a/Numix/64/mimetypes/text-x-gettext-translation.svg
+++ b/Numix/64/mimetypes/text-x-gettext-translation.svg
@@ -1,0 +1,1 @@
+text-x-po.svg

--- a/Numix/64/mimetypes/text-x-po.svg
+++ b/Numix/64/mimetypes/text-x-po.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 64 64"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="text-x-po0.svg">
+  <metadata
+     id="metadata20">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs18" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview16"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="25.644898"
+     inkscape:cy="32.334811"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4158" />
+  </sodipodi:namedview>
+  <g
+     id="g4">
+    <path
+       d="m 10.672 0 c -1.375 0 -2.672 1.355 -2.672 2.789 l 0 58.42 c 0 1.355 1.375 2.789 2.672 2.789 l 42.656 0 c 1.297 0 2.672 -1.434 2.672 -2.789 l 0 -43.21 l -18 -18 m -27.328 0"
+       style="fill:#dda06a;fill-opacity:1;stroke:none;fill-rule:nonzero"
+       id="path6" />
+    <path
+       d="m 42 18 l 14 14 l 0 -14 m -14 0"
+       style="fill:#000;fill-opacity:0.196;stroke:none;fill-rule:nonzero"
+       id="path8" />
+    <path
+       d="m 38 0 l 17.984 18 l -15.227 0 c -1.348 0 -2.758 -1.426 -2.758 -2.773 m 0 -15.227"
+       style="fill:#fff;fill-opacity:0.392;stroke:none;fill-rule:nonzero"
+       id="path10" />
+    <g
+       transform="matrix(2.182419,0,0,2.1797494,-0.92223015,-3.8581025)"
+       style="fill:#888"
+       id="g12" />
+  </g>
+  <path
+     style="fill:#000000;fill-opacity:0.19599998"
+     d="M 8,48 8,61.335938 C 8,62.632814 9.375,64 10.664062,64 l 42.671876,0 C 54.625,64 56,62.632814 56,61.335938 L 56,48 Z"
+     id="path3025"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;fill-opacity:1"
+     d="m 35.998047,52 c -1.207602,2e-6 -2.153068,0.415337 -2.835938,1.264143 -0.675682,0.834166 -1.011718,2.079715 -1.011718,3.726103 0,1.653707 0.326354,2.896808 0.980468,3.745611 0.668496,0.834169 1.628806,1.252439 2.886718,1.252439 1.21479,0 2.163534,-0.41827 2.832032,-1.252439 0.661306,-0.848803 1,-2.091904 1,-3.745611 -2e-6,-1.646386 -0.330264,-2.891937 -0.984376,-3.726103 C 38.211111,52.415337 37.255963,52 35.998047,52 Z m -9.064453,0.01179 C 25.932726,52.004215 24.973216,52.127011 24,52.241905 L 24,62 l 2,0 0,-3.246196 0.875,0 c 1.384328,0 2.445452,-0.335799 3.191406,-0.854467 0.760306,-0.526179 1.132812,-1.386869 1.132812,-2.559501 -2e-6,-1.165116 -0.375132,-2.032748 -1.121094,-2.543893 -0.745954,-0.518668 -1.788938,-0.774208 -3.14453,-0.784239 z m 9.064453,1.642607 c 0.366594,0 0.702956,0.0858 0.92578,0.261412 0.215646,0.175614 0.381088,0.410098 0.496094,0.710106 0.1294,0.300012 0.206246,0.651972 0.242188,1.069059 0.0431,0.402451 0.07032,0.834371 0.07032,1.295358 0,0.468308 -0.02718,0.900709 -0.07032,1.303161 -0.0359,0.402451 -0.11278,0.75442 -0.242188,1.06906 -0.11502,0.300012 -0.293422,0.534487 -0.523436,0.710105 -0.21565,0.175615 -0.539032,0.261412 -0.898438,0.261412 -0.366594,0 -0.706238,-0.0858 -0.921876,-0.261412 -0.222834,-0.175614 -0.39341,-0.410097 -0.515624,-0.710105 -0.11504,-0.300005 -0.19906,-0.651002 -0.242188,-1.053454 -0.03592,-0.409768 -0.05078,-0.850459 -0.05078,-1.318767 0,-0.460987 0.0148,-0.892907 0.05078,-1.295358 0.04312,-0.402452 0.1272,-0.753443 0.242188,-1.053451 0.12216,-0.307328 0.292792,-0.550096 0.515624,-0.725714 0.215638,-0.175634 0.555282,-0.261412 0.921876,-0.261412 z m -8.826171,0.163868 c 0.566624,-0.0046 1.01054,0.118422 1.347656,0.358956 0.344288,0.233023 0.515624,0.579712 0.515624,1.150995 0,0.601351 -0.17134,0.965652 -0.515624,1.221225 -0.344286,0.240528 -0.866714,0.322144 -1.539064,0.37066 l -0.980468,0 0,-3.078425 c 0.372114,-0.01978 0.867872,-0.02102 1.171876,-0.02341 z"
+     id="path20"
+     sodipodi:nodetypes="scscscscscccccscscccscccscccscccscccsccsccccc" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.1375"
+     d="m 24,19 0,25 2,0 0,-12 15.999999,0 L 35.500042,26.5 42,21 26,21 26,19 Z"
+     id="rect4148"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccc" />
+</svg>


### PR DESCRIPTION
Fixes #563 
``text-x-po`` from #580 

Additional mimetypes for ``.pot`` and ``.mo`` files (recoloured ``application-octet-stream``).

![16-64](https://github-cloud.s3.amazonaws.com/assets/7050624/10565276/3e2c0ef8-75cd-11e5-8370-97527d030b9c.png)

Edited the 64px ``application-octet-stream`` icon which was simply scaled up from 32px and hence less detailed than the 48px one.
