### PR TITLE
Symlinks for some -rtl icons

### DIFF
--- a/Numix/16/actions/edit-redo-rtl.svg
+++ b/Numix/16/actions/edit-redo-rtl.svg
@@ -1,0 +1,1 @@
+edit-undo.svg

--- a/Numix/16/actions/edit-undo-rtl.svg
+++ b/Numix/16/actions/edit-undo-rtl.svg
@@ -1,0 +1,1 @@
+edit-redo.svg

--- a/Numix/16/actions/go-first-rtl.svg
+++ b/Numix/16/actions/go-first-rtl.svg
@@ -1,0 +1,1 @@
+go-last.svg

--- a/Numix/16/actions/go-jump-rtl.svg
+++ b/Numix/16/actions/go-jump-rtl.svg
@@ -1,0 +1,1 @@
+go-jump.svg

--- a/Numix/16/actions/go-last-rtl.svg
+++ b/Numix/16/actions/go-last-rtl.svg
@@ -1,0 +1,1 @@
+go-first.svg

--- a/Numix/16/actions/go-next-rtl.svg
+++ b/Numix/16/actions/go-next-rtl.svg
@@ -1,0 +1,1 @@
+go-previous.svg

--- a/Numix/16/actions/go-previous-rtl.svg
+++ b/Numix/16/actions/go-previous-rtl.svg
@@ -1,0 +1,1 @@
+go-next.svg

--- a/Numix/22/actions/edit-redo-rtl.svg
+++ b/Numix/22/actions/edit-redo-rtl.svg
@@ -1,0 +1,1 @@
+edit-undo.svg

--- a/Numix/22/actions/edit-undo-rtl.svg
+++ b/Numix/22/actions/edit-undo-rtl.svg
@@ -1,0 +1,1 @@
+edit-redo.svg

--- a/Numix/22/actions/go-first-rtl.svg
+++ b/Numix/22/actions/go-first-rtl.svg
@@ -1,0 +1,1 @@
+go-last.svg

--- a/Numix/22/actions/go-jump-rtl.svg
+++ b/Numix/22/actions/go-jump-rtl.svg
@@ -1,0 +1,1 @@
+go-jump.svg

--- a/Numix/22/actions/go-last-rtl.svg
+++ b/Numix/22/actions/go-last-rtl.svg
@@ -1,0 +1,1 @@
+go-first.svg

--- a/Numix/22/actions/go-next-rtl.svg
+++ b/Numix/22/actions/go-next-rtl.svg
@@ -1,0 +1,1 @@
+go-previous.svg

--- a/Numix/22/actions/go-previous-rtl.svg
+++ b/Numix/22/actions/go-previous-rtl.svg
@@ -1,0 +1,1 @@
+go-next.svg

--- a/Numix/24/actions/edit-redo-rtl.svg
+++ b/Numix/24/actions/edit-redo-rtl.svg
@@ -1,0 +1,1 @@
+edit-undo.svg

--- a/Numix/24/actions/edit-undo-rtl.svg
+++ b/Numix/24/actions/edit-undo-rtl.svg
@@ -1,0 +1,1 @@
+edit-redo.svg

--- a/Numix/24/actions/go-first-rtl.svg
+++ b/Numix/24/actions/go-first-rtl.svg
@@ -1,0 +1,1 @@
+go-last.svg

--- a/Numix/24/actions/go-jump-rtl.svg
+++ b/Numix/24/actions/go-jump-rtl.svg
@@ -1,0 +1,1 @@
+go-jump.svg

--- a/Numix/24/actions/go-last-rtl.svg
+++ b/Numix/24/actions/go-last-rtl.svg
@@ -1,0 +1,1 @@
+go-first.svg

--- a/Numix/24/actions/go-next-rtl.svg
+++ b/Numix/24/actions/go-next-rtl.svg
@@ -1,0 +1,1 @@
+go-previous.svg

--- a/Numix/24/actions/go-previous-rtl.svg
+++ b/Numix/24/actions/go-previous-rtl.svg
@@ -1,0 +1,1 @@
+go-next.svg

--- a/Numix/32/actions/edit-redo-rtl.svg
+++ b/Numix/32/actions/edit-redo-rtl.svg
@@ -1,0 +1,1 @@
+edit-undo.svg

--- a/Numix/32/actions/edit-undo-rtl.svg
+++ b/Numix/32/actions/edit-undo-rtl.svg
@@ -1,0 +1,1 @@
+edit-redo.svg

--- a/Numix/32/actions/go-first-rtl.svg
+++ b/Numix/32/actions/go-first-rtl.svg
@@ -1,0 +1,1 @@
+go-last.svg

--- a/Numix/32/actions/go-jump-rtl.svg
+++ b/Numix/32/actions/go-jump-rtl.svg
@@ -1,0 +1,1 @@
+go-jump.svg

--- a/Numix/32/actions/go-last-rtl.svg
+++ b/Numix/32/actions/go-last-rtl.svg
@@ -1,0 +1,1 @@
+go-first.svg

--- a/Numix/32/actions/go-next-rtl.svg
+++ b/Numix/32/actions/go-next-rtl.svg
@@ -1,0 +1,1 @@
+go-previous.svg

--- a/Numix/32/actions/go-previous-rtl.svg
+++ b/Numix/32/actions/go-previous-rtl.svg
@@ -1,0 +1,1 @@
+go-next.svg

--- a/Numix/48/actions/edit-redo-rtl.svg
+++ b/Numix/48/actions/edit-redo-rtl.svg
@@ -1,0 +1,1 @@
+edit-undo.svg

--- a/Numix/48/actions/edit-undo-rtl.svg
+++ b/Numix/48/actions/edit-undo-rtl.svg
@@ -1,0 +1,1 @@
+edit-redo.svg

--- a/Numix/48/actions/go-first-rtl.svg
+++ b/Numix/48/actions/go-first-rtl.svg
@@ -1,0 +1,1 @@
+go-last.svg

--- a/Numix/48/actions/go-jump-rtl.svg
+++ b/Numix/48/actions/go-jump-rtl.svg
@@ -1,0 +1,1 @@
+go-jump.svg

--- a/Numix/48/actions/go-last-rtl.svg
+++ b/Numix/48/actions/go-last-rtl.svg
@@ -1,0 +1,1 @@
+go-first.svg

--- a/Numix/48/actions/go-next-rtl.svg
+++ b/Numix/48/actions/go-next-rtl.svg
@@ -1,0 +1,1 @@
+go-previous.svg

--- a/Numix/48/actions/go-previous-rtl.svg
+++ b/Numix/48/actions/go-previous-rtl.svg
@@ -1,0 +1,1 @@
+go-next.svg

--- a/Numix/64/actions/edit-redo-rtl.svg
+++ b/Numix/64/actions/edit-redo-rtl.svg
@@ -1,0 +1,1 @@
+edit-undo.svg

--- a/Numix/64/actions/edit-undo-rtl.svg
+++ b/Numix/64/actions/edit-undo-rtl.svg
@@ -1,0 +1,1 @@
+edit-redo.svg

--- a/Numix/64/actions/go-first-rtl.svg
+++ b/Numix/64/actions/go-first-rtl.svg
@@ -1,0 +1,1 @@
+go-last.svg

--- a/Numix/64/actions/go-jump-rtl.svg
+++ b/Numix/64/actions/go-jump-rtl.svg
@@ -1,0 +1,1 @@
+go-jump.svg

--- a/Numix/64/actions/go-last-rtl.svg
+++ b/Numix/64/actions/go-last-rtl.svg
@@ -1,0 +1,1 @@
+go-first.svg

--- a/Numix/64/actions/go-next-rtl.svg
+++ b/Numix/64/actions/go-next-rtl.svg
@@ -1,0 +1,1 @@
+go-previous.svg

--- a/Numix/64/actions/go-previous-rtl.svg
+++ b/Numix/64/actions/go-previous-rtl.svg
@@ -1,0 +1,1 @@
+go-next.svg


### PR DESCRIPTION
The ones that can by done by symlinks.

From #437 and #577:

+ edit-undo-trl
+ edit-redo-rtl
+ go-first-rtl
+ go-last-rtl
+ go-jump-rtl
+ go-next-rtl
+ go-previous-rtl