### PR TITLE
add new humanity symlinks

### DIFF
--- a/Numix/128/places/gnome-fs-bookmark.svg
+++ b/Numix/128/places/gnome-fs-bookmark.svg
@@ -1,0 +1,1 @@
+user-bookmarks.svg

--- a/Numix/128/places/stock_music-library.svg
+++ b/Numix/128/places/stock_music-library.svg
@@ -1,0 +1,1 @@
+folder-music.svg

--- a/Numix/16/actions/cab_extract.svg
+++ b/Numix/16/actions/cab_extract.svg
@@ -1,0 +1,1 @@
+tap-extract.svg

--- a/Numix/16/mimetypes/application-install.svg
+++ b/Numix/16/mimetypes/application-install.svg
@@ -1,0 +1,1 @@
+gnome-mime-x-install.svg

--- a/Numix/16/places/gnome-fs-bookmark.svg
+++ b/Numix/16/places/gnome-fs-bookmark.svg
@@ -1,0 +1,1 @@
+user-bookmarks.svg

--- a/Numix/16/places/stock_music-library.svg
+++ b/Numix/16/places/stock_music-library.svg
@@ -1,0 +1,1 @@
+folder-music.svg

--- a/Numix/16/status/audio-volume-muted-blocked-panel.svg
+++ b/Numix/16/status/audio-volume-muted-blocked-panel.svg
@@ -1,0 +1,1 @@
+audio-volume-muted-blocking.svg

--- a/Numix/16/status/gtk-dialog-warning-panel.svg
+++ b/Numix/16/status/gtk-dialog-warning-panel.svg
@@ -1,0 +1,1 @@
+dialog-warning.svg

--- a/Numix/16/status/messagebox_info.svg
+++ b/Numix/16/status/messagebox_info.svg
@@ -1,0 +1,1 @@
+dialog-information.svg

--- a/Numix/16/status/stock_dialog-error.svg
+++ b/Numix/16/status/stock_dialog-error.svg
@@ -1,0 +1,1 @@
+dialog-error.svg

--- a/Numix/22/actions/cab_extract.svg
+++ b/Numix/22/actions/cab_extract.svg
@@ -1,0 +1,1 @@
+tap-extract.svg

--- a/Numix/22/mimetypes/application-install.svg
+++ b/Numix/22/mimetypes/application-install.svg
@@ -1,0 +1,1 @@
+gnome-mime-x-install.svg

--- a/Numix/22/places/gnome-fs-bookmark.svg
+++ b/Numix/22/places/gnome-fs-bookmark.svg
@@ -1,0 +1,1 @@
+user-bookmarks.svg

--- a/Numix/22/places/stock_music-library.svg
+++ b/Numix/22/places/stock_music-library.svg
@@ -1,0 +1,1 @@
+folder-music.svg

--- a/Numix/22/status/audio-volume-muted-blocked-panel.svg
+++ b/Numix/22/status/audio-volume-muted-blocked-panel.svg
@@ -1,0 +1,1 @@
+audio-volume-muted-blocking.svg

--- a/Numix/22/status/gtk-dialog-warning-panel.svg
+++ b/Numix/22/status/gtk-dialog-warning-panel.svg
@@ -1,0 +1,1 @@
+dialog-warning.svg

--- a/Numix/22/status/messagebox_info.svg
+++ b/Numix/22/status/messagebox_info.svg
@@ -1,0 +1,1 @@
+dialog-information.svg

--- a/Numix/22/status/stock_dialog-error.svg
+++ b/Numix/22/status/stock_dialog-error.svg
@@ -1,0 +1,1 @@
+dialog-error.svg

--- a/Numix/24/actions/cab_extract.svg
+++ b/Numix/24/actions/cab_extract.svg
@@ -1,0 +1,1 @@
+tap-extract.svg

--- a/Numix/24/mimetypes/application-install.svg
+++ b/Numix/24/mimetypes/application-install.svg
@@ -1,0 +1,1 @@
+gnome-mime-x-install.svg

--- a/Numix/24/places/gnome-fs-bookmark.svg
+++ b/Numix/24/places/gnome-fs-bookmark.svg
@@ -1,0 +1,1 @@
+user-bookmarks.svg

--- a/Numix/24/places/stock_music-library.svg
+++ b/Numix/24/places/stock_music-library.svg
@@ -1,0 +1,1 @@
+folder-music.svg

--- a/Numix/24/status/audio-volume-muted-blocked-panel.svg
+++ b/Numix/24/status/audio-volume-muted-blocked-panel.svg
@@ -1,0 +1,1 @@
+audio-volume-muted-blocking.svg

--- a/Numix/24/status/gtk-dialog-warning-panel.svg
+++ b/Numix/24/status/gtk-dialog-warning-panel.svg
@@ -1,0 +1,1 @@
+dialog-warning.svg

--- a/Numix/24/status/messagebox_info.svg
+++ b/Numix/24/status/messagebox_info.svg
@@ -1,0 +1,1 @@
+dialog-information.svg

--- a/Numix/24/status/stock_dialog-error.svg
+++ b/Numix/24/status/stock_dialog-error.svg
@@ -1,0 +1,1 @@
+dialog-error.svg

--- a/Numix/256/places/gnome-fs-bookmark.svg
+++ b/Numix/256/places/gnome-fs-bookmark.svg
@@ -1,0 +1,1 @@
+user-bookmarks.svg

--- a/Numix/256/places/stock_music-library.svg
+++ b/Numix/256/places/stock_music-library.svg
@@ -1,0 +1,1 @@
+folder-music.svg

--- a/Numix/32/actions/cab_extract.svg
+++ b/Numix/32/actions/cab_extract.svg
@@ -1,0 +1,1 @@
+tap-extract.svg

--- a/Numix/32/mimetypes/application-install.svg
+++ b/Numix/32/mimetypes/application-install.svg
@@ -1,0 +1,1 @@
+gnome-mime-x-install.svg

--- a/Numix/32/places/gnome-fs-bookmark.svg
+++ b/Numix/32/places/gnome-fs-bookmark.svg
@@ -1,0 +1,1 @@
+user-bookmarks.svg

--- a/Numix/32/places/stock_music-library.svg
+++ b/Numix/32/places/stock_music-library.svg
@@ -1,0 +1,1 @@
+folder-music.svg

--- a/Numix/32/status/gtk-dialog-warning-panel.svg
+++ b/Numix/32/status/gtk-dialog-warning-panel.svg
@@ -1,0 +1,1 @@
+dialog-warning.svg

--- a/Numix/32/status/messagebox_info.svg
+++ b/Numix/32/status/messagebox_info.svg
@@ -1,0 +1,1 @@
+dialog-information.svg

--- a/Numix/32/status/stock_dialog-error.svg
+++ b/Numix/32/status/stock_dialog-error.svg
@@ -1,0 +1,1 @@
+dialog-error.svg

--- a/Numix/48/actions/cab_extract.svg
+++ b/Numix/48/actions/cab_extract.svg
@@ -1,0 +1,1 @@
+tap-extract.svg

--- a/Numix/48/mimetypes/application-install.svg
+++ b/Numix/48/mimetypes/application-install.svg
@@ -1,0 +1,1 @@
+gnome-mime-x-install.svg

--- a/Numix/48/places/gnome-fs-bookmark.svg
+++ b/Numix/48/places/gnome-fs-bookmark.svg
@@ -1,0 +1,1 @@
+user-bookmarks.svg

--- a/Numix/48/places/stock_music-library.svg
+++ b/Numix/48/places/stock_music-library.svg
@@ -1,0 +1,1 @@
+folder-music.svg

--- a/Numix/48/status/gtk-dialog-warning-panel.svg
+++ b/Numix/48/status/gtk-dialog-warning-panel.svg
@@ -1,0 +1,1 @@
+dialog-warning.svg

--- a/Numix/48/status/messagebox_info.svg
+++ b/Numix/48/status/messagebox_info.svg
@@ -1,0 +1,1 @@
+dialog-information.svg

--- a/Numix/48/status/stock_dialog-error.svg
+++ b/Numix/48/status/stock_dialog-error.svg
@@ -1,0 +1,1 @@
+dialog-error.svg

--- a/Numix/64/actions/cab_extract.svg
+++ b/Numix/64/actions/cab_extract.svg
@@ -1,0 +1,1 @@
+tap-extract.svg

--- a/Numix/64/mimetypes/application-install.svg
+++ b/Numix/64/mimetypes/application-install.svg
@@ -1,0 +1,1 @@
+gnome-mime-x-install.svg

--- a/Numix/64/places/gnome-fs-bookmark.svg
+++ b/Numix/64/places/gnome-fs-bookmark.svg
@@ -1,0 +1,1 @@
+user-bookmarks.svg

--- a/Numix/64/places/stock_music-library.svg
+++ b/Numix/64/places/stock_music-library.svg
@@ -1,0 +1,1 @@
+folder-music.svg

--- a/Numix/64/status/gtk-dialog-warning-panel.svg
+++ b/Numix/64/status/gtk-dialog-warning-panel.svg
@@ -1,0 +1,1 @@
+dialog-warning.svg

--- a/Numix/64/status/messagebox_info.svg
+++ b/Numix/64/status/messagebox_info.svg
@@ -1,0 +1,1 @@
+dialog-information.svg

--- a/Numix/64/status/stock_dialog-error.svg
+++ b/Numix/64/status/stock_dialog-error.svg
@@ -1,0 +1,1 @@
+dialog-error.svg

--- a/Numix/96/places/gnome-fs-bookmark.svg
+++ b/Numix/96/places/gnome-fs-bookmark.svg
@@ -1,0 +1,1 @@
+user-bookmarks.svg

--- a/Numix/96/places/stock_music-library.svg
+++ b/Numix/96/places/stock_music-library.svg
@@ -1,0 +1,1 @@
+folder-music.svg


### PR DESCRIPTION
Added symlinks for #826  : 
 - stock_music-library.svg
 - cab_extract.svg
 - application-install.svg
 - audio-volume-muted-blocked-panel.svg
 - dialog-info.svg
 - gnome-fs-bookmark.svg
 - gtk-dialog-warning-panel.svg
 - messagebox_info.svg
 - stock_bookmark.svg
 - stock_dialog-error.svg
