### PR TITLE
pkcs12 symlinks

### DIFF
--- a/Numix/16/mimetypes/application-x-pkcs12.svg
+++ b/Numix/16/mimetypes/application-x-pkcs12.svg
@@ -1,0 +1,1 @@
+application-certificate.svg

--- a/Numix/22/mimetypes/application-x-pkcs12.svg
+++ b/Numix/22/mimetypes/application-x-pkcs12.svg
@@ -1,0 +1,1 @@
+application-certificate.svg

--- a/Numix/24/mimetypes/application-x-pkcs12.svg
+++ b/Numix/24/mimetypes/application-x-pkcs12.svg
@@ -1,0 +1,1 @@
+application-certificate.svg

--- a/Numix/32/mimetypes/application-x-pkcs12.svg
+++ b/Numix/32/mimetypes/application-x-pkcs12.svg
@@ -1,0 +1,1 @@
+application-certificate.svg

--- a/Numix/48/mimetypes/application-x-pkcs12.svg
+++ b/Numix/48/mimetypes/application-x-pkcs12.svg
@@ -1,0 +1,1 @@
+application-certificate.svg

--- a/Numix/64/mimetypes/application-x-pkcs12.svg
+++ b/Numix/64/mimetypes/application-x-pkcs12.svg
@@ -1,0 +1,1 @@
+application-certificate.svg


### PR DESCRIPTION
PKCS#12 is a certificate with keys/signature on the same file, normally created when export from windows system
```
The PKCS#12 or PFX format is a binary format for storing the server certificate, any intermediate
certificates, and the private key in one encryptable file. PFX files usually have extensions such as .pfx and
.p12. PFX files are typically used on Windows machines to import and export certificates and private keys.

When converting a PFX file to PEM format, OpenSSL will put all the certificates and the private key into a
single file. You will need to open the file in a text editor and copy each certificate and private key (including
the BEGIN/END statments) to its own individual text file and save them as certificate.cer, CACert.cer, and
privateKey.key respectively.
```
![image](https://cloud.githubusercontent.com/assets/11244067/11218993/1e7ece7c-8d3f-11e5-8f6c-dd63e945bf29.png)
``standard::icon: application-x-pkcs12, application-x-generic``