### PR TITLE
Mimetype icons for CoffeeScript files

### DIFF
--- a/Numix/16/mimetypes/application-vnd.coffeescript.svg
+++ b/Numix/16/mimetypes/application-vnd.coffeescript.svg
@@ -41,8 +41,8 @@
      inkscape:window-height="704"
      id="namedview16"
      showgrid="false"
-     inkscape:zoom="11.91033"
-     inkscape:cx="-22.994279"
+     inkscape:zoom="1"
+     inkscape:cx="6.4731008"
      inkscape:cy="5.7372233"
      inkscape:window-x="0"
      inkscape:window-y="27"
@@ -73,7 +73,7 @@
   <g
      style="fill:#ffffff"
      id="g10"
-     transform="matrix(1.2999414,0,0,1.2999414,-2.2999414,-2.5992969)">
+     transform="matrix(1.2999414,0,0,1.2999414,-1.2999414,-2.5992969)">
     <path
        d="M 3,5 3,13 7,13 7,11 5,11 5,7 7,7 7,5 C 5.6666667,5 4.3333333,5 3,5 Z"
        id="path12"
@@ -82,7 +82,7 @@
        transform="matrix(0.76926545,0,0,0.76926545,1.7692654,1.9995493)"
        style="fill:#e6e6e6;fill-opacity:1" />
     <path
-       d="m 7.923389,5.8458765 3.077062,0 0,1.5385309 -1.5385313,0 2e-7,0.7692655 1.5385311,0 0,3.8463271 -3.077062,0 0,-1.538531 1.5385309,0 0,-0.7692653 -1.5385309,0 z"
+       d="m 7.923389,5.8458765 2.307797,0 0,1.5385309 -1.5385318,0 2e-7,0.7692655 1.5385316,0 0,3.8463271 -2.307797,0 0,-1.538531 1.5385309,0 0,-0.7692653 -1.5385309,0 z"
        id="path14"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ccccccccccccc"

--- a/Numix/16/mimetypes/application-vnd.coffeescript.svg
+++ b/Numix/16/mimetypes/application-vnd.coffeescript.svg
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="application-vnd.coffeescript.svg">
+  <metadata
+     id="metadata20">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs18" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview16"
+     showgrid="false"
+     inkscape:zoom="11.91033"
+     inkscape:cx="-22.994279"
+     inkscape:cy="5.7372233"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3008" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#1f244f;fill-opacity:1"
+     d="M 2.667969,-4.461e-4 C 2.324219,-4.461e-4 2,0.3378119 2,0.6964466 L 2,15.303108 C 2,15.641365 2.34375,16 2.667969,16 l 10.664062,0 C 13.65625,16 14,15.641365 14,15.303108 L 14,3.9995537 9.9999996,-4.461e-4 z"
+     id="path4-5"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssssccs" />
+  <path
+     style="fill:#000000;fill-opacity:0.19599998"
+     d="m 10.583223,3.3315847 0.0154,0.01953 0.04005,-0.01953 z m 0.02978,0.667969 3.387,3.664062 0,-3.664062 z"
+     id="path6"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccc" />
+  <path
+     style="fill:#ffffff;fill-opacity:0.39200003"
+     d="m 9.9999996,-4.461e-4 3.9963964,3.9999998 -3.383784,0 c -0.299099,0 -0.6126124,-0.317117 -0.6126124,-0.616216 z"
+     id="path8"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccssc" />
+  <g
+     style="fill:#ffffff"
+     id="g10"
+     transform="matrix(1.2999414,0,0,1.2999414,-2.2999414,-2.5992969)">
+    <path
+       d="M 3,5 3,13 7,13 7,11 5,11 5,7 7,7 7,5 C 5.6666667,5 4.3333333,5 3,5 Z"
+       id="path12"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc"
+       transform="matrix(0.76926545,0,0,0.76926545,1.7692654,1.9995493)"
+       style="fill:#e6e6e6;fill-opacity:1" />
+    <path
+       d="m 7.923389,5.8458765 3.077062,0 0,1.5385309 -1.5385313,0 2e-7,0.7692655 1.5385311,0 0,3.8463271 -3.077062,0 0,-1.538531 1.5385309,0 0,-0.7692653 -1.5385309,0 z"
+       id="path14"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccc"
+       style="fill:#e6e6e6;fill-opacity:1" />
+  </g>
+</svg>

--- a/Numix/22/mimetypes/application-vnd.coffeescript.svg
+++ b/Numix/22/mimetypes/application-vnd.coffeescript.svg
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   viewBox="0 0 22 22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="application-vnd.coffeescript.svg">
+  <metadata
+     id="metadata20">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs18" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview16"
+     showgrid="true"
+     inkscape:zoom="47.641319"
+     inkscape:cx="6.7286353"
+     inkscape:cy="9.9485631"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:object-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3008"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#1f244f;fill-opacity:1"
+     d="M 4,0 C 3.527343,0 3,0.527344 3,1 l 0,20 c 0,0.445312 0.554687,1 1,1 l 14,0 c 0.445313,0 0.992367,-0.554753 1,-1 L 19,6 13,0 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssssccs" />
+  <path
+     style="fill:#000000;fill-opacity:0.19599998"
+     d="m 14,6 5,5 0,-5 z"
+     id="path6-5"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccc" />
+  <path
+     style="fill:#ffffff;fill-opacity:0.39200003"
+     d="m 13,0 6,6 -5,0 C 13.554688,6 13,5.445312 13,5 z"
+     id="path8-8"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccssc" />
+  <g
+     style="fill:#ffffff"
+     id="g10"
+     transform="matrix(1.5293428,0,0,1.4624341,-0.82346027,-0.54920917)">
+    <path
+       d="m 6,8 c 0,3.333333 0,6.666667 0,10 l 4,0 0,-2 -2,0 0,-6 2,0 0,-2 C 8.6666667,8 7.3333333,8 6,8 Z"
+       transform="matrix(0.65387564,0,0,0.6837915,0.53844061,0.37554456)"
+       id="path12"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc"
+       style="fill:#e6e6e6;fill-opacity:1" />
+    <path
+       d="m 8.3849484,5.8458765 2.6155026,0 0,1.367583 -1.3077513,0 0,1.367583 1.3077513,0 0,4.1027485 -2.6155028,0 0,-1.367583 1.3077512,0 0,-1.3675825 -1.3077512,0 z"
+       id="path14"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccc"
+       style="fill:#e6e6e6;fill-opacity:1" />
+  </g>
+</svg>

--- a/Numix/24/mimetypes/application-vnd.coffeescript.svg
+++ b/Numix/24/mimetypes/application-vnd.coffeescript.svg
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="application-vnd.coffeescript.svg">
+  <metadata
+     id="metadata20">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs18" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview16"
+     showgrid="true"
+     inkscape:zoom="23.1177"
+     inkscape:cx="7.5919009"
+     inkscape:cy="8.1847414"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3008"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#1f244f;fill-opacity:1"
+     d="M 5,1 C 4.527343,1 4,1.527344 4,2 l 0,20 c 0,0.445312 0.554687,1 1,1 l 14,0 c 0.445313,0 0.992367,-0.554753 1,-1 L 20,7 14,1 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssssccs" />
+  <path
+     style="fill:#000000;fill-opacity:0.19599998"
+     d="m 15,7 5,5 0,-5 z"
+     id="path6-5"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccc" />
+  <path
+     style="fill:#ffffff;fill-opacity:0.39200003"
+     d="m 14,1 6,6 -5,0 C 14.554688,7 14,6.445312 14,6 z"
+     id="path8-8"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccssc" />
+  <g
+     style="fill:#ffffff"
+     id="g10"
+     transform="matrix(1.5293428,0,0,1.4624341,0.17653973,0.4507908)">
+    <path
+       d="m 7,9 c 0,3.333333 0,6.666667 0,10 l 4,0 0,-2 -2,0 0,-6 2,0 0,-2 C 9.6666667,9 8.3333333,9 7,9 Z"
+       transform="matrix(0.65387564,0,0,0.6837915,-0.11543503,-0.30824692)"
+       id="path12"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc"
+       style="fill:#e6e6e6" />
+    <path
+       d="m 8.3849484,5.8458765 2.6155026,0 0,1.367583 -1.3077513,0 0,1.367583 1.3077513,0 0,4.1027485 -2.6155028,0 0,-1.367583 1.3077512,0 0,-1.3675825 -1.3077512,0 z"
+       id="path14"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccc"
+       style="fill:#e6e6e6" />
+  </g>
+</svg>

--- a/Numix/32/mimetypes/application-vnd.coffeescript.svg
+++ b/Numix/32/mimetypes/application-vnd.coffeescript.svg
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   height="32"
+   viewBox="0 0 32 32"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="application-vnd.coffeescript.svg">
+  <metadata
+     id="metadata20">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs18" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview16"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="13.802738"
+     inkscape:cy="11.405692"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3008" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#1f244f;fill-opacity:1"
+     d="M 5.335888,2.977e-4 C 4.648414,3.127e-4 4,0.6767877 4,1.3940317 L 4,30.606268 C 4,31.282757 4.687474,32 5.335888,32 l 21.327332,0 c 0.648414,0 1.335888,-0.717243 1.335888,-1.393732 L 28,8.9999997 l -9,-9 z"
+     id="path4-1"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssssccs" />
+  <path
+     style="fill:#000000;fill-opacity:0.19599998"
+     d="M 21,8.9999997 28,16 28,8.9999997 z"
+     id="path6-4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccc" />
+  <path
+     style="fill:#ffffff;fill-opacity:0.39200003"
+     d="m 19.000306,2.977e-4 8.991594,8.999702 -7.613262,0 c -0.672951,0 -1.378332,-0.713489 -1.378332,-1.38644 z"
+     id="path8-6"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccssc" />
+  <g
+     style="fill:#ffffff"
+     id="g10"
+     transform="matrix(1.0715781,0,0,1.0501026,0.14106292,0.7975376)">
+    <path
+       d="m 7.9999999,12 0,14 L 14,26 l 0,-3 -3,0 0,-8 3,0 0,-3 z"
+       transform="matrix(0.9332031,0,0,0.9522879,0.8015628,-0.75948541)"
+       id="path12"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc"
+       style="fill:#e6e6e6;fill-opacity:1" />
+    <path
+       d="m 15.732812,10.667969 5.599219,0 0,2.856863 -2.799609,0 0,2.856864 2.799609,0 0,7.618304 -5.599219,-1e-6 0,-2.856863 2.79961,0 0,-2.856864 -2.79961,0 z"
+       id="path14"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccc"
+       style="fill:#e6e6e6;fill-opacity:1" />
+  </g>
+</svg>

--- a/Numix/48/mimetypes/application-vnd.coffeescript.svg
+++ b/Numix/48/mimetypes/application-vnd.coffeescript.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   viewBox="0 0 48 48"
+   height="48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="application-vnd.coffeescript.svg">
+  <metadata
+     id="metadata20">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs18" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview16"
+     showgrid="false"
+     showguides="false"
+     inkscape:zoom="1"
+     inkscape:cx="23.512481"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4148" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#1f244f;fill-opacity:1"
+     d="M 8,1 C 6.9714285,1 6,1.9714285 6,3 l 0,42 c 0,0.971429 1.0285714,2 2,2 l 32,0 c 0.971429,0 2,-1.028571 2,-2 L 42,14 29,1 z"
+     id="path4" />
+  <path
+     style="fill-opacity:.196"
+     d="M 29,12 29.0625,12.0625 29.21875,12 29,12 z m 2,2 11,11 0,-11 -11,0 z"
+     id="path6" />
+  <path
+     style="fill:#fff;fill-opacity:.392"
+     d="m 29,1 13,13 -11,0 c -0.971429,0 -2,-1.028571 -2,-2 L 29,1 z"
+     id="path8" />
+  <g
+     transform="translate(6,9)"
+     id="g10">
+    <path
+       style="fill:#e6e6e6"
+       d="m 9,9 c 0,6.666667 0,13.333333 0,20 l 8,0 0,-4 -4,0 0,-12 4,0 0,-4 C 14.333333,9 11.666667,9 9,9 Z"
+       id="path12"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       style="fill:#e6e6e6"
+       d="m 19,9 8,0 0,4 -4,0 0,4 4,0 0,12 -8,0 0,-4 4,0 0,-4 -4,0 z"
+       id="path14"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/Numix/64/mimetypes/application-vnd.coffeescript.svg
+++ b/Numix/64/mimetypes/application-vnd.coffeescript.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   viewBox="0 0 64 64"
+   version="1.1"
+   id="svg2"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="application-vnd.coffeescript.svg">
+  <metadata
+     id="metadata19">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs17" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview15"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="30.213788"
+     inkscape:cy="9.7139162"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4147" />
+  </sodipodi:namedview>
+  <g
+     id="surface1">
+    <path
+       style="stroke:none;fill-rule:nonzero;fill:#1f244f;fill-opacity:1"
+       d="M 10.671875 0 C 9.296875 0 8 1.355469 8 2.789062 L 8 61.210938 C 8 62.566406 9.375 64 10.671875 64 L 53.328125 64 C 54.625 64 56 62.566406 56 61.210938 L 56 18 L 38 0 Z M 10.671875 0 "
+       id="path5" />
+    <path
+       style=" stroke:none;fill-rule:nonzero;fill:rgb(0%,0%,0%);fill-opacity:0.196078;"
+       d="M 42 18 L 56 32 L 56 18 Z M 42 18 "
+       id="path7" />
+    <path
+       style=" stroke:none;fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:0.392157;"
+       d="M 38 0 L 55.984375 18 L 40.757812 18 C 39.410156 18 38 16.574219 38 15.226562 Z M 38 0 "
+       id="path9" />
+    <path
+       style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 18,24 c 0,9.333333 0,18.666667 0,28 l 12,0 0,-6 -6,0 0,-16 6,0 0,-6 c -4,0 -8,0 -12,0 z"
+       id="path11"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 34,24 12,0 0,6 -6,0 0,6 6,0 0,16 -12,0 0,-6 6,0 0,-6 -6,0 z m 0,0"
+       id="path13"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>


### PR DESCRIPTION
Quite minimalistic design this time, in line with the JS mimetype.
![allsizes](https://cloud.githubusercontent.com/assets/7050624/11022310/cd9b1e96-865b-11e5-87d1-7c1ba6d15331.png)
