### PR TITLE
inode/fifo mimetype icons

### DIFF
--- a/Numix/16/mimetypes/inode-fifo.svg
+++ b/Numix/16/mimetypes/inode-fifo.svg
@@ -44,7 +44,7 @@
      id="namedview30"
      showgrid="true"
      inkscape:zoom="51.936053"
-     inkscape:cx="8.0000015"
+     inkscape:cx="3.802532"
      inkscape:cy="8.0002229"
      inkscape:window-x="0"
      inkscape:window-y="27"
@@ -63,7 +63,7 @@
        id="grid3022" />
   </sodipodi:namedview>
   <path
-     style="fill:#dcdcdc;fill-opacity:1"
+     style="fill:#cccccc;fill-opacity:1"
      d="M 2.667969,-4.458e-4 C 2.324219,-4.458e-4 2,0.3378122 2,0.6964469 L 2,15.303108 C 2,15.641365 2.34375,16 2.667969,16 l 10.664062,0 C 13.65625,16 14,15.641365 14,15.303108 L 14,3.999554 10,-4.458e-4 z"
      id="path4"
      inkscape:connector-curvature="0"

--- a/Numix/16/mimetypes/inode-fifo.svg
+++ b/Numix/16/mimetypes/inode-fifo.svg
@@ -25,6 +25,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -43,9 +44,9 @@
      inkscape:window-height="1016"
      id="namedview30"
      showgrid="true"
-     inkscape:zoom="51.936053"
-     inkscape:cx="8.0000015"
-     inkscape:cy="8.0002229"
+     inkscape:zoom="73.448671"
+     inkscape:cx="6.8516556"
+     inkscape:cy="6.5134423"
      inkscape:window-x="0"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
@@ -57,7 +58,9 @@
      inkscape:snap-bbox-midpoints="true"
      inkscape:object-paths="true"
      inkscape:snap-intersection-paths="true"
-     inkscape:object-nodes="true">
+     inkscape:object-nodes="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true">
     <inkscape:grid
        type="xygrid"
        id="grid3022" />
@@ -80,29 +83,20 @@
      id="path8"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="ccssc" />
-  <g
-     transform="matrix(0.83333309,0,0,0.93333334,-2.0086748,-2.8323354)"
-     id="g4171">
-    <g
-       id="g4169"
-       transform="matrix(0.5,0,0,0.5,0,0.5)">
-      <path
-         style="fill:#808080;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 12.020823,20.06929 0,12.857143 2.4,0 0,-4.285714 3.600002,0 0.554528,-4.285715 -4.15453,0 0,-4.285714 z m 21.600006,0 0,4.285714 -3.415161,0 -0.04621,4.285715 3.461372,0 0,4.285714 2.400001,0 0,-12.857143 z"
-         id="path4150"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccccccccc" />
-      <path
-         style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
-         d="m 24.020825,18.56929 a 7.5,7.5 0 0 0 -7.5,7.5 7.5,7.5 0 0 0 7.5,7.5 7.5,7.5 0 0 0 7.5,-7.5 7.5,7.5 0 0 0 -7.5,-7.5 z m 0,2.142857 a 5.3571428,5.3571428 0 0 1 5.357143,5.357143 5.3571428,5.3571428 0 0 1 -5.357143,5.357143 5.3571428,5.3571428 0 0 1 -5.357143,-5.357143 5.3571428,5.3571428 0 0 1 5.357143,-5.357143 z"
-         id="path4153"
-         inkscape:connector-curvature="0" />
-      <path
-         style="fill:#808080;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 21.620826,21.183298 0,9.600278 7.764602,-4.714286 z"
-         id="path4172"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccc" />
-    </g>
-  </g>
+  <path
+     style="fill:#808080;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 3,11 1.9999999,0 0,-2.0000001 -1.9999994,0 z m 10,-2.0000001 -2,0 L 11,11 l 2,0 z"
+     id="path4150"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccc" />
+  <path
+     style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 8 6.5 A 3.5 3.5 0 0 0 4.5 10 A 3.5 3.5 0 0 0 8 13.5 A 3.5 3.5 0 0 0 11.5 10 A 3.5 3.5 0 0 0 8 6.5 z M 8 7 A 3 3 0 0 1 11 10 A 3 3 0 0 1 8 13 A 3 3 0 0 1 5 10 A 3 3 0 0 1 8 7 z "
+     id="path4141" />
+  <path
+     style="fill:#808080;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 7,7 0,6 3,-3 z"
+     id="path4172"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccc" />
 </svg>

--- a/Numix/16/mimetypes/inode-fifo.svg
+++ b/Numix/16/mimetypes/inode-fifo.svg
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="inode-fifo.svg"
+   inkscape:export-filename="/home/ismael/Imágenes/Icons/inode-fifo/16px.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <metadata
+     id="metadata34">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs32" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     id="namedview30"
+     showgrid="true"
+     inkscape:zoom="51.936053"
+     inkscape:cx="8.0000015"
+     inkscape:cy="8.0002229"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3022" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#dcdcdc;fill-opacity:1"
+     d="M 2.667969,-4.458e-4 C 2.324219,-4.458e-4 2,0.3378122 2,0.6964469 L 2,15.303108 C 2,15.641365 2.34375,16 2.667969,16 l 10.664062,0 C 13.65625,16 14,15.641365 14,15.303108 L 14,3.999554 10,-4.458e-4 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssssccs" />
+  <path
+     style="fill:#000000;fill-opacity:0.19599998"
+     d="m 10.583223,3.331585 0.0154,0.01953 0.04005,-0.01953 z m 0.02978,0.667969 3.387,3.664062 0,-3.664062 z"
+     id="path6"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccc" />
+  <path
+     style="fill:#ffffff;fill-opacity:0.39200003"
+     d="m 10,-4.458e-4 3.996396,3.9999998 -3.383784,0 C 10.313513,3.999554 10,3.682437 10,3.383338 z"
+     id="path8"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccssc" />
+  <g
+     transform="matrix(0.66666667,0,0,0.66666667,-0.00694177,-0.02309685)"
+     id="g4171">
+    <g
+       id="g4169"
+       transform="matrix(0.5,0,0,0.5,0,0.5)">
+      <path
+         style="fill:#808080;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 12.020823,20.06929 2e-6,6 0,6.631703 3,0 0,-3.631703 3,0 0,-6 -2.999998,0 -2e-6,-3 z m 20.999997,0 5e-6,3 -3,0 0,6 2.999997,0 3e-6,3 3,0 L 36,26 36.02083,20.06929 Z"
+         id="path4150"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccccccccccccc" />
+      <path
+         style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 24.020825,18.56929 a 7.5,7.5 0 0 0 -7.5,7.5 7.5,7.5 0 0 0 7.5,7.5 7.5,7.5 0 0 0 7.5,-7.5 7.5,7.5 0 0 0 -7.5,-7.5 z m 0,2.142857 a 5.3571428,5.3571428 0 0 1 5.357143,5.357143 5.3571428,5.3571428 0 0 1 -5.357143,5.357143 5.3571428,5.3571428 0 0 1 -5.357143,-5.357143 5.3571428,5.3571428 0 0 1 5.357143,-5.357143 z"
+         id="path4153"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#808080;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 21.020825,21.513374 0,9.342886 8.364603,-4.78697 z"
+         id="path4172"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+    </g>
+  </g>
+</svg>

--- a/Numix/16/mimetypes/inode-fifo.svg
+++ b/Numix/16/mimetypes/inode-fifo.svg
@@ -44,7 +44,7 @@
      id="namedview30"
      showgrid="true"
      inkscape:zoom="51.936053"
-     inkscape:cx="3.802532"
+     inkscape:cx="8.0000015"
      inkscape:cy="8.0002229"
      inkscape:window-x="0"
      inkscape:window-y="27"
@@ -81,17 +81,17 @@
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="ccssc" />
   <g
-     transform="matrix(0.66666667,0,0,0.66666667,-0.00694177,-0.02309685)"
+     transform="matrix(0.83333309,0,0,0.93333334,-2.0086748,-2.8323354)"
      id="g4171">
     <g
        id="g4169"
        transform="matrix(0.5,0,0,0.5,0,0.5)">
       <path
          style="fill:#808080;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 12.020823,20.06929 2e-6,6 0,6.631703 3,0 0,-3.631703 3,0 0,-6 -2.999998,0 -2e-6,-3 z m 20.999997,0 5e-6,3 -3,0 0,6 2.999997,0 3e-6,3 3,0 L 36,26 36.02083,20.06929 Z"
+         d="m 12.020823,20.06929 0,12.857143 2.4,0 0,-4.285714 3.600002,0 0.554528,-4.285715 -4.15453,0 0,-4.285714 z m 21.600006,0 0,4.285714 -3.415161,0 -0.04621,4.285715 3.461372,0 0,4.285714 2.400001,0 0,-12.857143 z"
          id="path4150"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccccccccccccccccc" />
+         sodipodi:nodetypes="cccccccccccccccccc" />
       <path
          style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
          d="m 24.020825,18.56929 a 7.5,7.5 0 0 0 -7.5,7.5 7.5,7.5 0 0 0 7.5,7.5 7.5,7.5 0 0 0 7.5,-7.5 7.5,7.5 0 0 0 -7.5,-7.5 z m 0,2.142857 a 5.3571428,5.3571428 0 0 1 5.357143,5.357143 5.3571428,5.3571428 0 0 1 -5.357143,5.357143 5.3571428,5.3571428 0 0 1 -5.357143,-5.357143 5.3571428,5.3571428 0 0 1 5.357143,-5.357143 z"
@@ -99,7 +99,7 @@
          inkscape:connector-curvature="0" />
       <path
          style="fill:#808080;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 21.020825,21.513374 0,9.342886 8.364603,-4.78697 z"
+         d="m 21.620826,21.183298 0,9.600278 7.764602,-4.714286 z"
          id="path4172"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cccc" />

--- a/Numix/22/mimetypes/inode-fifo.svg
+++ b/Numix/22/mimetypes/inode-fifo.svg
@@ -44,7 +44,7 @@
      id="namedview30"
      showgrid="true"
      inkscape:zoom="37.772727"
-     inkscape:cx="11"
+     inkscape:cx="5.2286402"
      inkscape:cy="11"
      inkscape:window-x="0"
      inkscape:window-y="27"
@@ -102,7 +102,7 @@
          inkscape:connector-curvature="0" />
       <path
          style="fill:#808080;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 20,21 0,10 9.714286,-5 z"
+         d="M 22,20.417569 22,31.582431 29.714286,26 Z"
          id="path4172"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cccc" />

--- a/Numix/22/mimetypes/inode-fifo.svg
+++ b/Numix/22/mimetypes/inode-fifo.svg
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   viewBox="0 0 22 22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="inode-fifo.svg"
+   inkscape:export-filename="/home/ismael/Imágenes/Icons/inode-fifo/22px.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <metadata
+     id="metadata34">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs32" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     id="namedview30"
+     showgrid="true"
+     inkscape:zoom="37.772727"
+     inkscape:cx="11"
+     inkscape:cy="11"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3022"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#cccccc"
+     d="M 4,0 C 3.527343,0 3,0.527344 3,1 l 0,20 c 0,0.445312 0.554687,1 1,1 l 14,0 c 0.445313,0 0.992367,-0.554753 1,-1 L 19,6 13,0 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssssccs" />
+  <path
+     style="fill:#000000;fill-opacity:0.19599998"
+     d="m 14,6 5,5 0,-5 z"
+     id="path6"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccc" />
+  <path
+     style="fill:#ffffff;fill-opacity:0.39200003"
+     d="m 13,0 6,6 -5,0 C 13.554688,6 13,5.445312 13,5 z"
+     id="path8"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccssc" />
+  <g
+     transform="translate(-1,-1)"
+     id="g4171">
+    <g
+       id="g4169"
+       transform="matrix(0.5,0,0,0.5,0,0.5)">
+      <path
+         style="fill:#808080;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 12,19 0,7 0,7 2,0 0,-4 4,0 0,-6 -4,0 0,-4 z m 22,0 0,4 -4,0 0,6 4,0 0,4 2,0 0,-7 0,-7 z"
+         id="path4150"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccccccccccccc" />
+      <path
+         style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 24,18 a 8,8 0 0 0 -8,8 8,8 0 0 0 8,8 8,8 0 0 0 8,-8 8,8 0 0 0 -8,-8 z m 0,2.285714 A 5.7142857,5.7142857 0 0 1 29.714286,26 5.7142857,5.7142857 0 0 1 24,31.714286 5.7142857,5.7142857 0 0 1 18.285714,26 5.7142857,5.7142857 0 0 1 24,20.285714 Z"
+         id="path4153"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#808080;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 20,21 0,10 9.714286,-5 z"
+         id="path4172"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+    </g>
+  </g>
+</svg>

--- a/Numix/24/mimetypes/inode-fifo.svg
+++ b/Numix/24/mimetypes/inode-fifo.svg
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="inode-fifo.svg"
+   inkscape:export-filename="/home/ismael/Imágenes/Icons/inode-fifo/24px.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <metadata
+     id="metadata34">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs32" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     id="namedview30"
+     showgrid="true"
+     inkscape:zoom="37.772727"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-nodes="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3022"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#dcdcdc"
+     d="M 5,1 C 4.527343,1 4,1.527344 4,2 l 0,20 c 0,0.445312 0.554687,1 1,1 l 14,0 c 0.445313,0 0.992367,-0.554753 1,-1 L 20,7 14,1 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssssccs" />
+  <path
+     style="fill:#000000;fill-opacity:0.19599998"
+     d="m 15,7 5,5 0,-5 z"
+     id="path6"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccc" />
+  <path
+     style="fill:#ffffff;fill-opacity:0.39200003"
+     d="m 14,1 6,6 -5,0 C 14.554688,7 14,6.445312 14,6 z"
+     id="path8"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccssc" />
+  <g
+     id="g4171">
+    <g
+       id="g4169"
+       transform="matrix(0.5,0,0,0.5,0,0.5)">
+      <path
+         style="fill:#808080;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 12,19 0,7 0,7 2,0 0,-4 4,0 0,-6 -4,0 0,-4 z m 22,0 0,4 -4,0 0,6 4,0 0,4 2,0 0,-7 0,-7 z"
+         id="path4150"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccccccccccccc" />
+      <path
+         style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 24,18 a 8,8 0 0 0 -8,8 8,8 0 0 0 8,8 8,8 0 0 0 8,-8 8,8 0 0 0 -8,-8 z m 0,2.285714 A 5.7142857,5.7142857 0 0 1 29.714286,26 5.7142857,5.7142857 0 0 1 24,31.714286 5.7142857,5.7142857 0 0 1 18.285714,26 5.7142857,5.7142857 0 0 1 24,20.285714 Z"
+         id="path4153"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#808080;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 20,21 0,10 9.714286,-5 z"
+         id="path4172"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+    </g>
+  </g>
+</svg>

--- a/Numix/24/mimetypes/inode-fifo.svg
+++ b/Numix/24/mimetypes/inode-fifo.svg
@@ -44,7 +44,7 @@
      id="namedview30"
      showgrid="true"
      inkscape:zoom="37.772727"
-     inkscape:cx="12"
+     inkscape:cx="6.2286402"
      inkscape:cy="12"
      inkscape:window-x="0"
      inkscape:window-y="27"
@@ -68,11 +68,14 @@
        snapvisiblegridlinesonly="true" />
   </sodipodi:namedview>
   <path
-     style="fill:#dcdcdc"
+     style="fill:#cccccc"
      d="M 5,1 C 4.527343,1 4,1.527344 4,2 l 0,20 c 0,0.445312 0.554687,1 1,1 l 14,0 c 0.445313,0 0.992367,-0.554753 1,-1 L 20,7 14,1 z"
      id="path4"
      inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ssssssccs" />
+     sodipodi:nodetypes="ssssssccs"
+     inkscape:export-filename="/home/ismael/Imágenes/Icons/inode-fifo/path4.png"
+     inkscape:export-xdpi="90"
+     inkscape:export-ydpi="90" />
   <path
      style="fill:#000000;fill-opacity:0.19599998"
      d="m 15,7 5,5 0,-5 z"

--- a/Numix/24/mimetypes/inode-fifo.svg
+++ b/Numix/24/mimetypes/inode-fifo.svg
@@ -44,7 +44,7 @@
      id="namedview30"
      showgrid="true"
      inkscape:zoom="37.772727"
-     inkscape:cx="6.2286402"
+     inkscape:cx="12"
      inkscape:cy="12"
      inkscape:window-x="0"
      inkscape:window-y="27"
@@ -106,7 +106,7 @@
          inkscape:connector-curvature="0" />
       <path
          style="fill:#808080;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 20,21 0,10 9.714286,-5 z"
+         d="M 22,20.417569 22,31.582431 29.714286,26 Z"
          id="path4172"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cccc" />

--- a/Numix/32/mimetypes/inode-fifo.svg
+++ b/Numix/32/mimetypes/inode-fifo.svg
@@ -44,7 +44,7 @@
      id="namedview12"
      showgrid="true"
      inkscape:zoom="25.96875"
-     inkscape:cx="16"
+     inkscape:cx="7.6052948"
      inkscape:cy="16"
      inkscape:window-x="0"
      inkscape:window-y="27"
@@ -102,7 +102,7 @@
              inkscape:connector-curvature="0" />
           <path
              style="fill:#808080;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             d="m 21,22 0,7.5 7.821429,-3.75 z"
+             d="m 22.5,20.5 0,10.5 6.321429,-5.25 z"
              id="path4172"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="cccc" />

--- a/Numix/32/mimetypes/inode-fifo.svg
+++ b/Numix/32/mimetypes/inode-fifo.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   height="32"
+   viewBox="0 0 32 32"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="inode-fifo.svg"
+   inkscape:export-filename="/home/ismael/Imágenes/Icons/inode-fifo/32px.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="25.96875"
+     inkscape:cx="16"
+     inkscape:cy="16"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:object-nodes="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#cccccc;fill-opacity:1"
+     d="M 5.335888,2.969e-4 C 4.648414,3.119e-4 4,0.6767878 4,1.3940311 L 4,30.606268 C 4,31.282757 4.687474,32 5.335888,32 l 21.327332,0 c 0.648414,0 1.335888,-0.717243 1.335888,-1.393732 L 28,8.9999996 l -9,-9 z"
+     id="path4-1"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssssccs" />
+  <path
+     style="fill:#000000;fill-opacity:0.19599998"
+     d="M 21,8.9999996 28,16 28,8.9999996 z"
+     id="path6-4"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccc" />
+  <path
+     style="fill:#ffffff;fill-opacity:0.39200003"
+     d="m 19.000306,2.969e-4 8.991594,8.9997027 -7.613262,0 c -0.672951,0 -1.378332,-0.7134896 -1.378332,-1.3864402 z"
+     id="path8-6"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccssc" />
+  <g
+     id="g4163">
+    <g
+       id="g4156">
+      <g
+         id="g4150">
+        <g
+           id="g4169"
+           transform="matrix(0.66666667,0,0,0.66666667,-4e-8,0.33333327)">
+          <path
+             style="fill:#808080;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 12,19 0,7.5 0,6 3,0 0,-2.999998 3.806859,0 0,-7.5 L 15,22 15,19 Z m 21,0 0,3 -3.922383,0 0,7.5 3.922383,0 0,3 3,0 0,-6 0,-7.5 z"
+             id="path4150"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cccccccccccccccccccc" />
+          <path
+             style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
+             d="M 24,19 A 6.75,6.75 0 0 0 17.25,25.75 6.75,6.75 0 0 0 24,32.5 6.75,6.75 0 0 0 30.75,25.75 6.75,6.75 0 0 0 24,19 Z m 0,1.928571 A 4.8214285,4.8214285 0 0 1 28.821429,25.75 4.8214285,4.8214285 0 0 1 24,30.571429 4.8214285,4.8214285 0 0 1 19.178571,25.75 4.8214285,4.8214285 0 0 1 24,20.928571 Z"
+             id="path4153"
+             inkscape:connector-curvature="0" />
+          <path
+             style="fill:#808080;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 21,22 0,7.5 7.821429,-3.75 z"
+             id="path4172"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cccc" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/Numix/32/mimetypes/inode-fifo.svg
+++ b/Numix/32/mimetypes/inode-fifo.svg
@@ -44,7 +44,7 @@
      id="namedview12"
      showgrid="true"
      inkscape:zoom="25.96875"
-     inkscape:cx="7.6052948"
+     inkscape:cx="16"
      inkscape:cy="16"
      inkscape:window-x="0"
      inkscape:window-y="27"
@@ -102,7 +102,7 @@
              inkscape:connector-curvature="0" />
           <path
              style="fill:#808080;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             d="m 22.5,20.5 0,10.5 6.321429,-5.25 z"
+             d="m 21,22 0,7.5 7.821429,-3.75 z"
              id="path4172"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="cccc" />

--- a/Numix/48/mimetypes/inode-fifo.svg
+++ b/Numix/48/mimetypes/inode-fifo.svg
@@ -49,7 +49,7 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:snap-midpoints="true"
      inkscape:zoom="18.065217"
-     inkscape:cx="24"
+     inkscape:cx="11.932611"
      inkscape:cy="24"
      inkscape:window-x="0"
      inkscape:window-y="27"
@@ -87,7 +87,7 @@
        sodipodi:nodetypes="cccc"
        inkscape:connector-curvature="0"
        id="path4172"
-       d="m 21,22 0,8 8,-4 z"
+       d="m 22,21 0,10 7,-5 z"
        style="fill:#808080;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   </g>
 </svg>

--- a/Numix/48/mimetypes/inode-fifo.svg
+++ b/Numix/48/mimetypes/inode-fifo.svg
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   viewBox="0 0 48 48"
+   height="48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="inode-fifo.svg"
+   inkscape:export-filename="/home/ismael/Imágenes/Icons/inode-fifo/48px.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <metadata
+     id="metadata18">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs16" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     id="namedview14"
+     showgrid="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-nodes="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:zoom="18.065217"
+     inkscape:cx="24"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4146" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#cccccc"
+     d="M 8,1 C 6.9714285,1 6,1.9714285 6,3 l 0,42 c 0,0.971429 1.0285714,2 2,2 l 32,0 c 0.971429,0 2,-1.028571 2,-2 L 42,14 29,1 z"
+     id="path4" />
+  <path
+     style="fill-opacity:.196"
+     d="M 29,12 29.0625,12.0625 29.21875,12 29,12 z m 2,2 11,11 0,-11 -11,0 z"
+     id="path6" />
+  <path
+     style="fill:#fff;fill-opacity:.392"
+     d="m 29,1 13,13 -11,0 c -0.971429,0 -2,-1.028571 -2,-2 L 29,1 z"
+     id="path8" />
+  <g
+     id="g4169">
+    <path
+       sodipodi:nodetypes="cccccccccccccccccccc"
+       inkscape:connector-curvature="0"
+       id="path4150"
+       d="m 12,19 0,7 0,7 3,0 0,-3 4,0 0,-8 -4,0 0,-3 z m 21,0 0,3 -4,0 0,8 4,0 0,3 3,0 0,-7 0,-7 z"
+       style="fill:#808080;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path4153"
+       d="M 24 19 A 7 7 0 0 0 17 26 A 7 7 0 0 0 24 33 A 7 7 0 0 0 31 26 A 7 7 0 0 0 24 19 z M 24 21 A 5 5 0 0 1 29 26 A 5 5 0 0 1 24 31 A 5 5 0 0 1 19 26 A 5 5 0 0 1 24 21 z "
+       style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="path4172"
+       d="m 21,22 0,8 8,-4 z"
+       style="fill:#808080;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+</svg>

--- a/Numix/48/mimetypes/inode-fifo.svg
+++ b/Numix/48/mimetypes/inode-fifo.svg
@@ -49,7 +49,7 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:snap-midpoints="true"
      inkscape:zoom="18.065217"
-     inkscape:cx="11.932611"
+     inkscape:cx="24"
      inkscape:cy="24"
      inkscape:window-x="0"
      inkscape:window-y="27"
@@ -87,7 +87,7 @@
        sodipodi:nodetypes="cccc"
        inkscape:connector-curvature="0"
        id="path4172"
-       d="m 22,21 0,10 7,-5 z"
+       d="m 21,22 0,8 8,-4 z"
        style="fill:#808080;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   </g>
 </svg>

--- a/Numix/64/mimetypes/inode-fifo.svg
+++ b/Numix/64/mimetypes/inode-fifo.svg
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   viewBox="0 0 64 64"
+   version="1.1"
+   id="svg2"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="inode-fifo.svg">
+  <metadata
+     id="metadata29">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs27" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     id="namedview25"
+     showgrid="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-nodes="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:snap-nodes="true"
+     inkscape:zoom="12.984375"
+     inkscape:cx="32"
+     inkscape:cy="32"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4167" />
+  </sodipodi:namedview>
+  <path
+     inkscape:connector-curvature="0"
+     id="path5"
+     d="M 10.671875,0 C 9.296875,0 8,1.355469 8,2.789062 L 8,61.210938 C 8,62.566406 9.375,64 10.671875,64 l 42.65625,0 C 54.625,64 56,62.566406 56,61.210938 L 56,18 38,0 Z m 0,0"
+     style="fill:#dcdcdc;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path7"
+     d="m 42,18 14,14 0,-14 z m 0,0"
+     style="fill:#000000;fill-opacity:0.19607801;fill-rule:nonzero;stroke:none" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path9"
+     d="M 38,0 55.984375,18 40.757812,18 C 39.410156,18 38,16.574219 38,15.226562 Z m 0,0"
+     style="fill:#ffffff;fill-opacity:0.39215698;fill-rule:nonzero;stroke:none" />
+  <g
+     transform="scale(2,2)"
+     id="g4163">
+    <g
+       id="g4156">
+      <g
+         id="g4150">
+        <g
+           id="g4169"
+           transform="matrix(0.66666667,0,0,0.66666667,-4e-8,0.33333327)">
+          <path
+             style="fill:#808080;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 12,18.25 0,7.75 0,7.25 3,0 0,-3.75 3,0 0,-7.5 -3,0 0,-3.75 z m 21,0 0,3.75 -3,0 0,7.5 3,0 0,3.75 3,0 0,-7.25 0,-7.75 z"
+             id="path4150"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cccccccccccccccccccc" />
+          <path
+             style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
+             d="M 24,17.875 A 7.875,7.875 0 0 0 16.125,25.75 7.875,7.875 0 0 0 24,33.625 7.875,7.875 0 0 0 31.875,25.75 7.875,7.875 0 0 0 24,17.875 Z m 0,2.25 A 5.6249999,5.6249999 0 0 1 29.625,25.75 5.6249999,5.6249999 0 0 1 24,31.375 5.6249999,5.6249999 0 0 1 18.375,25.75 5.6249999,5.6249999 0 0 1 24,20.125 Z"
+             id="path4153"
+             inkscape:connector-curvature="0" />
+          <path
+             style="fill:#808080;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="M 21,20.5 21,31 30,25.75 Z"
+             id="path4172"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cccc" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/Numix/64/mimetypes/inode-fifo.svg
+++ b/Numix/64/mimetypes/inode-fifo.svg
@@ -13,7 +13,10 @@
    version="1.1"
    id="svg2"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="inode-fifo.svg">
+   sodipodi:docname="inode-fifo.svg"
+   inkscape:export-filename="/home/ismael/Imágenes/Icons/inode-fifo/64px.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
   <metadata
      id="metadata29">
     <rdf:RDF>
@@ -65,7 +68,7 @@
      inkscape:connector-curvature="0"
      id="path5"
      d="M 10.671875,0 C 9.296875,0 8,1.355469 8,2.789062 L 8,61.210938 C 8,62.566406 9.375,64 10.671875,64 l 42.65625,0 C 54.625,64 56,62.566406 56,61.210938 L 56,18 38,0 Z m 0,0"
-     style="fill:#dcdcdc;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+     style="fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none" />
   <path
      inkscape:connector-curvature="0"
      id="path7"

--- a/Numix/64/mimetypes/inode-fifo.svg
+++ b/Numix/64/mimetypes/inode-fifo.svg
@@ -54,7 +54,7 @@
      inkscape:snap-center="true"
      inkscape:snap-nodes="true"
      inkscape:zoom="12.984375"
-     inkscape:cx="32"
+     inkscape:cx="15.21059"
      inkscape:cy="32"
      inkscape:window-x="0"
      inkscape:window-y="27"
@@ -102,7 +102,7 @@
              inkscape:connector-curvature="0" />
           <path
              style="fill:#808080;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             d="M 21,20.5 21,31 30,25.75 Z"
+             d="M 21.75,20.5 21.75,31 30,25.75 Z"
              id="path4172"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="cccc" />

--- a/Numix/64/mimetypes/inode-fifo.svg
+++ b/Numix/64/mimetypes/inode-fifo.svg
@@ -54,7 +54,7 @@
      inkscape:snap-center="true"
      inkscape:snap-nodes="true"
      inkscape:zoom="12.984375"
-     inkscape:cx="15.21059"
+     inkscape:cx="32"
      inkscape:cy="32"
      inkscape:window-x="0"
      inkscape:window-y="27"
@@ -102,7 +102,7 @@
              inkscape:connector-curvature="0" />
           <path
              style="fill:#808080;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             d="M 21.75,20.5 21.75,31 30,25.75 Z"
+             d="M 21,20.5 21,31 30,25.75 Z"
              id="path4172"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="cccc" />


### PR DESCRIPTION
**inode/fifo mimetype**
_64px,48px,32px,24px,22px,16px icons:_

![64px](https://cloud.githubusercontent.com/assets/8478202/11765271/66802606-a150-11e5-8cec-3fbcaa853bf4.png)![48px](https://cloud.githubusercontent.com/assets/8478202/11765272/69799658-a150-11e5-8bd2-c5dd26d4f261.png)![32px](https://cloud.githubusercontent.com/assets/8478202/11765273/6cf421e0-a150-11e5-9628-d21dee672841.png)![24px](https://cloud.githubusercontent.com/assets/8478202/11765275/707cf68e-a150-11e5-87a0-23a11c55188b.png)![22px](https://cloud.githubusercontent.com/assets/8478202/11765277/74d56130-a150-11e5-96c0-a216ab0abe06.png)![16px](https://cloud.githubusercontent.com/assets/8478202/11765278/77a0ef6a-a150-11e5-8c14-0437851d02f3.png)

*Edit: Issue https://github.com/numixproject/numix-icon-theme/issues/936*










