### PR TITLE
Mimetype icon for Rust source files

### DIFF
--- a/Numix/16/mimetypes/text-rust.svg
+++ b/Numix/16/mimetypes/text-rust.svg
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="text-rust0d.svg">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="128"
+     inkscape:cx="7.4016933"
+     inkscape:cy="5.783347"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:object-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3004" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#b2542c;fill-opacity:1"
+     d="M 2.667969,-4.46e-4 C 2.324219,-4.46e-4 2,0.337812 2,0.696447 L 2,15.303108 C 2,15.641365 2.34375,16 2.667969,16 l 10.664062,0 C 13.65625,16 14,15.641365 14,15.303108 l 0,-11.303554 -4,-4 z"
+     id="path4-9"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssssccs" />
+  <path
+     style="fill:#000000;fill-opacity:0.19599998"
+     d="m 10.583223,3.331585 0.0154,0.01953 0.04005,-0.01953 z m 0.02978,0.667969 3.387,3.6640618 0,-3.6640618 z"
+     id="path6"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccc" />
+  <path
+     style="fill:#ffffff;fill-opacity:0.39200003"
+     d="m 10,-4.46e-4 3.996396,4 -3.383784,0 C 10.313513,3.999554 10,3.682437 10,3.383338 z"
+     id="path8"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccssc" />
+  <g
+     transform="matrix(1.1777925,0,0,1.061307,0,-2.2499953)"
+     style="font-style:normal;font-weight:normal;font-size:16.5667572px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="text4213" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 7.75 4 L 7.3125 5.1640625 A 3.9000001 3.9000001 0 0 0 6.6777344 5.3359375 L 5.7167969 4.5449219 L 5.2832031 4.7949219 L 5.4863281 6.0175781 A 3.9000001 3.9000001 0 0 0 5.0214844 6.4882812 L 3.7949219 6.2832031 L 3.5449219 6.7167969 L 4.3359375 7.6757812 A 3.9000001 3.9000001 0 0 0 4.1601562 8.3144531 L 3 8.75 L 3 9.25 L 4.1640625 9.6875 A 3.9000001 3.9000001 0 0 0 4.3359375 10.322266 L 3.5449219 11.283203 L 3.7949219 11.716797 L 5.0175781 11.513672 A 3.9000001 3.9000001 0 0 0 5.4882812 11.978516 L 5.2832031 13.205078 L 5.7167969 13.455078 L 6.6757812 12.664062 A 3.9000001 3.9000001 0 0 0 7.3144531 12.839844 L 7.75 14 L 8.25 14 L 8.6875 12.835938 A 3.9000001 3.9000001 0 0 0 9.3222656 12.664062 L 10.283203 13.455078 L 10.716797 13.205078 L 10.513672 11.982422 A 3.9000001 3.9000001 0 0 0 10.978516 11.511719 L 12.205078 11.716797 L 12.455078 11.283203 L 11.664062 10.324219 A 3.9000001 3.9000001 0 0 0 11.839844 9.6855469 L 13 9.25 L 13 8.75 L 11.835938 8.3125 A 3.9000001 3.9000001 0 0 0 11.664062 7.6777344 L 12.455078 6.7167969 L 12.205078 6.2832031 L 10.982422 6.4863281 A 3.9000001 3.9000001 0 0 0 10.511719 6.0214844 L 10.716797 4.7949219 L 10.283203 4.5449219 L 9.3242188 5.3359375 A 3.9000001 3.9000001 0 0 0 8.6855469 5.1601562 L 8.25 4 L 7.75 4 z M 8 6 A 3 3 0 0 1 11 9 A 3 3 0 0 1 8 12 A 3 3 0 0 1 5 9 A 3 3 0 0 1 8 6 z "
+     id="path4239" />
+  <path
+     sodipodi:nodetypes="cccscccscccccccccccccccccc"
+     inkscape:connector-curvature="0"
+     id="path4143"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:6.69263983px;line-height:125%;font-family:'Roboto Slab';-inkscape-font-specification:'Roboto Slab Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 8,7.0000002 c 1.1782291,0 2,0.4716883 2,1.3699998 0,0.6666665 -0.6960053,0.887096 -0.9925307,0.97 0.2931555,0.131533 0.5550824,0.182279 0.8719087,0.76 0.190801,0.347917 0.230895,0.333185 0.820622,0.349667 l 0,0.550332 -1.0769697,0 C 9.2088722,10.999999 9.098679,10.721295 8.87,10.3 8.5277207,9.669409 8.1440646,9.704439 7.7,9.7 l -0.7,0 0,0.733334 1,-1e-6 L 8,11 l -2.8,0 0,-0.566667 0.8,1e-6 0,-2.8666672 -0.8,0 0,-0.5666666 z M 7,9 8,9 C 8.7479105,8.9924001 9,8.7345419 9,8.37 9,7.8840572 8.5711064,7.75 8.1,7.75 l -1.1,0 z" />
+</svg>

--- a/Numix/22/mimetypes/text-rust.svg
+++ b/Numix/22/mimetypes/text-rust.svg
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   viewBox="0 0 22 22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="text-rust.svg">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview12"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="10.193993"
+     inkscape:cy="8.0031405"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:object-nodes="true"
+     showguides="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3004"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#b2542c;fill-opacity:1"
+     d="M 4,0 C 3.527343,0 3,0.527344 3,1 l 0,20 c 0,0.445312 0.554687,1 1,1 l 14,0 c 0.445313,0 0.992367,-0.554753 1,-1 L 19,6 13,0 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssssccs" />
+  <path
+     style="fill:#000000;fill-opacity:0.19599998"
+     d="m 14,6 5,5 0,-5 z"
+     id="path6"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccc" />
+  <path
+     style="fill:#ffffff;fill-opacity:0.39200003"
+     d="m 13,0 6,6 -5,0 C 13.554688,6 13,5.445312 13,5 z"
+     id="path8"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccssc" />
+  <path
+     sodipodi:nodetypes="cccscccscccccccccccccccccc"
+     inkscape:connector-curvature="0"
+     id="path4143"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:6.69263983px;line-height:125%;font-family:'Roboto Slab';-inkscape-font-specification:'Roboto Slab Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 10.989492,10 c 1.285341,0 2.207779,0.731246 2.210508,2 0,1 -0.702216,1.400644 -1.025698,1.525 0.319806,0.1973 0.405652,0.258464 0.751397,1.125 0.239395,0.6 0.430961,0.6 1.074301,0.624722 l 0,0.725277 -1.275,0 c -0.451809,0 -0.533532,-0.418056 -0.783,-1.049999 -0.373396,-0.945886 -0.747515,-0.943341 -1.231949,-0.949999 L 10,14 l 0,1.25 1,-2e-6 L 11,16 l -3,0 0,-0.750002 1,2e-6 0,-4.5 -1,0 L 8,10 Z M 10,13 l 1,0 c 0.815902,-0.0114 1.1,-0.453187 1.1,-1 5.39e-4,-0.650201 -0.486629,-1 -1.1,-1 l -1,0 z" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 10.699219 7 L 10.220703 8.0644531 A 5 5 0 0 0 9.203125 8.3339844 L 8.2597656 7.6542969 L 7.7402344 7.953125 L 7.8574219 9.1152344 A 5 5 0 0 0 7.1152344 9.8574219 L 5.953125 9.7402344 L 5.6542969 10.259766 L 6.3378906 11.208984 A 5 5 0 0 0 6.0683594 12.220703 L 5 12.699219 L 5 13.300781 L 6.0644531 13.779297 A 5 5 0 0 0 6.3339844 14.796875 L 5.6542969 15.740234 L 5.953125 16.259766 L 7.1152344 16.142578 A 5 5 0 0 0 7.8574219 16.884766 L 7.7402344 18.046875 L 8.2597656 18.345703 L 9.2089844 17.662109 A 5 5 0 0 0 10.220703 17.931641 L 10.699219 19 L 11.300781 19 L 11.779297 17.935547 A 5 5 0 0 0 12.796875 17.666016 L 13.740234 18.345703 L 14.259766 18.046875 L 14.142578 16.884766 A 5 5 0 0 0 14.884766 16.142578 L 16.046875 16.259766 L 16.345703 15.740234 L 15.662109 14.791016 A 5 5 0 0 0 15.931641 13.779297 L 17 13.300781 L 17 12.699219 L 15.935547 12.220703 A 5 5 0 0 0 15.666016 11.203125 L 16.345703 10.259766 L 16.046875 9.7402344 L 14.884766 9.8574219 A 5 5 0 0 0 14.142578 9.1152344 L 14.259766 7.953125 L 13.740234 7.6542969 L 12.791016 8.3378906 A 5 5 0 0 0 11.779297 8.0683594 L 11.300781 7 L 10.699219 7 z M 11 9 A 4 4 0 0 1 15 13 A 4 4 0 0 1 11 17 A 4 4 0 0 1 7 13 A 4 4 0 0 1 11 9 z "
+     id="path4145" />
+</svg>

--- a/Numix/24/mimetypes/text-rust.svg
+++ b/Numix/24/mimetypes/text-rust.svg
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="text-rust.svg">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview12"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="13.186065"
+     inkscape:cy="12"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3004"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#b2542c;fill-opacity:1"
+     d="M 5,1 C 4.527343,1 4,1.527344 4,2 l 0,20 c 0,0.445312 0.554687,1 1,1 l 14,0 c 0.445313,0 0.992367,-0.554753 1,-1 L 20,7 14,1 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssssccs" />
+  <path
+     style="fill:#000000;fill-opacity:0.19599998"
+     d="m 15,7 5,5 0,-5 z"
+     id="path6"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccc" />
+  <path
+     style="fill:#ffffff;fill-opacity:0.39200003"
+     d="m 14,1 6,6 -5,0 C 14.554688,7 14,6.445312 14,6 z"
+     id="path8"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccssc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 11.699219,8.0000003 11.220703,9.064453 A 5,5 0 0 0 10.203125,9.333985 L 9.2597656,8.654297 8.7402344,8.953125 8.8574219,10.115235 A 5,5 0 0 0 8.1152344,10.857422 L 6.953125,10.740235 6.6542969,11.259766 7.3378906,12.208984 A 5,5 0 0 0 7.0683594,13.220703 L 6,13.699219 l 0,0.601562 1.0644531,0.478516 a 5,5 0 0 0 0.2695313,1.017578 l -0.6796875,0.943359 0.2988281,0.519532 1.1621094,-0.117188 a 5,5 0 0 0 0.7421875,0.742188 l -0.1171875,1.162109 0.5195312,0.298828 0.9492184,-0.683594 a 5,5 0 0 0 1.011719,0.269532 L 11.699219,20 l 0.601562,0 0.478516,-1.064453 a 5,5 0 0 0 1.017578,-0.269531 l 0.943359,0.679687 0.519532,-0.298828 -0.117188,-1.162109 a 5,5 0 0 0 0.742188,-0.742188 l 1.162109,0.117188 0.298828,-0.519532 -0.683594,-0.949218 a 5,5 0 0 0 0.269532,-1.011719 L 18,14.300781 18,13.699219 16.935547,13.220703 a 5,5 0 0 0 -0.269531,-1.017578 l 0.679687,-0.943359 -0.298828,-0.519531 -1.162109,0.117187 A 5,5 0 0 0 15.142578,10.115235 L 15.259766,8.953125 14.740234,8.654297 13.791016,9.337891 A 5,5 0 0 0 12.779297,9.06836 l -0.478516,-1.0683597 -0.601562,0 z M 12,10 a 4,4 0 0 1 4,4 4,4 0 0 1 -4,4 4,4 0 0 1 -4,-4 4,4 0 0 1 4,-4 z"
+     id="path4145" />
+  <path
+     sodipodi:nodetypes="cccscccscccccccccccccccccc"
+     inkscape:connector-curvature="0"
+     id="path4143"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:6.69263983px;line-height:125%;font-family:'Roboto Slab';-inkscape-font-specification:'Roboto Slab Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 11.989492,11 c 1.285341,0 2.207779,0.731246 2.210508,2 0,1 -0.702216,1.400644 -1.025698,1.525 0.319806,0.1973 0.405652,0.258464 0.751397,1.125 0.239395,0.6 0.430961,0.6 1.074301,0.624722 l 0,0.725277 -1.275,0 c -0.451809,0 -0.533532,-0.418056 -0.783,-1.049999 -0.373396,-0.945886 -0.747515,-0.943341 -1.231949,-0.949999 L 11,15 l 0,1.25 1,-2e-6 L 12,17 l -3,0 0,-0.750002 1,2e-6 0,-4.5 -1,0 L 9,11 Z M 11,14 l 1,0 c 0.815902,-0.0114 1.1,-0.453187 1.1,-1 5.39e-4,-0.650201 -0.486629,-1 -1.1,-1 l -1,0 z" />
+</svg>

--- a/Numix/32/mimetypes/text-rust.svg
+++ b/Numix/32/mimetypes/text-rust.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   height="32"
+   viewBox="0 0 32 32"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="text-rust.svg">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview12"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="18.611331"
+     inkscape:cy="13.266512"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:object-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3004" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#b2542c;fill-opacity:1"
+     d="M 5.335888,2.969e-4 C 4.648414,3.119e-4 4,0.6767878 4,1.3940311 L 4,30.606268 C 4,31.282757 4.687474,32 5.335888,32 l 21.327332,0 c 0.648414,0 1.335888,-0.717243 1.335888,-1.393732 L 28,8.9999996 l -9,-9 z"
+     id="path4-1"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssssccs" />
+  <path
+     style="fill:#000000;fill-opacity:0.19599998"
+     d="M 21,8.9999996 28,16 28,8.9999996 z"
+     id="path6-4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccc" />
+  <path
+     style="fill:#ffffff;fill-opacity:0.39200003"
+     d="m 19.000306,2.969e-4 8.991594,8.9997027 -7.613262,0 c -0.672951,0 -1.378332,-0.7134896 -1.378332,-1.3864402 z"
+     id="path8-6"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccssc" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 15.482422 11 L 14.939453 12.068359 C 14.573174 12.124369 14.212315 12.208247 13.859375 12.320312 L 12.90625 11.599609 L 11.939453 12.076172 L 11.931641 13.271484 C 11.656245 13.461637 11.393864 13.66958 11.148438 13.896484 L 9.984375 13.650391 L 9.2734375 14.548828 L 9.796875 15.619141 C 9.6557586 15.87671 9.5313572 16.142991 9.4238281 16.416016 L 8.2558594 16.681641 L 8.0019531 17.857422 L 8.9394531 18.591797 C 8.9288521 18.727946 8.9224869 18.86347 8.9199219 19 C 8.9204372 19.137776 8.9248967 19.274601 8.9335938 19.412109 L 8 20.142578 L 8.2597656 21.318359 L 9.4199219 21.582031 C 9.5301687 21.853913 9.657121 22.118896 9.8007812 22.375 L 9.2753906 23.449219 L 9.9863281 24.349609 L 11.152344 24.101562 C 11.396238 24.331014 11.657345 24.541559 11.931641 24.734375 L 11.939453 25.927734 L 12.900391 26.404297 L 13.853516 25.683594 C 14.207963 25.793208 14.570103 25.874482 14.9375 25.927734 L 15.478516 26.992188 L 16.517578 27 L 17.060547 25.931641 C 17.426826 25.875631 17.787685 25.791753 18.140625 25.679688 L 19.09375 26.400391 L 20.060547 25.923828 L 20.068359 24.728516 C 20.343755 24.53838 20.606136 24.33042 20.851562 24.103516 L 22.015625 24.349609 L 22.726562 23.451172 L 22.203125 22.380859 C 22.34424 22.12329 22.468643 21.857009 22.576172 21.583984 L 23.744141 21.318359 L 23.998047 20.142578 L 23.060547 19.408203 C 23.071147 19.272054 23.077518 19.13653 23.080078 19 C 23.079563 18.862224 23.075136 18.725399 23.066406 18.587891 L 24 17.857422 L 23.740234 16.681641 L 22.580078 16.417969 C 22.469831 16.146087 22.342879 15.881104 22.199219 15.625 L 22.724609 14.550781 L 22.013672 13.650391 L 20.847656 13.898438 C 20.603762 13.668987 20.342655 13.458441 20.068359 13.265625 L 20.060547 12.072266 L 19.099609 11.595703 L 18.146484 12.316406 C 17.792036 12.206792 17.429897 12.125518 17.0625 12.072266 L 16.521484 11.007812 L 15.482422 11 z M 16 13 A 6 6 0 0 1 22 19 A 6 6 0 0 1 16 25 A 6 6 0 0 1 10 19 A 6 6 0 0 1 16 13 z "
+     id="path4138" />
+  <path
+     sodipodi:nodetypes="cccscccscccccccccccccccccc"
+     inkscape:connector-curvature="0"
+     id="path4143-5"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:6.69263983px;line-height:125%;font-family:'Roboto Slab';-inkscape-font-specification:'Roboto Slab Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 15.77,15 c 2.238633,0 3.83,0.828376 3.83,2.625 0,1.526282 -1.22723,1.986067 -1.9,2.105 0.545944,0.143223 0.772035,0.549645 1.07,1.47 C 19.029,22 19.382104,22 20,22 l 0,0.999998 -1.5,0 c -0.786897,0 -0.911716,-0.633412 -1.2,-1.399998 -0.498092,-1.324494 -0.701034,-1.35 -1.6,-1.35 l -0.7,0 0,1.750001 1,-2e-6 L 16,23 l -4,0 0,-1.000001 1,2e-6 L 13,16 l -1,0 0,-1 z m -0.77,4 0.87,0 c 1.421031,-0.0152 1.93,-0.645916 1.93,-1.375 0,-0.971886 -0.844897,-1.375 -1.74,-1.375 l -1.06,0 z" />
+</svg>

--- a/Numix/48/mimetypes/text-rust.svg
+++ b/Numix/48/mimetypes/text-rust.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   viewBox="0 0 48 48"
+   height="48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="text-rust.svg">
+  <metadata
+     id="metadata18">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs16" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview14"
+     showgrid="false"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="22.594142"
+     inkscape:cy="19.593032"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4156" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#b2542c;fill-opacity:1"
+     d="M 8,1 C 6.9714285,1 6,1.9714285 6,3 l 0,42 c 0,0.971429 1.0285714,2 2,2 l 32,0 c 0.971429,0 2,-1.028571 2,-2 L 42,14 29,1 z"
+     id="path4" />
+  <path
+     style="fill-opacity:.196"
+     d="M 29,12 29.0625,12.0625 29.21875,12 29,12 z m 2,2 11,11 0,-11 -11,0 z"
+     id="path6" />
+  <path
+     style="fill:#fff;fill-opacity:.392"
+     d="m 29,1 13,13 -11,0 c -0.971429,0 -2,-1.028571 -2,-2 L 29,1 z"
+     id="path8" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 23.398438,16 -0.957032,2.128906 A 10,10 0 0 0 20.40625,18.66797 l -1.886718,-1.359376 -1.039062,0.597656 0.234374,2.32422 a 10,10 0 0 0 -1.484374,1.484374 l -2.32422,-0.234374 -0.597656,1.039062 1.367188,1.898436 A 10,10 0 0 0 14.13672,26.441406 L 12,27.398438 l 0,1.203124 2.128906,0.957032 a 10,10 0 0 0 0.539064,2.035156 l -1.359376,1.886718 0.597656,1.039064 2.32422,-0.234376 a 10,10 0 0 0 1.484374,1.484376 l -0.234374,2.324218 1.039062,0.597656 1.898438,-1.367188 a 10,10 0 0 0 2.023436,0.539064 L 23.398438,40 l 1.203124,0 0.957032,-2.128906 a 10,10 0 0 0 2.035156,-0.539062 l 1.886718,1.359374 1.039064,-0.597656 -0.234376,-2.324218 a 10,10 0 0 0 1.484376,-1.484376 l 2.324218,0.234376 0.597656,-1.039064 -1.367188,-1.898436 a 10,10 0 0 0 0.539064,-2.023438 L 36,28.601562 36,27.398438 33.871094,26.441406 A 10,10 0 0 0 33.332032,24.40625 L 34.691406,22.519532 34.09375,21.48047 31.769532,21.714844 A 10,10 0 0 0 30.285156,20.23047 l 0.234376,-2.32422 -1.039064,-0.597656 -1.898436,1.367188 A 10,10 0 0 0 25.558594,18.13672 L 24.601562,16 23.398438,16 Z M 24,20 a 8,8 0 0 1 8,8 8,8 0 0 1 -8,8 8,8 0 0 1 -8,-8 8,8 0 0 1 8,-8 z"
+     id="path4145" />
+  <path
+     sodipodi:nodetypes="cccscccscccccccccccccccccc"
+     inkscape:connector-curvature="0"
+     id="path4143-5"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:6.69263983px;line-height:125%;font-family:'Roboto Slab';-inkscape-font-specification:'Roboto Slab Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 24.4,23 c 2.798291,0 3.9,1.375 3.9,3 0,1.666665 -1.459037,2.576334 -2.3,2.725 0.68243,0.179029 0.827544,0.874556 1.2,2.025 0.32375,1 0.563591,1.25 1.8,1.25 l 0,0.999997 -1.875,0 c -0.983621,0 -1.152826,-0.786911 -1.5,-1.749997 C 25.129338,29.875 24.748708,29 23.625,29 L 22,29 l 0,3.000001 1,-2e-6 L 23,33 l -4,0 0,-1.000001 1,2e-6 L 20,24 l -1,0 0,-1 z m -2.4,5 2.1875,0 C 25.875,28 26.4,26.911355 26.4,26 c 0,-1.214857 -0.876562,-2 -2.21875,-2 L 22,24 Z" />
+</svg>

--- a/Numix/64/mimetypes/text-rust.svg
+++ b/Numix/64/mimetypes/text-rust.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   viewBox="0 0 64 64"
+   version="1.1"
+   id="svg2"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="text-rust2.svg">
+  <metadata
+     id="metadata17">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs15" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview13"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="34.000364"
+     inkscape:cy="23.809778"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:object-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4151" />
+  </sodipodi:namedview>
+  <g
+     id="surface1">
+    <path
+       style="stroke:none;fill-rule:nonzero;fill:#b2542c;fill-opacity:1"
+       d="M 10.671875 0 C 9.296875 0 8 1.355469 8 2.789062 L 8 61.210938 C 8 62.566406 9.375 64 10.671875 64 L 53.328125 64 C 54.625 64 56 62.566406 56 61.210938 L 56 18 L 38 0 Z M 10.671875 0 "
+       id="path5" />
+    <path
+       style=" stroke:none;fill-rule:nonzero;fill:rgb(0%,0%,0%);fill-opacity:0.196078;"
+       d="M 42 18 L 56 32 L 56 18 Z M 42 18 "
+       id="path7" />
+    <path
+       style=" stroke:none;fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:0.392157;"
+       d="M 38 0 L 55.984375 18 L 40.757812 18 C 39.410156 18 38 16.574219 38 15.226562 Z M 38 0 "
+       id="path9" />
+  </g>
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 30.964846,21.000024 -1.085938,2.136718 c -0.732558,0.11202 -1.454276,0.279776 -2.160156,0.503906 l -1.90625,-1.441406 -1.933594,0.953126 -0.0156,2.390624 c -0.550792,0.380306 -1.075554,0.796192 -1.566406,1.25 l -2.32815,-0.492186 -1.421874,1.796874 1.046874,2.140626 c -0.282232,0.515138 -0.531036,1.0477 -0.746094,1.59375 l -2.335936,0.53125 -0.507814,2.351562 1.875,1.46875 c -0.0212,0.272298 -0.03394,0.543346 -0.03906,0.816406 0.001,0.275552 0.01,0.549202 0.02734,0.824218 L 16,39.28518 l 0.519532,2.351562 2.320312,0.527344 c 0.220494,0.543764 0.474398,1.07373 0.761718,1.585938 l -1.05078,2.148438 1.421874,1.80078 2.332032,-0.496094 c 0.487788,0.458904 1.010002,0.879994 1.558594,1.265626 l 0.0156,2.386718 1.921876,0.953126 1.90625,-1.441406 c 0.708894,0.219228 1.433174,0.381776 2.167968,0.48828 L 30.957008,52.9844 33.035132,53 34.12107,50.863282 c 0.732558,-0.11202 1.454276,-0.279776 2.160156,-0.503906 l 1.90625,1.441406 1.933594,-0.953126 0.0156,-2.390624 c 0.550792,-0.380272 1.075554,-0.796192 1.566406,-1.25 l 2.328126,0.492186 1.421874,-1.796874 -1.046874,-2.140626 c 0.28223,-0.515138 0.531036,-1.0477 0.746094,-1.59375 l 2.335938,-0.53125 0.507812,-2.351562 -1.875,-1.46875 c 0.0212,-0.272298 0.03394,-0.543346 0.03906,-0.816406 -10e-4,-0.275552 -0.0098,-0.549202 -0.02734,-0.824218 L 48,34.714868 47.480468,32.363306 45.160156,31.835962 c -0.220494,-0.543764 -0.474398,-1.07373 -0.761718,-1.585938 l 1.05078,-2.148438 -1.421874,-1.80078 -2.332032,0.496094 C 41.207524,26.337998 40.68531,25.916906 40.136718,25.531274 l -0.0156,-2.386718 -1.921876,-0.953126 -1.90625,1.441406 c -0.708918,-0.219228 -1.433196,-0.381776 -2.16799,-0.48828 l -1.082032,-2.128908 -2.078124,-0.0156 z m 1.035156,4 a 12,12 0 0 1 12,12 12,12 0 0 1 -12,12 12,12 0 0 1 -12,-12 12,12 0 0 1 12,-12 z"
+     id="path4138" />
+  <path
+     sodipodi:nodetypes="cccscccscccccccccccccccccc"
+     inkscape:connector-curvature="0"
+     id="path4143-5"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:6.69263983px;line-height:125%;font-family:'Roboto Slab';-inkscape-font-specification:'Roboto Slab Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 32.64,29 c 4.477266,0 6.36,2 6.36,5 0,2.666664 -2.45446,3.922134 -3.8,4.16 1.091888,0.286446 1.54407,1.39929 2.14,3.24 C 37.858,43 38.764208,43 40,43 l 0,1.999996 -3,0 c -1.573794,0 -1.844521,-1.259058 -2.4,-2.799996 C 33.806941,40 33.197932,39 31.4,39 l -2.4,0 0,4.000002 2,-4e-6 L 31,45 l -7,0 0,-2.000002 2,4e-6 L 26,31 l -2,0 0,-2 z m -3.64,8 3.3,0 c 2.7,0 3.41,-1.541832 3.41,-3 0,-1.943772 -1.2725,-3 -3.42,-3 L 29,31 Z" />
+</svg>


### PR DESCRIPTION
Pushed the uppermost variant.
![rust-all](https://cloud.githubusercontent.com/assets/7050624/10865946/2cbe46f4-801d-11e5-974c-e410a0ad9690.png)

