### PR TITLE
More breeze icons again

### DIFF
--- a/Numix/16/actions/amarok_playcount.svg
+++ b/Numix/16/actions/amarok_playcount.svg
@@ -1,0 +1,1 @@
+games-difficult.svg

--- a/Numix/16/actions/contrast.svg
+++ b/Numix/16/actions/contrast.svg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   width="100%"
+   height="100%"
+   sodipodi:docname="contrast.svg">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="3.8661971"
+     inkscape:cy="5.956176"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3758" />
+  </sodipodi:namedview>
+  <circle
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none"
+     id="path4136"
+     cx="3.5"
+     cy="11.5"
+     r="3.5" />
+  <circle
+     r="3.5"
+     cy="11.5"
+     cx="12.5"
+     id="circle4138"
+     style="opacity:1;fill:#000000;fill-opacity:1;stroke:none" />
+  <circle
+     style="opacity:1;fill:#808080;fill-opacity:1;stroke:none"
+     id="circle4140"
+     cx="8"
+     cy="4.5"
+     r="3.5" />
+</svg>

--- a/Numix/16/actions/globe.svg
+++ b/Numix/16/actions/globe.svg
@@ -1,0 +1,1 @@
+stock_timezone.svg

--- a/Numix/16/actions/internet-amarok.svg
+++ b/Numix/16/actions/internet-amarok.svg
@@ -1,0 +1,1 @@
+stock_timezone.svg

--- a/Numix/16/actions/photos-amarok.svg
+++ b/Numix/16/actions/photos-amarok.svg
@@ -1,0 +1,1 @@
+gtk-orientation-landscape.svg

--- a/Numix/16/actions/playlist-generator.svg
+++ b/Numix/16/actions/playlist-generator.svg
@@ -1,0 +1,1 @@
+image-auto-adjust.svg

--- a/Numix/16/status/rating-unrated.svg
+++ b/Numix/16/status/rating-unrated.svg
@@ -1,0 +1,1 @@
+non-starred.svg

--- a/Numix/16/status/whitebalance.svg
+++ b/Numix/16/status/whitebalance.svg
@@ -1,1 +1,60 @@
-weather-clear.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   viewBox="0 0 22 22"
+   height="16"
+   style="enable-background:new"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="whitebalance.svg">
+  <metadata
+     id="metadata34">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview32"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="3.775353"
+     inkscape:cy="7.1738107"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4133" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4" />
+  <path
+     style="fill:#dedc3f;fill-opacity:1"
+     d="M 9.4312279,3.0000086 C 9.1921696,4.979682 8.0505855,5.4457015 6.4874816,4.212507 7.0242111,6.1329706 6.1472761,6.9974034 4.2312345,6.4562542 5.4620392,8.0251344 4.9835177,9.1542204 3.006236,9.3875004 4.7437342,10.365949 4.7374837,11.596541 2.999976,12.56875 c 1.9796754,0.23906 2.4456907,1.380638 1.2124987,2.943756 1.9204652,-0.53674 2.7848889,0.34018 2.2437473,2.256237 1.5688827,-1.230819 2.6979567,-0.752299 2.931251,1.224998 0.978438,-1.737558 2.209029,-1.731237 3.181246,0.0063 0.239039,-1.979698 1.380626,-2.445697 2.943746,-1.212499 -0.536752,-1.920478 0.340186,-2.784896 2.256246,-2.243757 -1.230815,-1.568952 -0.75228,-2.697991 1.225013,-2.931291 -1.737528,-0.978473 -1.731251,-2.209041 0.0063,-3.1812596 -1.979767,-0.239098 -2.445746,-1.380666 -1.212558,-2.9437903 -1.920493,0.5367453 -2.784883,-0.3401876 -2.243746,-2.256247 -1.5689,1.2308283 -2.697947,0.752295 -2.931246,-1.2249985 -0.978448,1.7374938 -2.209049,1.7312478 -3.1812461,-0.00624 z"
+     id="path30"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/Numix/22/actions/amarok_playcount.svg
+++ b/Numix/22/actions/amarok_playcount.svg
@@ -1,0 +1,1 @@
+games-difficult.svg

--- a/Numix/22/actions/contrast.svg
+++ b/Numix/22/actions/contrast.svg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   viewBox="0 0 22 22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="contrast.svg">
+  <metadata
+     id="metadata20">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs18" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview16"
+     showgrid="true"
+     inkscape:zoom="22.585937"
+     inkscape:cx="-0.30020015"
+     inkscape:cy="10.84238"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2987" />
+  </sodipodi:namedview>
+  <circle
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none"
+     id="path4136"
+     cx="5"
+     cy="16"
+     r="5" />
+  <circle
+     r="5"
+     cy="16"
+     cx="17"
+     id="circle4138"
+     style="opacity:1;fill:#000000;fill-opacity:1;stroke:none" />
+  <circle
+     style="opacity:1;fill:#808080;fill-opacity:1;stroke:none"
+     id="circle4140"
+     cx="11"
+     cy="6"
+     r="5" />
+</svg>

--- a/Numix/22/actions/globe.svg
+++ b/Numix/22/actions/globe.svg
@@ -1,0 +1,1 @@
+stock_timezone.svg

--- a/Numix/22/actions/internet-amarok.svg
+++ b/Numix/22/actions/internet-amarok.svg
@@ -1,0 +1,1 @@
+stock_timezone.svg

--- a/Numix/22/actions/photos-amarok.svg
+++ b/Numix/22/actions/photos-amarok.svg
@@ -1,0 +1,1 @@
+gtk-orientation-landscape.svg

--- a/Numix/22/actions/playlist-generator.svg
+++ b/Numix/22/actions/playlist-generator.svg
@@ -1,0 +1,1 @@
+image-auto-adjust.svg

--- a/Numix/22/status/rating-unrated.svg
+++ b/Numix/22/status/rating-unrated.svg
@@ -1,0 +1,1 @@
+non-starred.svg

--- a/Numix/22/status/whitebalance.svg
+++ b/Numix/22/status/whitebalance.svg
@@ -1,1 +1,56 @@
-weather-clear.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   viewBox="0 0 22 22"
+   height="22"
+   style="enable-background:new"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="whitebalance.svg">
+  <metadata
+     id="metadata34">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview32"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="3.775353"
+     inkscape:cy="7.1738107"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <defs
+     id="defs4" />
+  <path
+     style="fill:#dedc3f;fill-opacity:1"
+     d="M 9.4312279,3.0000086 C 9.1921696,4.979682 8.0505855,5.4457015 6.4874816,4.212507 7.0242111,6.1329706 6.1472761,6.9974034 4.2312345,6.4562542 5.4620392,8.0251344 4.9835177,9.1542204 3.006236,9.3875004 4.7437342,10.365949 4.7374837,11.596541 2.999976,12.56875 c 1.9796754,0.23906 2.4456907,1.380638 1.2124987,2.943756 1.9204652,-0.53674 2.7848889,0.34018 2.2437473,2.256237 1.5688827,-1.230819 2.6979567,-0.752299 2.931251,1.224998 0.978438,-1.737558 2.209029,-1.731237 3.181246,0.0063 0.239039,-1.979698 1.380626,-2.445697 2.943746,-1.212499 -0.536752,-1.920478 0.340186,-2.784896 2.256246,-2.243757 -1.230815,-1.568952 -0.75228,-2.697991 1.225013,-2.931291 -1.737528,-0.978473 -1.731251,-2.209041 0.0063,-3.1812596 -1.979767,-0.239098 -2.445746,-1.380666 -1.212558,-2.9437903 -1.920493,0.5367453 -2.784883,-0.3401876 -2.243746,-2.256247 -1.5689,1.2308283 -2.697947,0.752295 -2.931246,-1.2249985 -0.978448,1.7374938 -2.209049,1.7312478 -3.1812461,-0.00624 z"
+     id="path30"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/Numix/24/actions/amarok_playcount.svg
+++ b/Numix/24/actions/amarok_playcount.svg
@@ -1,0 +1,1 @@
+games-difficult.svg

--- a/Numix/24/actions/contrast.svg
+++ b/Numix/24/actions/contrast.svg
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="24"
+   height="24"
+   id="svg2976"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="contrast.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview39"
+     showgrid="false"
+     inkscape:zoom="16.84375"
+     inkscape:cx="11.439985"
+     inkscape:cy="5.3210682"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2976">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4167" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2978" />
+  <metadata
+     id="metadata2981">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <circle
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none"
+     id="path4136"
+     cx="6"
+     cy="17"
+     r="5" />
+  <circle
+     r="5"
+     cy="17"
+     cx="18"
+     id="circle4138"
+     style="opacity:1;fill:#000000;fill-opacity:1;stroke:none" />
+  <circle
+     style="opacity:1;fill:#808080;fill-opacity:1;stroke:none"
+     id="circle4140"
+     cx="12"
+     cy="7"
+     r="5" />
+</svg>

--- a/Numix/24/actions/globe.svg
+++ b/Numix/24/actions/globe.svg
@@ -1,0 +1,1 @@
+stock_timezone.svg

--- a/Numix/24/actions/internet-amarok.svg
+++ b/Numix/24/actions/internet-amarok.svg
@@ -1,0 +1,1 @@
+stock_timezone.svg

--- a/Numix/24/actions/photos-amarok.svg
+++ b/Numix/24/actions/photos-amarok.svg
@@ -1,0 +1,1 @@
+gtk-orientation-landscape.svg

--- a/Numix/24/actions/playlist-generator.svg
+++ b/Numix/24/actions/playlist-generator.svg
@@ -1,0 +1,1 @@
+image-auto-adjust.svg

--- a/Numix/24/status/rating-unrated.svg
+++ b/Numix/24/status/rating-unrated.svg
@@ -1,0 +1,1 @@
+non-starred.svg

--- a/Numix/24/status/whitebalance.svg
+++ b/Numix/24/status/whitebalance.svg
@@ -1,1 +1,61 @@
-weather-clear.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   viewBox="0 0 24 24"
+   height="24"
+   style="enable-background:new"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="whitebalance.svg">
+  <metadata
+     id="metadata34">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview32"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="10.328743"
+     inkscape:cy="10.816853"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4133" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4" />
+  <path
+     style="fill:#dedc3f;fill-opacity:1"
+     d="M 10.431228,4.0000088 C 10.19217,5.9796822 9.0505855,6.4457017 7.4874816,5.2125072 8.0242111,7.1329708 7.1472761,7.9974036 5.2312345,7.4562544 6.4620392,9.0251342 5.9835177,10.15422 4.006236,10.3875 c 1.7374982,0.978449 1.7312477,2.209041 -0.00626,3.18125 1.9796754,0.23906 2.4456907,1.380638 1.2124987,2.943756 1.9204652,-0.53674 2.7848889,0.34018 2.2437473,2.256237 1.5688827,-1.230819 2.697957,-0.752299 2.931251,1.224998 0.978438,-1.737558 2.209029,-1.731237 3.181246,0.0063 0.239039,-1.979698 1.380626,-2.445697 2.943746,-1.212499 -0.536752,-1.920478 0.340186,-2.784896 2.256246,-2.243757 -1.230815,-1.568952 -0.75228,-2.697991 1.225013,-2.931291 -1.737528,-0.978473 -1.731251,-2.209041 0.0063,-3.18126 -1.979767,-0.239098 -2.445746,-1.3806658 -1.212558,-2.9437897 -1.920493,0.5367453 -2.784883,-0.3401876 -2.243746,-2.256247 -1.5689,1.2308283 -2.697947,0.752295 -2.931246,-1.2249985 -0.978448,1.7374938 -2.209049,1.7312478 -3.181246,-0.00624 z"
+     id="path30"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/Numix/32/actions/amarok_playcount.svg
+++ b/Numix/32/actions/amarok_playcount.svg
@@ -1,0 +1,1 @@
+games-difficult.svg

--- a/Numix/32/actions/contrast.svg
+++ b/Numix/32/actions/contrast.svg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   height="32"
+   viewBox="0 0 32 32"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="contrast.svg">
+  <metadata
+     id="metadata18">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs16" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview14"
+     showgrid="true"
+     inkscape:zoom="11.91033"
+     inkscape:cx="5.2026316"
+     inkscape:cy="17.212851"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2995" />
+  </sodipodi:namedview>
+  <circle
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none"
+     id="path4136"
+     cx="7.5"
+     cy="23.5"
+     r="7.5" />
+  <circle
+     r="7.5"
+     cy="23.5"
+     cx="24.5"
+     id="circle4138"
+     style="opacity:1;fill:#000000;fill-opacity:1;stroke:none" />
+  <circle
+     style="opacity:1;fill:#808080;fill-opacity:1;stroke:none"
+     id="circle4140"
+     cx="16"
+     cy="8.5"
+     r="7.5" />
+</svg>

--- a/Numix/32/actions/globe.svg
+++ b/Numix/32/actions/globe.svg
@@ -1,0 +1,1 @@
+stock_timezone.svg

--- a/Numix/32/actions/internet-amarok.svg
+++ b/Numix/32/actions/internet-amarok.svg
@@ -1,0 +1,1 @@
+stock_timezone.svg

--- a/Numix/32/actions/photos-amarok.svg
+++ b/Numix/32/actions/photos-amarok.svg
@@ -1,0 +1,1 @@
+gtk-orientation-landscape.svg

--- a/Numix/32/actions/playlist-generator.svg
+++ b/Numix/32/actions/playlist-generator.svg
@@ -1,0 +1,1 @@
+image-auto-adjust.svg

--- a/Numix/32/status/rating-unrated.svg
+++ b/Numix/32/status/rating-unrated.svg
@@ -1,0 +1,1 @@
+non-starred.svg

--- a/Numix/48/actions/amarok_playcount.svg
+++ b/Numix/48/actions/amarok_playcount.svg
@@ -1,0 +1,1 @@
+games-difficult.svg

--- a/Numix/48/actions/contrast.svg
+++ b/Numix/48/actions/contrast.svg
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="contrast.svg">
+  <metadata
+     id="metadata18">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs16" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview14"
+     showgrid="true"
+     inkscape:zoom="11.910329"
+     inkscape:cx="7.8435391"
+     inkscape:cy="21.430553"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:object-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2995" />
+  </sodipodi:namedview>
+  <circle
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none"
+     id="path4136"
+     cx="12"
+     cy="34"
+     r="10" />
+  <circle
+     r="10"
+     cy="34"
+     cx="35.999996"
+     id="circle4138"
+     style="opacity:1;fill:#000000;fill-opacity:1;stroke:none" />
+  <circle
+     style="opacity:1;fill:#808080;fill-opacity:1;stroke:none"
+     id="circle4140"
+     cx="23.999996"
+     cy="14"
+     r="10" />
+</svg>

--- a/Numix/48/actions/globe.svg
+++ b/Numix/48/actions/globe.svg
@@ -1,0 +1,1 @@
+stock_timezone.svg

--- a/Numix/48/actions/internet-amarok.svg
+++ b/Numix/48/actions/internet-amarok.svg
@@ -1,0 +1,1 @@
+stock_timezone.svg

--- a/Numix/48/actions/photos-amarok.svg
+++ b/Numix/48/actions/photos-amarok.svg
@@ -1,0 +1,1 @@
+gtk-orientation-landscape.svg

--- a/Numix/48/actions/playlist-generator.svg
+++ b/Numix/48/actions/playlist-generator.svg
@@ -1,0 +1,1 @@
+image-auto-adjust.svg

--- a/Numix/48/status/rating-unrated.svg
+++ b/Numix/48/status/rating-unrated.svg
@@ -1,0 +1,1 @@
+non-starred.svg

--- a/Numix/64/actions/amarok_playcount.svg
+++ b/Numix/64/actions/amarok_playcount.svg
@@ -1,0 +1,1 @@
+games-difficult.svg

--- a/Numix/64/actions/contrast.svg
+++ b/Numix/64/actions/contrast.svg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="contrast.svg">
+  <metadata
+     id="metadata18">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs16" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     id="namedview14"
+     showgrid="true"
+     inkscape:zoom="16.84375"
+     inkscape:cx="21.086499"
+     inkscape:cy="25.176404"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2995" />
+  </sodipodi:namedview>
+  <circle
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none"
+     id="path4136"
+     cx="15"
+     cy="47"
+     r="15" />
+  <circle
+     r="15"
+     cy="47"
+     cx="49"
+     id="circle4138"
+     style="opacity:1;fill:#000000;fill-opacity:1;stroke:none" />
+  <circle
+     style="opacity:1;fill:#808080;fill-opacity:1;stroke:none"
+     id="circle4140"
+     cx="32"
+     cy="17"
+     r="15" />
+</svg>

--- a/Numix/64/actions/globe.svg
+++ b/Numix/64/actions/globe.svg
@@ -1,0 +1,1 @@
+stock_timezone.svg

--- a/Numix/64/actions/internet-amarok.svg
+++ b/Numix/64/actions/internet-amarok.svg
@@ -1,0 +1,1 @@
+stock_timezone.svg

--- a/Numix/64/actions/photos-amarok.svg
+++ b/Numix/64/actions/photos-amarok.svg
@@ -1,0 +1,1 @@
+gtk-orientation-landscape.svg

--- a/Numix/64/actions/playlist-generator.svg
+++ b/Numix/64/actions/playlist-generator.svg
@@ -1,0 +1,1 @@
+image-auto-adjust.svg

--- a/Numix/64/status/rating-unrated.svg
+++ b/Numix/64/status/rating-unrated.svg
@@ -1,0 +1,1 @@
+non-starred.svg


### PR DESCRIPTION
From #580 
+ amarok_playcount
+ contrast
+ globe
+ internet-amarok
+ photos-amarok
+ playlist-generator
+ rating-unrated

All are symlinks, save for ``contrast``.

Fixed wrong colour of 16/22/24px ``whitebalance``.