### PR TITLE
Redesign for gtkrc mimetype icons

### DIFF
--- a/Numix/16/mimetypes/text-x-gtkrc.svg
+++ b/Numix/16/mimetypes/text-x-gtkrc.svg
@@ -12,8 +12,8 @@
    viewBox="0 0 16 16"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="text-x-gtkrc.svg">
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="text-x-gtkrc2.svg">
   <metadata
      id="metadata24">
     <rdf:RDF>
@@ -22,6 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -36,17 +37,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="970"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
      id="namedview20"
-     showgrid="true"
-     inkscape:zoom="20.85965"
-     inkscape:cx="13.212645"
-     inkscape:cy="8.7968964"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="7.5784881"
+     inkscape:cy="11.744486"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="27"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg2">
+     inkscape:current-layer="svg2"
+     inkscape:object-nodes="true">
     <inkscape:grid
        type="xygrid"
        id="grid3012" />
@@ -66,28 +68,23 @@
   <g
      style="fill:#ffffff"
      id="g10"
-     transform="matrix(1.3350716,0,0,1.3350716,-2.6805728,-3.0156444)">
-    <path
-       d="m 10.667969,6.332031 0,-0.332031 -5.335938,0 0,0.332031 L 5,6.332031 5,8 l 0.332031,0 0,0.332031 5.335938,0 L 10.667969,8 11,8 11,6.332031 z m -5.335938,0 3.335938,0 0,1.667969 -3.335938,0 z m 4,0.335938 1,0 0,0.664062 -0.332031,0 0,0.335938 -0.332031,0 0,-0.335938 -0.335938,0 z"
-       id="path12"
-       inkscape:connector-curvature="0" />
-    <path
-       d="m 5.332031,9.332031 0,0.335938 -0.332031,0 0,2 0.332031,0 0,0.332031 2,0 0,-0.332031 0.335938,0 0,-2 -0.335938,0 0,-0.335938 z M 7,10 l 0.332031,0 0,0.332031 L 7,10.320312 l 0,0.347657 -0.332031,0 0,0.332031 -0.335938,0 0,0.332031 L 6,11.332031 6,11 l -0.332031,0 0,-0.332031 0.332031,0 L 6,11 l 0.332031,0 0,-0.332031 0.335938,0 0,-0.335938 0.332031,0 z"
-       id="path14"
-       inkscape:connector-curvature="0" />
-    <path
-       d="m 8.996094,9.332031 0,0.335938 1.332031,0 0,-0.335938 z m 1.332031,0.335938 0,0.332031 0.332031,0 0,-0.332031 z M 10.660156,10 l 0,1.332031 0.335938,0 0,-1.332031 z m 0,1.332031 -0.332031,0 0,0.335938 0.332031,0 z m -0.332031,0.335938 -1.332031,0 0,0.332031 1.332031,0 z m -1.332031,0 0,-0.335938 -0.335938,0 0,0.335938 z m -0.335938,-0.335938 0,-1.332031 -0.332031,0 0,1.332031 z m 0,-1.332031 0.335938,0 0,-0.332031 -0.335938,0 z"
-       id="path16"
-       inkscape:connector-curvature="0" />
-    <path
-       d="m 9.328125,11 -0.332031,0 0,-0.667969 0.332031,0 0,-0.332031 0.667969,0 0,0.332031 0.332031,0 0,0.667969 -0.332031,0 0,0.332031 -0.667969,0 z"
-       id="path18"
-       inkscape:connector-curvature="0" />
-  </g>
+     transform="matrix(1.3350716,0,0,1.3350716,-2.6805728,-3.0156444)" />
   <path
      style="fill:#ffffff;fill-opacity:0.39200003"
      d="m 10,-4.455e-4 3.996396,3.9999998 -3.383784,0 C 10.313513,3.9995543 10,3.6824373 10,3.3833383 z"
      id="path8"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="ccssc" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 10 9 A 2 2 0 0 0 8 11 A 2 2 0 0 0 10 13 A 2 2 0 0 0 12 11 A 2 2 0 0 0 10 9 z M 10 9.75 A 1.25 1.25 0 0 1 11.25 11 A 1.25 1.25 0 0 1 10 12.25 A 1.25 1.25 0 0 1 8.75 11 A 1.25 1.25 0 0 1 10 9.75 z M 10 10.25 A 0.75 0.75 0 0 0 9.25 11 A 0.75 0.75 0 0 0 10 11.75 A 0.75 0.75 0 0 0 10.75 11 A 0.75 0.75 0 0 0 10 10.25 z "
+     id="path4152" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 5 9 C 4.446 9 4 9.446 4 10 L 4 12 C 4 12.554 4.446 13 5 13 L 7 13 C 7.554 13 8 12.554 8 12 L 8 10 C 8 9.446 7.554 9 7 9 L 5 9 z M 6.8339844 10 L 7.25 10.400391 L 5.5839844 12 L 4.75 11.199219 L 5.1660156 10.800781 L 5.5839844 11.199219 L 6.8339844 10 z "
+     id="rect4160" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 5 5 C 4.446 5 4 5.446 4 6 L 4 7 C 4 7.554 4.446 8 5 8 L 11 8 C 11.554 8 12 7.554 12 7 L 12 6 C 12 5.446 11.554 5 11 5 L 5 5 z M 4.5 5.5 L 9 5.5 L 9 7.5 L 4.5 7.5 L 4.5 5.5 z M 10 6 L 11 6 L 11 7 L 10 7 L 10 6 z "
+     id="rect4168" />
 </svg>

--- a/Numix/22/mimetypes/text-x-gtkrc.svg
+++ b/Numix/22/mimetypes/text-x-gtkrc.svg
@@ -12,7 +12,7 @@
    viewBox="0 0 22 22"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="text-x-gtkrc.svg">
   <metadata
      id="metadata24">
@@ -22,6 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -36,17 +37,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="970"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
      id="namedview20"
-     showgrid="true"
-     inkscape:zoom="29.5"
-     inkscape:cx="12.288453"
-     inkscape:cy="10.826288"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="9.4219367"
+     inkscape:cy="6.6470733"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="27"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg2">
+     inkscape:current-layer="svg2"
+     inkscape:object-nodes="true">
     <inkscape:grid
        type="xygrid"
        id="grid3012"
@@ -64,24 +66,7 @@
   <g
      style="fill:#ffffff"
      id="g10"
-     transform="matrix(1.6666667,0,0,1.6666667,-2.3333333,-2)">
-    <path
-       d="m 10.667969,6.332031 0,-0.332031 -5.335938,0 0,0.332031 L 5,6.332031 5,8 l 0.332031,0 0,0.332031 5.335938,0 L 10.667969,8 11,8 11,6.332031 z m -5.335938,0 3.335938,0 0,1.667969 -3.335938,0 z m 4,0.335938 1,0 0,0.664062 -0.332031,0 0,0.335938 -0.332031,0 0,-0.335938 -0.335938,0 z"
-       id="path12"
-       inkscape:connector-curvature="0" />
-    <path
-       d="m 5.332031,9.332031 0,0.335938 -0.332031,0 0,2 0.332031,0 0,0.332031 2,0 0,-0.332031 0.335938,0 0,-2 -0.335938,0 0,-0.335938 z M 7,10 l 0.332031,0 0,0.332031 L 7,10.320312 l 0,0.347657 -0.332031,0 0,0.332031 -0.335938,0 0,0.332031 L 6,11.332031 6,11 l -0.332031,0 0,-0.332031 0.332031,0 L 6,11 l 0.332031,0 0,-0.332031 0.335938,0 0,-0.335938 0.332031,0 z"
-       id="path14"
-       inkscape:connector-curvature="0" />
-    <path
-       d="m 8.996094,9.332031 0,0.335938 1.332031,0 0,-0.335938 z m 1.332031,0.335938 0,0.332031 0.332031,0 0,-0.332031 z M 10.660156,10 l 0,1.332031 0.335938,0 0,-1.332031 z m 0,1.332031 -0.332031,0 0,0.335938 0.332031,0 z m -0.332031,0.335938 -1.332031,0 0,0.332031 1.332031,0 z m -1.332031,0 0,-0.335938 -0.335938,0 0,0.335938 z m -0.335938,-0.335938 0,-1.332031 -0.332031,0 0,1.332031 z m 0,-1.332031 0.335938,0 0,-0.332031 -0.335938,0 z"
-       id="path16"
-       inkscape:connector-curvature="0" />
-    <path
-       d="m 9.328125,11 -0.332031,0 0,-0.667969 0.332031,0 0,-0.332031 0.667969,0 0,0.332031 0.332031,0 0,0.667969 -0.332031,0 0,0.332031 -0.667969,0 z"
-       id="path18"
-       inkscape:connector-curvature="0" />
-  </g>
+     transform="matrix(1.6666667,0,0,1.6666667,-2.3333333,-2)" />
   <path
      style="fill:#000000;fill-opacity:0.19599998"
      d="m 14,6 5,5 0,-5 z"
@@ -94,4 +79,18 @@
      id="path8"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="ccssc" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 7,13 c -0.554,0 -1,0.446 -1,1 l 0,3 c 0,0.554 0.446,1 1,1 l 3,0 c 0.554,0 1,-0.446 1,-1 l 0,-3 c 0,-0.554 -0.446,-1 -1,-1 z M 9.7167969,14 10.25,14.539062 7.7162031,17 6.6497969,15.921875 7.183,15.380859 7.7162031,15.921875 Z"
+     id="rect4141"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="sssssssssccccccc" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 7 8 C 6.446 8 6 8.446 6 9 L 6 11 C 6 11.554 6.446 12 7 12 L 15 12 C 15.554 12 16 11.554 16 11 L 16 9 C 16 8.446 15.554 8 15 8 L 7 8 z M 7 9 L 12 9 L 12 11 L 7 11 L 7 9 z M 13 9 L 15 9 L 15 11 L 13 11 L 13 9 z "
+     id="rect4145" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 13.5 13 A 2.5 2.5 0 0 0 11 15.5 A 2.5 2.5 0 0 0 13.5 18 A 2.5 2.5 0 0 0 16 15.5 A 2.5 2.5 0 0 0 13.5 13 z M 13.5 13.75 A 1.75 1.75 0 0 1 15.25 15.5 A 1.75 1.75 0 0 1 13.5 17.25 A 1.75 1.75 0 0 1 11.75 15.5 A 1.75 1.75 0 0 1 13.5 13.75 z M 13.5 14.5 A 1 1 0 0 0 12.5 15.5 A 1 1 0 0 0 13.5 16.5 A 1 1 0 0 0 14.5 15.5 A 1 1 0 0 0 13.5 14.5 z "
+     id="path4140" />
 </svg>

--- a/Numix/24/mimetypes/text-x-gtkrc.svg
+++ b/Numix/24/mimetypes/text-x-gtkrc.svg
@@ -12,7 +12,7 @@
    viewBox="0 0 24 24"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="text-x-gtkrc.svg">
   <metadata
      id="metadata24">
@@ -36,15 +36,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="970"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
      id="namedview20"
      showgrid="true"
-     inkscape:zoom="29.5"
-     inkscape:cx="12.288453"
+     inkscape:zoom="32"
+     inkscape:cx="8.875227"
      inkscape:cy="10.826288"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="27"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
@@ -61,27 +61,6 @@
      id="path4"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="ssssssccs" />
-  <g
-     style="fill:#ffffff"
-     id="g10"
-     transform="matrix(1.6666667,0,0,1.6666667,-1.3333333,-1)">
-    <path
-       d="m 10.667969,6.332031 0,-0.332031 -5.335938,0 0,0.332031 L 5,6.332031 5,8 l 0.332031,0 0,0.332031 5.335938,0 L 10.667969,8 11,8 11,6.332031 z m -5.335938,0 3.335938,0 0,1.667969 -3.335938,0 z m 4,0.335938 1,0 0,0.664062 -0.332031,0 0,0.335938 -0.332031,0 0,-0.335938 -0.335938,0 z"
-       id="path12"
-       inkscape:connector-curvature="0" />
-    <path
-       d="m 5.332031,9.332031 0,0.335938 -0.332031,0 0,2 0.332031,0 0,0.332031 2,0 0,-0.332031 0.335938,0 0,-2 -0.335938,0 0,-0.335938 z M 7,10 l 0.332031,0 0,0.332031 L 7,10.320312 l 0,0.347657 -0.332031,0 0,0.332031 -0.335938,0 0,0.332031 L 6,11.332031 6,11 l -0.332031,0 0,-0.332031 0.332031,0 L 6,11 l 0.332031,0 0,-0.332031 0.335938,0 0,-0.335938 0.332031,0 z"
-       id="path14"
-       inkscape:connector-curvature="0" />
-    <path
-       d="m 8.996094,9.332031 0,0.335938 1.332031,0 0,-0.335938 z m 1.332031,0.335938 0,0.332031 0.332031,0 0,-0.332031 z M 10.660156,10 l 0,1.332031 0.335938,0 0,-1.332031 z m 0,1.332031 -0.332031,0 0,0.335938 0.332031,0 z m -0.332031,0.335938 -1.332031,0 0,0.332031 1.332031,0 z m -1.332031,0 0,-0.335938 -0.335938,0 0,0.335938 z m -0.335938,-0.335938 0,-1.332031 -0.332031,0 0,1.332031 z m 0,-1.332031 0.335938,0 0,-0.332031 -0.335938,0 z"
-       id="path16"
-       inkscape:connector-curvature="0" />
-    <path
-       d="m 9.328125,11 -0.332031,0 0,-0.667969 0.332031,0 0,-0.332031 0.667969,0 0,0.332031 0.332031,0 0,0.667969 -0.332031,0 0,0.332031 -0.667969,0 z"
-       id="path18"
-       inkscape:connector-curvature="0" />
-  </g>
   <path
      style="fill:#000000;fill-opacity:0.19599998"
      d="m 15,7 5,5 0,-5 z"
@@ -94,4 +73,20 @@
      id="path8"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="ccssc" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 8,14 c -0.554,0 -1,0.446 -1,1 l 0,3 c 0,0.554 0.446,1 1,1 l 3,0 c 0.554,0 1,-0.446 1,-1 l 0,-3 c 0,-0.554 -0.446,-1 -1,-1 z M 10.716797,15 11.25,15.539062 8.7162031,18 7.6497969,16.921875 8.183,16.380859 8.7162031,16.921875 Z"
+     id="rect4141"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="sssssssssccccccc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 8,9 C 7.446,9 7,9.446 7,10 l 0,2 c 0,0.554 0.446,1 1,1 l 8,0 c 0.554,0 1,-0.446 1,-1 l 0,-2 C 17,9.446 16.554,9 16,9 L 8,9 Z m 0,1 5,0 0,2 -5,0 0,-2 z m 6,0 2,0 0,2 -2,0 0,-2 z"
+     id="rect4145" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 14.5,14 A 2.5,2.5 0 0 0 12,16.5 2.5,2.5 0 0 0 14.5,19 2.5,2.5 0 0 0 17,16.5 2.5,2.5 0 0 0 14.5,14 Z m 0,0.75 a 1.75,1.75 0 0 1 1.75,1.75 1.75,1.75 0 0 1 -1.75,1.75 1.75,1.75 0 0 1 -1.75,-1.75 1.75,1.75 0 0 1 1.75,-1.75 z m 0,0.75 a 1,1 0 0 0 -1,1 1,1 0 0 0 1,1 1,1 0 0 0 1,-1 1,1 0 0 0 -1,-1 z"
+     id="path4140" />
 </svg>

--- a/Numix/32/mimetypes/text-x-gtkrc.svg
+++ b/Numix/32/mimetypes/text-x-gtkrc.svg
@@ -12,7 +12,7 @@
    viewBox="0 0 32 32"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="text-x-gtkrc.svg">
   <metadata
      id="metadata24">
@@ -36,17 +36,19 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="970"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
      id="namedview20"
-     showgrid="true"
-     inkscape:zoom="7.375"
-     inkscape:cx="6.8679379"
-     inkscape:cy="22.956671"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="16.252404"
+     inkscape:cy="10.099066"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="27"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg2">
+     inkscape:current-layer="svg2"
+     inkscape:object-nodes="true"
+     showguides="true">
     <inkscape:grid
        type="xygrid"
        id="grid3012" />
@@ -71,18 +73,22 @@
      sodipodi:nodetypes="ccssc" />
   <g
      style="fill:#fff"
-     id="g10">
-    <path
-       d="M 21.332031 12.667969 L 21.332031 12 L 10.667969 12 L 10.667969 12.667969 L 10 12.667969 L 10 16 L 10.667969 16 L 10.667969 16.667969 L 21.332031 16.667969 L 21.332031 16 L 22 16 L 22 12.667969 Z M 10.667969 12.667969 L 17.332031 12.667969 L 17.332031 16 L 10.667969 16 Z M 18.667969 13.332031 L 20.667969 13.332031 L 20.667969 14.667969 L 20 14.667969 L 20 15.332031 L 19.332031 15.332031 L 19.332031 14.667969 L 18.667969 14.667969 Z "
-       id="path12" />
-    <path
-       d="M 10.667969 18.667969 L 10.667969 19.332031 L 10 19.332031 L 10 23.332031 L 10.667969 23.332031 L 10.667969 24 L 14.667969 24 L 14.667969 23.332031 L 15.332031 23.332031 L 15.332031 19.332031 L 14.667969 19.332031 L 14.667969 18.667969 Z M 14 20 L 14.667969 20 L 14.667969 20.667969 L 14 20.644531 L 14 21.332031 L 13.332031 21.332031 L 13.332031 22 L 12.667969 22 L 12.667969 22.667969 L 12 22.667969 L 12 22 L 11.332031 22 L 11.332031 21.332031 L 12 21.332031 L 12 22 L 12.667969 22 L 12.667969 21.332031 L 13.332031 21.332031 L 13.332031 20.667969 L 14 20.667969 Z "
-       id="path14" />
-    <path
-       d="M 17.988281 18.667969 L 17.988281 19.332031 L 20.65625 19.332031 L 20.65625 18.667969 Z M 20.65625 19.332031 L 20.65625 20 L 21.324219 20 L 21.324219 19.332031 Z M 21.324219 20 L 21.324219 22.667969 L 21.988281 22.667969 L 21.988281 20 Z M 21.324219 22.667969 L 20.65625 22.667969 L 20.65625 23.332031 L 21.324219 23.332031 Z M 20.65625 23.332031 L 17.988281 23.332031 L 17.988281 24 L 20.65625 24 Z M 17.988281 23.332031 L 17.988281 22.667969 L 17.324219 22.667969 L 17.324219 23.332031 Z M 17.324219 22.667969 L 17.324219 20 L 16.65625 20 L 16.65625 22.667969 Z M 17.324219 20 L 17.988281 20 L 17.988281 19.332031 L 17.324219 19.332031 Z "
-       id="path16" />
-    <path
-       d="M 18.65625 22 L 17.988281 22 L 17.988281 20.667969 L 18.65625 20.667969 L 18.65625 20 L 19.988281 20 L 19.988281 20.667969 L 20.65625 20.667969 L 20.65625 22 L 19.988281 22 L 19.988281 22.667969 L 18.65625 22.667969 Z "
-       id="path18" />
-  </g>
+     id="g10" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 10,12 c -0.554,0 -1,0.446 -1,1 l 0,4 c 0,0.554 0.446,1 1,1 l 12,0 c 0.554,0 1,-0.446 1,-1 l 0,-4 c 0,-0.554 -0.446,-1 -1,-1 z m 0,1 8,0 0,4 -8,0 z m 9,1 3,0 -1.5,2 z"
+     id="rect4153"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="sssssssssccccccccc" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 10.199219,20 C 9.5344187,20 9,20.534419 9,21.199219 l 0,3.601562 C 9,25.465581 9.5344187,26 10.199219,26 l 3.601562,0 C 14.465581,26 15,25.465581 15,24.800781 l 0,-3.601562 C 15,20.534419 14.465581,20 13.800781,20 Z M 13.607422,21 14.25,21.666016 11.035156,25 9.698711,23.666016 10.341289,23 l 0.693867,0.666016 z"
+     id="rect4155"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="sssssssssccccccc" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 20,20 a 3,3 0 0 0 -3,3 3,3 0 0 0 3,3 3,3 0 0 0 3,-3 3,3 0 0 0 -3,-3 z m 0,1 a 2,2 0 0 1 2,2 2,2 0 0 1 -2,2 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 z m 0,1 a 1,1 0 0 0 -1,1 1,1 0 0 0 1,1 1,1 0 0 0 1,-1 1,1 0 0 0 -1,-1 z"
+     id="path4157"
+     inkscape:connector-curvature="0" />
 </svg>

--- a/Numix/48/mimetypes/text-x-gtkrc.svg
+++ b/Numix/48/mimetypes/text-x-gtkrc.svg
@@ -1,11 +1,83 @@
-<svg width="48" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" height="48">
-<path style="fill:#dc322f" d="M 8,1 C 6.9714285,1 6,1.9714285 6,3 l 0,42 c 0,0.971429 1.0285714,2 2,2 l 32,0 c 0.971429,0 2,-1.028571 2,-2 L 42,14 29,1 z"/>
-<path style="fill-opacity:.196" d="M 29,12 29.0625,12.0625 29.21875,12 29,12 z m 2,2 11,11 0,-11 -11,0 z"/>
-<path style="fill:#fff;fill-opacity:.392" d="m 29,1 13,13 -11,0 c -0.971429,0 -2,-1.028571 -2,-2 L 29,1 z"/>
-<g style="fill:#fff" transform="translate(0 2)">
-<path d="m 32,17 0,-1 -16,0 0,1 -1,0 0,5 1,0 0,1 16,0 0,-1 1,0 0,-5 z m -16,0 10,0 0,5 -10,0 z m 12,1 3,0 0,2 -1,0 0,1 -1,0 0,-1 -1,0 z"/>
-<path d="m 16,26 0,1 -1,0 0,6 1,0 0,1 6,0 0,-1 1,0 0,-2 0,-1 0,-1 0,-2 -1,0 0,-1 z m 5,2 1,0 0,1 -1,-0.03574 0,1.03574 -1,0 0,1 -1,0 0,1 -1,0 0,-1 -1,0 0,-1 1,0 0,1 1,0 0,-1 1,0 0,-1 1,0 z"/>
-<path d="m 26.984424,26 0,1 4,0 0,-1 -4,0 z m 4,1 0,1 1,0 0,-1 -1,0 z m 1,1 0,4 1,0 0,-4 -1,0 z m 0,4 -1,0 0,1 1,0 0,-1 z m -1,1 -4,0 0,1 4,0 0,-1 z m -4,0 0,-1 -1,0 0,1 1,0 z m -1,-1 0,-4 -1,0 0,4 1,0 z m 0,-4 1,0 0,-1 -1,0 0,1 z"/>
-<path d="m 27.984424,31 -1,0 0,-2 1,0 0,-1 2,0 0,1 1,0 0,2 -1,0 0,1 -2,0 z"/>
-</g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   viewBox="0 0 48 48"
+   height="48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="text-x-gtkrc.svg">
+  <metadata
+     id="metadata24">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs22" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview20"
+     showgrid="false"
+     inkscape:snap-smooth-nodes="false"
+     inkscape:object-nodes="true"
+     inkscape:zoom="1"
+     inkscape:cx="23.041269"
+     inkscape:cy="13.682935"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4152" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#dc322f"
+     d="M 8,1 C 6.9714285,1 6,1.9714285 6,3 l 0,42 c 0,0.971429 1.0285714,2 2,2 l 32,0 c 0.971429,0 2,-1.028571 2,-2 L 42,14 29,1 z"
+     id="path4" />
+  <path
+     style="fill-opacity:.196"
+     d="M 29,12 29.0625,12.0625 29.21875,12 29,12 z m 2,2 11,11 0,-11 -11,0 z"
+     id="path6" />
+  <path
+     style="fill:#fff;fill-opacity:.392"
+     d="m 29,1 13,13 -11,0 c -0.971429,0 -2,-1.028571 -2,-2 L 29,1 z"
+     id="path8" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 14,20 c -0.554,0 -1,0.446 -1,1 l 0,6 c 0,0.554 0.446,1 1,1 l 20,0 c 0.554,0 1,-0.446 1,-1 l 0,-6 c 0,-0.554 -0.446,-1 -1,-1 z m 0,1 14,0 0,6 -14,0 z m 16,2 3,0 -1.5,2 z"
+     id="rect4154"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="sssssssssccccccccc" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 15 30 C 13.892 30 13 30.892 13 32 L 13 38 C 13 39.108 13.892 40 15 40 L 21 40 C 22.108 40 23 39.108 23 38 L 23 32 C 23 30.892 22.108 30 21 30 L 15 30 z M 20.769531 31.5 L 22 32.773438 L 16.460938 38.5 L 14 35.955078 L 15.230469 34.681641 L 16.460938 35.955078 L 20.769531 31.5 z "
+     id="rect4162" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 30,30 a 5,5 0 0 0 -5,5 5,5 0 0 0 5,5 5,5 0 0 0 5,-5 5,5 0 0 0 -5,-5 z m 0,1 a 4,4 0 0 1 4,4 4,4 0 0 1 -4,4 4,4 0 0 1 -4,-4 4,4 0 0 1 4,-4 z m 0,2 a 2,2 0 0 0 -2,2 2,2 0 0 0 2,2 2,2 0 0 0 2,-2 2,2 0 0 0 -2,-2 z"
+     id="path4166"
+     inkscape:connector-curvature="0" />
 </svg>

--- a/Numix/64/mimetypes/text-x-gtkrc.svg
+++ b/Numix/64/mimetypes/text-x-gtkrc.svg
@@ -1,12 +1,86 @@
-
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="64px" height="64px" viewBox="0 0 64 64" version="1.1">
-<g id="surface1">
-<path style=" stroke:none;fill-rule:nonzero;fill:rgb(86.27451%,19.607843%,18.431373%);fill-opacity:1;" d="M 10.671875 0 C 9.296875 0 8 1.355469 8 2.789062 L 8 61.210938 C 8 62.566406 9.375 64 10.671875 64 L 53.328125 64 C 54.625 64 56 62.566406 56 61.210938 L 56 18 L 38 0 Z M 10.671875 0 "/>
-<path style=" stroke:none;fill-rule:nonzero;fill:rgb(0%,0%,0%);fill-opacity:0.196078;" d="M 42 18 L 56 32 L 56 18 Z M 42 18 "/>
-<path style=" stroke:none;fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:0.392157;" d="M 38 0 L 55.984375 18 L 40.757812 18 C 39.410156 18 38 16.574219 38 15.226562 Z M 38 0 "/>
-<path style=" stroke:none;fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:1;" d="M 42.664062 25.335938 L 42.664062 24 L 21.335938 24 L 21.335938 25.335938 L 20 25.335938 L 20 32 L 21.335938 32 L 21.335938 33.335938 L 42.664062 33.335938 L 42.664062 32 L 44 32 L 44 25.335938 Z M 21.335938 25.335938 L 34.664062 25.335938 L 34.664062 32 L 21.335938 32 Z M 37.335938 26.664062 L 41.335938 26.664062 L 41.335938 29.335938 L 40 29.335938 L 40 30.664062 L 38.664062 30.664062 L 38.664062 29.335938 L 37.335938 29.335938 Z M 37.335938 26.664062 "/>
-<path style=" stroke:none;fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:1;" d="M 21.335938 37.335938 L 21.335938 38.664062 L 20 38.664062 L 20 46.664062 L 21.335938 46.664062 L 21.335938 48 L 29.335938 48 L 29.335938 46.664062 L 30.664062 46.664062 L 30.664062 38.664062 L 29.335938 38.664062 L 29.335938 37.335938 Z M 28 40 L 29.335938 40 L 29.335938 41.335938 L 28 41.289062 L 28 42.664062 L 26.664062 42.664062 L 26.664062 44 L 25.335938 44 L 25.335938 45.335938 L 24 45.335938 L 24 44 L 22.664062 44 L 22.664062 42.664062 L 24 42.664062 L 24 44 L 25.335938 44 L 25.335938 42.664062 L 26.664062 42.664062 L 26.664062 41.335938 L 28 41.335938 Z M 28 40 "/>
-<path style=" stroke:none;fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:1;" d="M 35.976562 37.335938 L 35.976562 38.664062 L 41.3125 38.664062 L 41.3125 37.335938 Z M 41.3125 38.664062 L 41.3125 40 L 42.648438 40 L 42.648438 38.664062 Z M 42.648438 40 L 42.648438 45.335938 L 43.976562 45.335938 L 43.976562 40 Z M 42.648438 45.335938 L 41.3125 45.335938 L 41.3125 46.664062 L 42.648438 46.664062 Z M 41.3125 46.664062 L 35.976562 46.664062 L 35.976562 48 L 41.3125 48 Z M 35.976562 46.664062 L 35.976562 45.335938 L 34.648438 45.335938 L 34.648438 46.664062 Z M 34.648438 45.335938 L 34.648438 40 L 33.3125 40 L 33.3125 45.335938 Z M 34.648438 40 L 35.976562 40 L 35.976562 38.664062 L 34.648438 38.664062 Z M 34.648438 40 "/>
-<path style=" stroke:none;fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:1;" d="M 37.3125 44 L 35.976562 44 L 35.976562 41.335938 L 37.3125 41.335938 L 37.3125 40 L 39.976562 40 L 39.976562 41.335938 L 41.3125 41.335938 L 41.3125 44 L 39.976562 44 L 39.976562 45.335938 L 37.3125 45.335938 Z M 37.3125 44 "/>
-</g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   viewBox="0 0 64 64"
+   version="1.1"
+   id="svg2"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="text-x-gtkrc.svg">
+  <metadata
+     id="metadata23">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs21" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview19"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="38.37025"
+     inkscape:cy="32"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4151" />
+  </sodipodi:namedview>
+  <g
+     id="surface1">
+    <path
+       style=" stroke:none;fill-rule:nonzero;fill:rgb(86.27451%,19.607843%,18.431373%);fill-opacity:1;"
+       d="M 10.671875 0 C 9.296875 0 8 1.355469 8 2.789062 L 8 61.210938 C 8 62.566406 9.375 64 10.671875 64 L 53.328125 64 C 54.625 64 56 62.566406 56 61.210938 L 56 18 L 38 0 Z M 10.671875 0 "
+       id="path5" />
+    <path
+       style=" stroke:none;fill-rule:nonzero;fill:rgb(0%,0%,0%);fill-opacity:0.196078;"
+       d="M 42 18 L 56 32 L 56 18 Z M 42 18 "
+       id="path7" />
+    <path
+       style=" stroke:none;fill-rule:nonzero;fill:rgb(100%,100%,100%);fill-opacity:0.392157;"
+       d="M 38 0 L 55.984375 18 L 40.757812 18 C 39.410156 18 38 16.574219 38 15.226562 Z M 38 0 "
+       id="path9" />
+  </g>
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 20,25 c -1.108,0 -2,0.892 -2,2 l 0,8 c 0,1.108 0.892,2 2,2 l 24,0 c 1.108,0 2,-0.892 2,-2 l 0,-8 c 0,-1.108 -0.892,-2 -2,-2 z m 0,2 16,0 0,8 -16,0 z m 18,2 6,0 -3,4 z"
+     id="rect4153"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="sssssssssccccccccc" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 20.398438,41 C 19.068838,41 18,42.068838 18,43.398438 l 0,7.203124 C 18,51.931162 19.068838,53 20.398438,53 l 7.203124,0 C 28.931162,53 30,51.931162 30,50.601562 l 0,-7.203124 C 30,42.068838 28.931162,41 27.601562,41 Z M 27.214844,43 28.5,44.332032 22.070312,51 19.397422,48.332032 20.682578,47 l 1.387734,1.332032 z"
+     id="rect4155"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="sssssssssccccccc" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 40,41 a 6,6 0 0 0 -6,6 6,6 0 0 0 6,6 6,6 0 0 0 6,-6 6,6 0 0 0 -6,-6 z m 0,2 a 4,4 0 0 1 4,4 4,4 0 0 1 -4,4 4,4 0 0 1 -4,-4 4,4 0 0 1 4,-4 z m 0,2 a 2,2 0 0 0 -2,2 2,2 0 0 0 2,2 2,2 0 0 0 2,-2 2,2 0 0 0 -2,-2 z"
+     id="path4157"
+     inkscape:connector-curvature="0" />
 </svg>


### PR DESCRIPTION
The old design was irrecognisable for sizes other than 48px.