### PR TITLE
New design for nm-tech*

### DIFF
--- a/Numix-Light/16/status/network-cellular-3g.svg
+++ b/Numix-Light/16/status/network-cellular-3g.svg
@@ -1,0 +1,1 @@
+nm-tech-3g.svg

--- a/Numix-Light/16/status/network-cellular-4g.svg
+++ b/Numix-Light/16/status/network-cellular-4g.svg
@@ -1,0 +1,1 @@
+nm-tech-4g.svg

--- a/Numix-Light/16/status/network-cellular-edge.svg
+++ b/Numix-Light/16/status/network-cellular-edge.svg
@@ -1,0 +1,1 @@
+nm-tech-edge.svg

--- a/Numix-Light/16/status/network-cellular-gprs.svg
+++ b/Numix-Light/16/status/network-cellular-gprs.svg
@@ -1,0 +1,1 @@
+nm-tech-gprs.svg

--- a/Numix-Light/16/status/network-cellular-hspa.svg
+++ b/Numix-Light/16/status/network-cellular-hspa.svg
@@ -1,0 +1,1 @@
+nm-tech-hspa.svg

--- a/Numix-Light/16/status/network-cellular-offline.svg
+++ b/Numix-Light/16/status/network-cellular-offline.svg
@@ -1,0 +1,1 @@
+gsm-3g-none.svg

--- a/Numix-Light/16/status/nm-tech-3g.svg
+++ b/Numix-Light/16/status/nm-tech-3g.svg
@@ -41,9 +41,9 @@
      inkscape:window-height="1056"
      id="namedview3373"
      showgrid="true"
-     inkscape:zoom="20.85965"
-     inkscape:cx="13.581944"
-     inkscape:cy="0.9419594"
+     inkscape:zoom="29.5"
+     inkscape:cx="0.59701127"
+     inkscape:cy="5.3503583"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -52,43 +52,38 @@
        type="xygrid"
        id="grid3411" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4143"
-     width="9"
-     height="1"
-     x="7"
-     y="2"
-     rx="0.5"
-     ry="0.5" />
-  <rect
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4145"
-     width="1"
-     height="12"
-     x="11"
-     y="2"
-     rx="0.5"
-     ry="0.49999997" />
-  <path
-     style="fill:none;fill-rule:evenodd;stroke:#353535;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 7.5,2.5 4,5.5 4,-5.5"
-     id="path4147"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccc" />
   <g
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.38390064px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="text4218"
-     transform="matrix(0.6562625,0,0,0.6562625,1.6790482,3.6110078)">
+     id="g4146">
     <path
-       d="m 1.8937715,15.432832 q -0.2848297,0 -0.6068111,-0.04954 -0.30959751,-0.03715 -0.60681113,-0.09907 -0.28482971,-0.06192 -0.53250773,-0.136223 -0.24767801,-0.0743 -0.38390092,-0.136223 l 0.29721362,-1.275542 q 0.28482971,0.123839 0.73065014,0.260062 0.45820432,0.136223 1.08978322,0.136223 0.7801858,0 1.0897833,-0.334365 0.3219814,-0.334365 0.3219814,-0.829721 0,-0.606812 -0.4829721,-0.842106 Q 2.3272081,11.878652 1.584174,11.878652 l -0.4705882,0 0,-1.263158 0.5696594,0 q 0.2352941,0 0.4705882,-0.04954 0.2352942,-0.04954 0.4210527,-0.160991 0.1857585,-0.111455 0.2972136,-0.297214 0.123839,-0.185758 0.123839,-0.4705877 0,-0.4210527 -0.2600619,-0.6563468 -0.247678,-0.247678 -0.6934985,-0.247678 -0.4334365,0 -0.866873,0.1486068 Q 0.75445268,9.0179712 0.44485516,9.2284975 L -0.10003647,8.1139465 Q 0.23432885,7.8910363 0.77922048,7.6681261 1.336496,7.4328319 2.0299944,7.4328319 q 0.6439629,0 1.1145511,0.1609908 0.4829721,0.1609907 0.7925696,0.4582043 0.3095976,0.2848297 0.4582044,0.6811145 0.1486068,0.3962848 0.1486068,0.8544892 0,0.4582043 -0.2600619,0.8792573 -0.260062,0.421052 -0.6934985,0.643962 0.5944273,0.247678 0.9164087,0.730651 0.3343653,0.482972 0.3343653,1.151702 0,0.532508 -0.1733746,0.978328 -0.1733746,0.445821 -0.5325077,0.780186 -0.3591332,0.321982 -0.9164087,0.50774 -0.5572755,0.173375 -1.3250774,0.173375 z"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#353535;fill-opacity:1"
-       id="path4223"
-       inkscape:connector-curvature="0" />
-    <path
-       d="m 9.3104893,8.7579093 q -0.5448916,0 -0.9164086,0.1981424 -0.371517,0.1981424 -0.6191951,0.5572756 -0.2352941,0.3467492 -0.3467492,0.8421047 -0.099071,0.482973 -0.099071,1.0774 0,1.374613 0.4334365,2.03096 0.4334366,0.643962 1.2755418,0.643962 0.1362229,0 0.2972136,-0.01238 0.1609907,-0.01238 0.2972136,-0.03715 l 0,-2.798762 1.5232191,0 0,3.826626 q -0.272446,0.09907 -0.854489,0.22291 -0.5696589,0.123839 -1.3869963,0.123839 -0.7182662,0 -1.3003096,-0.247678 Q 7.0442357,14.925097 6.635567,14.429741 6.2268983,13.922001 6.003988,13.178967 5.7810778,12.423549 5.7810778,11.432837 q 0,-0.978328 0.2600619,-1.7213623 0.260062,-0.755418 0.7058824,-1.2631579 0.4458204,-0.5077399 1.0526315,-0.7554179 0.6068112,-0.260062 1.3003096,-0.260062 0.4458204,0 0.7925696,0.074303 0.3591322,0.06192 0.6191942,0.1486069 0.260062,0.086687 0.421053,0.1857585 0.173375,0.099071 0.260062,0.1486068 L 10.796557,9.2037297 Q 10.524111,9.0303551 10.127826,8.8941322 9.7315419,8.7579093 9.3104893,8.7579093 Z"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#353535;fill-opacity:1"
-       id="path4225"
-       inkscape:connector-curvature="0" />
+       style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 15,15 15,1 1,15 Z"
+       id="path4139"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <g
+       transform="matrix(-1,0,0,1,-12.253709,-20.565582)"
+       id="g4169"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="matrix(0.49999997,0,0,0.49999997,1.499,1.2500093)"
+       id="text4155"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4140"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#353535;fill-opacity:1"
+         d="m 2.6625387,10.999982 q -0.3560371,0 -0.7585139,-0.06192 Q 1.5170279,10.891623 1.1455108,10.814223 0.78947367,10.736824 0.47987614,10.643944 0.17027861,10.551065 -2.9087067e-8,10.473666 L 0.37151701,8.8792386 q 0.35603716,0.1547987 0.91331269,0.3250774 0.5727555,0.1702786 1.3622292,0.1702786 0.9752322,0 1.3622291,-0.4179567 0.4024768,-0.4179566 0.4024768,-1.0371517 0,-0.7585139 -0.6037152,-1.0526316 Q 3.2043344,6.5572571 2.2755418,6.5572571 l -0.5882353,0 0,-1.5789474 0.7120743,0 q 0.2941177,0 0.5882353,-0.061919 Q 3.2817338,4.8544707 3.5139319,4.7151518 3.7461301,4.5758329 3.885449,4.3436347 4.0402477,4.1114366 4.0402477,3.7553994 q 0,-0.5263158 -0.3250774,-0.8204334 -0.3095975,-0.3095976 -0.866873,-0.3095976 -0.5417957,0 -1.0835914,0.1857586 Q 1.2383901,2.9814056 0.85139318,3.2445635 L 0.17027861,1.8513746 Q 0.58823528,1.5727368 1.2693498,1.2940991 1.9659443,0.99998141 2.8328174,0.99998141 q 0.8049536,0 1.3931889,0.20123839 0.6037151,0.2012384 0.9907121,0.5727554 0.3869969,0.3560372 0.5727554,0.8513932 0.1857585,0.4953561 0.1857585,1.0681115 0,0.5727555 -0.3250774,1.0990713 -0.3250774,0.5263158 -0.8668731,0.8049535 0.7430341,0.3095976 1.1455109,0.9133128 0.4179566,0.6037151 0.4179566,1.4396285 0,0.6656347 -0.2167182,1.2229102 Q 5.9133128,9.7306318 5.4643964,10.148588 5.01548,10.551065 4.3188855,10.783263 3.6222911,10.999982 2.6625387,10.999982 Z" />
+    </g>
+    <g
+       transform="matrix(0.52478257,0,0,0.52478257,-3.4927796,-3.4110486)"
+       id="text4380"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
+      <path
+         sodipodi:nodetypes="ascaaasccccascccacscaascccca"
+         inkscape:connector-curvature="0"
+         id="path4403"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#353535;fill-opacity:1"
+         d="m 19.878081,11.770099 c -0.26463,0.01281 -0.457796,0.04053 -0.767707,0.205822 -0.309911,0.165285 -0.568171,0.397718 -0.774778,0.697299 -0.196277,0.289251 -0.34168,0.685213 -0.433875,1.053697 -0.09699,0.387667 -0.159149,0.795263 -0.119363,1.192895 0.06055,0.605143 0.145386,1.278777 0.537746,1.743446 0.384492,0.455351 0.893576,0.805769 1.596041,0.805769 0.113634,0 0.07648,-0.0074 0.07648,-0.0074 l -2.4e-5,-3.339478 1.905951,0 0,4.571055 c -0.227267,0.08264 -0.576666,0.238122 -0.87971,0.305238 -0.411435,0.09112 -0.744278,0.128637 -1.257653,0.128637 -0.599161,0 -1.141505,-0.103304 -1.627032,-0.309911 -0.475197,-0.216937 -0.883246,-0.532013 -1.224148,-0.945228 -0.340902,-0.423544 -0.604326,-0.945227 -0.790273,-1.565049 -0.185946,-0.630153 -0.219098,-1.059211 -0.216115,-1.596087 0.0034,-0.60292 0.04567,-1.169803 0.262602,-1.789624 0.216938,-0.630153 0.511353,-1.157001 0.883246,-1.580546 0.371893,-0.423546 0.810934,-0.738622 1.317121,-0.945229 0.506189,-0.216938 0.833472,-0.240534 1.262956,-0.268412 0.325962,-0.02116 0.654231,0.0268 0.976828,0.07809 0.262299,0.0417 0.557839,0.113634 0.774777,0.185946 0.216937,0.07231 0.392553,0.149791 0.526848,0.232433 l 0.325407,0.185947 -0.495858,1.518565 c -0.227268,-0.14463 -0.506188,-0.27376 -0.83676,-0.387394 -0.345293,-0.133943 -0.677503,-0.187196 -1.022707,-0.170481 z" />
+    </g>
   </g>
 </svg>

--- a/Numix-Light/16/status/nm-tech-4g.svg
+++ b/Numix-Light/16/status/nm-tech-4g.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg3351"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="nm-tech-4g.svg">
+  <metadata
+     id="metadata3377">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3375" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1056"
+     id="namedview3373"
+     showgrid="true"
+     inkscape:zoom="20.85965"
+     inkscape:cx="-3.7722479"
+     inkscape:cy="7.1733974"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3351">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3411" />
+  </sodipodi:namedview>
+  <g
+     id="g4150">
+    <path
+       style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 15,15 15,1 1,15 Z"
+       id="path4139-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <g
+       transform="matrix(-1,0,0,1,-12.253709,-20.565582)"
+       id="g4169-4"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="matrix(0.52476889,0,0,0.52476889,-3.5188818,-3.4186932)"
+       id="text4380-5"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
+      <path
+         sodipodi:nodetypes="ascaaasccccascccacscaascccca"
+         inkscape:connector-curvature="0"
+         id="path4403-9"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#353535;fill-opacity:1"
+         d="m 19.930451,11.784195 c -0.26463,0.01281 -0.457796,0.04053 -0.767707,0.205822 -0.309911,0.165285 -0.568171,0.397718 -0.774778,0.697299 -0.196277,0.289251 -0.34168,0.685213 -0.433875,1.053697 -0.09699,0.387667 -0.159149,0.795263 -0.119363,1.192895 0.06055,0.605143 0.145386,1.278777 0.537746,1.743446 0.384492,0.455351 0.893576,0.805769 1.596041,0.805769 0.113634,0 0.07648,-0.0074 0.07648,-0.0074 l -2.4e-5,-3.339478 1.905951,0 0,4.571055 c -0.227267,0.08264 -0.576666,0.238122 -0.87971,0.305238 -0.411435,0.09112 -0.744278,0.128637 -1.257653,0.128637 -0.599161,0 -1.141505,-0.103304 -1.627032,-0.309911 -0.475197,-0.216937 -0.883246,-0.532013 -1.224148,-0.945228 -0.340902,-0.423544 -0.604326,-0.945227 -0.790273,-1.565049 -0.185946,-0.630153 -0.219098,-1.059211 -0.216115,-1.596087 0.0034,-0.60292 0.04567,-1.169803 0.262602,-1.789624 0.216938,-0.630153 0.511353,-1.157001 0.883246,-1.580546 0.371893,-0.423546 0.810934,-0.738622 1.317121,-0.945229 0.506189,-0.216938 0.833472,-0.240534 1.262956,-0.268412 0.325962,-0.02116 0.654231,0.0268 0.976828,0.07809 0.262299,0.0417 0.557839,0.113634 0.774777,0.185946 0.216937,0.07231 0.392553,0.149791 0.526848,0.232433 l 0.325407,0.185947 -0.495858,1.518565 C 21.56265,12.19744 21.28373,12.06831 20.953158,11.954676 20.607865,11.820733 20.275655,11.76748 19.930451,11.784195 Z" />
+    </g>
+    <path
+       sodipodi:nodetypes="ccccccccccccccccc"
+       inkscape:connector-curvature="0"
+       id="rect4146"
+       d="M 2.8111226,1.9997144 1.5,4.4810012 l 0,1.018528 1.5005708,0 0,0.9999739 0.9999739,0 0,-0.9999739 0.4999869,0 0,-0.7999791 -0.4999869,0 0,-2.6744458 0,-0.02539 z m 0.1894482,1.3078721 0,1.3919636 -0.7068415,0 z"
+       style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+</svg>

--- a/Numix-Light/16/status/nm-tech-cdma-1x.svg
+++ b/Numix-Light/16/status/nm-tech-cdma-1x.svg
@@ -41,9 +41,9 @@
      inkscape:window-height="1056"
      id="namedview3373"
      showgrid="true"
-     inkscape:zoom="41.7193"
-     inkscape:cx="3.9584721"
-     inkscape:cy="9.3375749"
+     inkscape:zoom="14.75"
+     inkscape:cx="-13.043165"
+     inkscape:cy="6.8682833"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -52,38 +52,23 @@
        type="xygrid"
        id="grid3411" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4143"
-     width="9"
-     height="1"
-     x="7"
-     y="2"
-     rx="0.5"
-     ry="0.5" />
-  <rect
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4145"
-     width="1"
-     height="12"
-     x="11"
-     y="2"
-     rx="0.5"
-     ry="0.49999997" />
-  <path
-     style="fill:none;fill-rule:evenodd;stroke:#353535;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 7.5,2.5 4,5.5 4,-5.5"
-     id="path4147"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccc" />
   <g
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.28792572px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="text4139"
-     transform="matrix(1.1666667,0,0,1.1666667,-0.50000013,-2.3333339)">
+     id="g4143">
     <path
-       d="M 5.4984521,14 Q 4.2817338,14 3.640867,13.219814 3.0000001,12.439629 3.0000001,11 q 0,-0.71517 0.1950464,-1.2724456 Q 3.390093,9.1702789 3.7337462,8.7894739 4.0866874,8.399381 4.5603716,8.2043346 5.0433437,8.0000002 5.6099072,8.0000002 q 0.3065016,0 0.5479876,0.055728 0.250774,0.04644 0.4365325,0.1114551 0.1857586,0.065015 0.3065016,0.1393189 0.130031,0.074303 0.1950464,0.1114551 L 6.7987617,9.3281736 Q 6.5851394,9.1888547 6.2786379,9.0959755 5.9814242,8.9938083 5.5913314,8.9938083 q -0.2693499,0 -0.5294118,0.1021672 -0.250774,0.092879 -0.4551084,0.3250774 -0.1950464,0.2229102 -0.3250774,0.6037151 -0.120743,0.380805 -0.120743,0.947368 0,0.984521 0.3343653,1.513932 0.3436533,0.520124 1.1145511,0.520124 0.4458204,0 0.7337461,-0.102167 0.2972137,-0.102167 0.4736843,-0.204334 l 0.2879257,0.900928 Q 6.8637772,13.749226 6.4458205,13.879257 6.0371518,14 5.4984521,14 Z"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#353535;fill-opacity:1"
-       id="path4144"
-       inkscape:connector-curvature="0" />
+       style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 15,15 15,1 1,15 Z"
+       id="path4139"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <g
+       transform="matrix(0.55555556,0,0,0.55555556,5.8788793,4.4174906)"
+       id="text4137"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:13.93188858px;line-height:354.99999523%;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4142"
+         style="line-height:354.99999523%;fill:#353535;fill-opacity:1"
+         d="m -2.5279578,4.648517 q -1.8250774,0 -2.7863777,-1.1702786 -0.9613003,-1.1702787 -0.9613003,-3.3297214 0,-1.07275542 0.2925696,-1.9086687 0.2925697,-0.8359134 0.8080496,-1.4071208 0.5294117,-0.5851393 1.2399381,-0.877709 0.7244582,-0.3065015 1.5743034,-0.3065015 0.4597523,0 0.8219814,0.083591 0.376161,0.06966 0.65479875,0.1671827 0.27863778,0.097523 0.45975233,0.2089783 0.19504644,0.1114551 0.29256966,0.1671827 l -0.44582044,1.3653251 q -0.32043343,-0.2089784 -0.7801858,-0.3482973 -0.4458204,-0.1532507 -1.0309597,-0.1532507 -0.4040248,0 -0.7941177,0.1532507 -0.376161,0.1393189 -0.6826625,0.4876161 -0.2925697,0.3343654 -0.4876161,0.9055728 -0.1811146,0.57120743 -0.1811146,1.42105263 0,1.47678017 0.501548,2.27089787 0.5154799,0.7801857 1.6718267,0.7801857 0.6687306,0 1.1006192,-0.1532507 0.4458204,-0.1532508 0.71052628,-0.3065016 l 0.43188855,1.3513932 Q -0.47997018,4.272356 -1.1069052,4.4674025 -1.7199083,4.648517 -2.5279578,4.648517 Z" />
+    </g>
   </g>
 </svg>

--- a/Numix-Light/16/status/nm-tech-edge.svg
+++ b/Numix-Light/16/status/nm-tech-edge.svg
@@ -41,9 +41,9 @@
      inkscape:window-height="1056"
      id="namedview3373"
      showgrid="true"
-     inkscape:zoom="29.5"
-     inkscape:cx="6.3273665"
-     inkscape:cy="5.8581559"
+     inkscape:zoom="14.75"
+     inkscape:cx="-20.246276"
+     inkscape:cy="6.8682833"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -52,34 +52,23 @@
        type="xygrid"
        id="grid3411" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4143"
-     width="9"
-     height="1"
-     x="7"
-     y="2"
-     rx="0.5"
-     ry="0.5" />
-  <rect
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4145"
-     width="1"
-     height="12"
-     x="11"
-     y="2"
-     rx="0.5"
-     ry="0.49999997" />
-  <path
-     style="fill:none;fill-rule:evenodd;stroke:#353535;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 7.5,2.5 4,5.5 4,-5.5"
-     id="path4147"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccc" />
-  <path
-     style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 7,6.9999996 -4,0 L 3,14 l 4,0 0,-1 -3,0 0,-2 2,0 0,-1.0000004 -2,0 0,-2 3,0 z"
-     id="path4206"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccccccccccc" />
+  <g
+     id="g4145">
+    <path
+       style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 15,15 15,1 1,15 Z"
+       id="path4139-0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <g
+       transform="matrix(-1,0,0,1,-15.253709,-19.565582)"
+       id="g4169"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccccccccccccc"
+       inkscape:connector-curvature="0"
+       id="path4140"
+       d="m 2,2 0,5 3,0 0,-0.9999995 -2,0 L 3,5 4.5,5 4.5,4 3,4 3,3 5,3 5,2 Z"
+       style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
 </svg>

--- a/Numix-Light/16/status/nm-tech-evdo.svg
+++ b/Numix-Light/16/status/nm-tech-evdo.svg
@@ -41,9 +41,9 @@
      inkscape:window-height="1056"
      id="namedview3373"
      showgrid="true"
-     inkscape:zoom="29.5"
-     inkscape:cx="6.3273665"
-     inkscape:cy="6.980932"
+     inkscape:zoom="14.75"
+     inkscape:cx="-25.229327"
+     inkscape:cy="12.292012"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -52,43 +52,25 @@
        type="xygrid"
        id="grid3411" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4143"
-     width="9"
-     height="1"
-     x="7"
-     y="2"
-     rx="0.5"
-     ry="0.5" />
-  <rect
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4145"
-     width="1"
-     height="12"
-     x="11"
-     y="2"
-     rx="0.5"
-     ry="0.49999997" />
-  <path
-     style="fill:none;fill-rule:evenodd;stroke:#353535;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 7.5,2.5 4,5.5 4,-5.5"
-     id="path4147"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccc" />
-  <path
-     style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 4,6.9999996 -4,0 L 0,14 l 4,0 0,-1 -3,0 0,-2 2,0 0,-1.0000004 -2,0 0,-2 3,0 z"
-     id="path4206"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccccccccccc" />
   <g
-     transform="scale(0.9647938,1.0364909)"
-     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.91043091px;line-height:125%;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="text4325">
+     id="g4146">
     <path
-       d="M 6.5517138,13.507113 Q 6.2898635,12.754294 5.9952818,11.805086 5.7007002,10.855879 5.4388499,9.9175817 5.1769995,8.9683742 4.9697013,8.128271 4.7624032,7.2881678 4.6642093,6.7535567 l 1.418356,0 q 0.065463,0.5237007 0.1963878,1.2219683 0.1309251,0.6873571 0.2836712,1.4292664 0.1636564,0.7309986 0.3382233,1.4510876 0.1854773,0.709178 0.3600442,1.27652 0.1745669,-0.556432 0.3491338,-1.26561 Q 7.7845925,10.146701 7.9373386,9.4157019 8.0900846,8.6737926 8.2210098,7.975525 8.3519349,7.2772574 8.4392184,6.7535567 l 1.4074456,0 Q 9.7157388,7.4081826 9.519351,8.2155545 9.3338737,9.0229264 9.0829338,9.9175817 8.8429043,10.801327 8.5483227,11.728713 8.253741,12.645189 7.9373386,13.507113 l -1.3856248,0 z"
-       style="fill:#353535;fill-opacity:1"
-       id="path4330" />
+       style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 15,15 15,1 1,15 Z"
+       id="path4139"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       sodipodi:nodetypes="ccccccccccccc"
+       inkscape:connector-curvature="0"
+       id="path4140-0"
+       d="m 2,2 0,5.0003988 2.9999392,0 0,-0.9999799 -1.9999595,0 0,-0.9999797 1.4999696,0 0,-0.9999797 -1.4999696,0 0,-0.9999798 1.9999595,0 0,-1.0004797 z"
+       style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       id="rect4137"
+       d="M 5.1999352,2 6.5436579,7 7.4752796,7 8.8190023,2 7.7838673,2 7.009469,5.5919274 6.2350702,2 Z"
+       style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   </g>
 </svg>

--- a/Numix-Light/16/status/nm-tech-gprs.svg
+++ b/Numix-Light/16/status/nm-tech-gprs.svg
@@ -41,9 +41,9 @@
      inkscape:window-height="1056"
      id="namedview3373"
      showgrid="true"
-     inkscape:zoom="14.75"
-     inkscape:cx="-12.843399"
-     inkscape:cy="10.547058"
+     inkscape:zoom="118"
+     inkscape:cx="1.448317"
+     inkscape:cy="11.951515"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -52,38 +52,29 @@
        type="xygrid"
        id="grid3411" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4143"
-     width="9"
-     height="1"
-     x="7"
-     y="2"
-     rx="0.5"
-     ry="0.5" />
-  <rect
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4145"
-     width="1"
-     height="12"
-     x="11"
-     y="2"
-     rx="0.5"
-     ry="0.49999997" />
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#353535;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 7.5,2.5 4,5.5 4,-5.5"
-     id="path4147"
+     sodipodi:nodetypes="cccc"
      inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccc" />
+     id="path4139"
+     d="M 15,15 15,1 1,15 Z"
+     style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <g
-     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:37.5px;line-height:125%;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="text4137"
-     transform="matrix(0.28895769,0,0,0.28895769,3.8164303,11.547472)">
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="g4169"
+     transform="matrix(-1,0,0,1,-44.963641,-18.34766)" />
+  <g
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="g4169-7"
+     transform="matrix(-1,0,0,1,-64.982985,-20.426498)" />
+  <g
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="text4380"
+     transform="matrix(0.52480727,0,0,0.52480727,-5.5231927,-3.4441309)">
     <path
-       d="m 5.4291859,-11.725 q -1.65,0 -2.775,0.6 -1.125,0.6 -1.87500003,1.6875 -0.7125,1.05 -1.05,2.55 -0.3,1.4625 -0.3,3.2625 0,4.1625 1.3125,6.15 1.31250003,1.95 3.86250003,1.95 0.4125,0 0.9,-0.0375 0.4875,-0.0375 0.9,-0.1125 l 0,-8.475 4.6125001,0 0,11.5875 q -0.825,0.3 -2.5875001,0.675 -1.725,0.375 -4.2,0.375 -2.175,0 -3.93750003,-0.75 Q -1.4333141,6.95 -2.6708141,5.45 q -1.2375,-1.5375 -1.9125,-3.7875 -0.675,-2.2875 -0.675,-5.2875 0,-2.9625 0.7875,-5.2125 0.7875,-2.2875 2.1375,-3.825 1.34999998,-1.5375 3.18749997,-2.2875 1.83750003,-0.7875 3.93750003,-0.7875 1.35,0 2.4,0.225 1.0875,0.1875 1.875,0.45 0.7875,0.2625 1.2750001,0.5625 0.525,0.3 0.7875,0.45 l -1.2000001,3.675 q -0.825,-0.525 -2.025,-0.9375 -1.2,-0.4125 -2.475,-0.4125 z"
-       id="path4142"
+       d="m 19.937055,11.833171 c -0.26463,0.01281 -0.457796,0.04053 -0.767707,0.205822 -0.309911,0.165285 -0.568171,0.397718 -0.774778,0.697299 -0.196277,0.289251 -0.34168,0.685213 -0.433875,1.053697 -0.09699,0.387667 -0.159149,0.795263 -0.119363,1.192895 0.06055,0.605143 0.145386,1.278777 0.537746,1.743446 0.384492,0.455351 0.893576,0.805769 1.596041,0.805769 0.113634,0 0.07648,-0.0074 0.07648,-0.0074 l -2.4e-5,-3.339478 1.905951,0 0,4.571055 c -0.227267,0.08264 -0.576666,0.238122 -0.87971,0.305238 -0.411435,0.09112 -0.744278,0.128637 -1.257653,0.128637 -0.599161,0 -1.141505,-0.103304 -1.627032,-0.309911 -0.475197,-0.216937 -0.883246,-0.532013 -1.224148,-0.945228 -0.340902,-0.423544 -0.604326,-0.945227 -0.790273,-1.565049 -0.185946,-0.630153 -0.219098,-1.059211 -0.216115,-1.596087 0.0034,-0.60292 0.04567,-1.169803 0.262602,-1.789624 0.216938,-0.630153 0.511353,-1.157001 0.883246,-1.580546 0.371893,-0.423546 0.810934,-0.738622 1.317121,-0.945229 0.506189,-0.216938 0.833472,-0.240534 1.262956,-0.268412 0.325962,-0.02116 0.654231,0.0268 0.976828,0.07809 0.262299,0.0417 0.557839,0.113634 0.774777,0.185946 0.216937,0.07231 0.392553,0.149791 0.526848,0.232433 l 0.325407,0.185947 -0.495858,1.518565 c -0.227268,-0.14463 -0.506188,-0.27376 -0.83676,-0.387394 -0.345293,-0.133943 -0.677503,-0.187196 -1.022707,-0.170481 z"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#353535;fill-opacity:1"
+       id="path4403"
        inkscape:connector-curvature="0"
-       style="fill:#353535;fill-opacity:1" />
+       sodipodi:nodetypes="ascaaasccccascccacscaascccca" />
   </g>
 </svg>

--- a/Numix-Light/16/status/nm-tech-hspa.svg
+++ b/Numix-Light/16/status/nm-tech-hspa.svg
@@ -41,9 +41,9 @@
      inkscape:window-height="1056"
      id="namedview3373"
      showgrid="true"
-     inkscape:zoom="29.5"
-     inkscape:cx="-2.9438199"
-     inkscape:cy="5.8581559"
+     inkscape:zoom="41.7193"
+     inkscape:cx="9.2775326"
+     inkscape:cy="7.4238073"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -52,33 +52,24 @@
        type="xygrid"
        id="grid3411" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4143"
-     width="9"
-     height="1"
-     x="7"
-     y="2"
-     rx="0.5"
-     ry="0.5" />
-  <rect
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4145"
-     width="1"
-     height="12"
-     x="11"
-     y="2"
-     rx="0.5"
-     ry="0.49999997" />
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#353535;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 7.5,2.5 4,5.5 4,-5.5"
-     id="path4147"
+     sodipodi:nodetypes="cccc"
      inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccc" />
+     id="path4139"
+     d="M 15,15 15,1 1,15 Z"
+     style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <g
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="g4169"
+     transform="matrix(-1,0,0,1,-44.963641,-18.34766)" />
+  <g
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="g4169-7"
+     transform="matrix(-1,0,0,1,-64.982985,-20.426498)" />
   <path
-     style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 3,7 0,7 1,0 0,-3 2,0 0,3 1,0 0,-7 -1,0 0,3 -2,0 0,-3 z"
-     id="path4137"
-     inkscape:connector-curvature="0" />
+     id="rect4134"
+     d="m 2,2 1,0 0,1.499954 1,0 L 4,2 5,2 5,6 4,6 4,4.499955 l -1,0 L 3,6 2,6 Z"
+     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.06666672;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccccccccccc" />
 </svg>

--- a/Numix-Light/16/status/nm-tech-umts.svg
+++ b/Numix-Light/16/status/nm-tech-umts.svg
@@ -41,9 +41,9 @@
      inkscape:window-height="1056"
      id="namedview3373"
      showgrid="true"
-     inkscape:zoom="29.5"
-     inkscape:cx="4.6568816"
-     inkscape:cy="3.2401823"
+     inkscape:zoom="14.75"
+     inkscape:cx="32.139656"
+     inkscape:cy="10.32072"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -52,38 +52,38 @@
        type="xygrid"
        id="grid3411" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4143"
-     width="9"
-     height="1"
-     x="7"
-     y="2"
-     rx="0.5"
-     ry="0.5" />
-  <rect
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4145"
-     width="1"
-     height="12"
-     x="11"
-     y="2"
-     rx="0.5"
-     ry="0.49999997" />
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#353535;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 7.5,2.5 4,5.5 4,-5.5"
-     id="path4147"
+     sodipodi:nodetypes="cccc"
      inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccc" />
+     id="path4139"
+     d="M 15,15 15,1 1,15 Z"
+     style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <g
-     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.14466667px;line-height:125%;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="text4231"
-     transform="matrix(0.91493818,0,0,0.91493818,0.25518545,1.1945232)">
-    <path
-       d="m 5.2918848,13.275735 q -0.6579575,0 -1.1075617,-0.175455 Q 3.745685,12.91386 3.4825021,12.573915 3.2193191,12.233969 3.1096595,11.751467 2.9999999,11.268964 2.9999999,10.676802 l 0,-4.3315514 1.3597785,0 0,4.2438254 q 0,0.427672 0.043865,0.723753 0.043865,0.285115 0.1425573,0.46057 0.1096596,0.175457 0.2960809,0.252216 0.1864214,0.07676 0.471536,0.07676 0.2851148,0 0.4715362,-0.07676 0.1864213,-0.07676 0.2960809,-0.252216 0.1096595,-0.186421 0.1535233,-0.471535 0.043865,-0.296081 0.043865,-0.723753 l 0,-4.2328604 1.3488127,0 0,4.3315514 q 0,0.592162 -0.1096597,1.074665 -0.1096604,0.482502 -0.3838091,0.822448 -0.2741498,0.339945 -0.723754,0.526365 -0.4496044,0.175455 -1.1185276,0.175455 z"
-       id="path4236"
-       style="fill:#353535;fill-opacity:1"
-       inkscape:connector-curvature="0" />
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="g4169"
+     transform="matrix(-1,0,0,1,-44.963641,-18.34766)" />
+  <g
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="g4169-7"
+     transform="matrix(-1,0,0,1,-64.982985,-20.426498)" />
+  <g
+     id="g4443"
+     transform="matrix(0.5,0,0,0.5,1,0.5)">
+    <g
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="g4143"
+       transform="translate(-0.9682208,-7.6886254)">
+      <path
+         style="fill:#353535;fill-opacity:1"
+         sodipodi:nodetypes="csccczcccsccsccczcccscc"
+         inkscape:connector-curvature="0"
+         id="path4145"
+         transform="translate(-0.0317792,-0.3680156)"
+         d="m 3,11.056641 0,4.46875 c 0,0.521398 0.068318,1.001578 0.2050781,1.4375 0.1453076,0.427374 0.3636817,0.798976 0.6542969,1.115234 0.2991627,0.307711 0.6739355,0.550971 1.1269531,0.730469 0.4261578,0.160815 0.9361562,0.248047 1.5136719,0.248047 0.5775157,0 1.0875141,-0.08723 1.5136719,-0.248047 C 8.4666895,18.629096 8.8414623,18.385836 9.140625,18.078125 9.4312402,17.761867 9.6496143,17.390265 9.7949219,16.962891 9.931682,16.526969 10,16.046789 10,15.525391 l 0,-4.46875 -2,0 0,4.302734 C 8,15.71837 7.9616931,16.026778 7.8847656,16.283203 7.7992906,16.531081 7.6875414,16.736035 7.5507812,16.898438 7.4054737,17.052293 7.235655,17.162089 7.0390625,17.230469 6.8721752,17.2861 6.6897988,17.324219 6.5,17.324219 c -0.1897988,0 -0.3721752,-0.03812 -0.5390625,-0.09375 C 5.764345,17.162089 5.5945263,17.052293 5.4492188,16.898438 5.3124586,16.736035 5.2007094,16.531081 5.1152344,16.283203 5.0383069,16.026778 5,15.71837 5,15.359375 l 0,-4.302734 z" />
+    </g>
+    <g
+       transform="matrix(-1,0,0,1,-12.253709,-14.565582)"
+       id="g4169-6"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   </g>
 </svg>

--- a/Numix-Light/22/status/gsm-3g-none.svg
+++ b/Numix-Light/22/status/gsm-3g-none.svg
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -42,8 +42,8 @@
      id="namedview3071"
      showgrid="true"
      inkscape:zoom="21.454545"
-     inkscape:cx="-2.4859186"
-     inkscape:cy="5.4670416"
+     inkscape:cx="6.6729799"
+     inkscape:cy="4.8144992"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -53,14 +53,9 @@
        id="grid4137" />
   </sodipodi:namedview>
   <path
-     style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;opacity:0.4"
-     d="m 19,3 -16,16 11.5,0 0,-1 c 0,-0.779849 0.423009,-1.407283 1,-1.869141 l 0,-0.09961 C 15.5,14.114682 17.070012,12.5 19,12.5 Z"
+     style="opacity:0.4;fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 19,3 3,19 19,19 Z"
      id="path4139"
      inkscape:connector-curvature="0"
-     sodipodi:nodetypes="cccscscc" />
-  <path
-     inkscape:connector-curvature="0"
-     style="fill:#353535;fill-opacity:1"
-     d="m 19,14 c -1.108,0 -2,0.910763 -2,2.03125 L 17,17 c -0.554,0 -1,0.446 -1,1 l 0,3 c 0,0.554 0.446,1 1,1 l 4,0 c 0.554,0 1,-0.446 1,-1 l 0,-3 c 0,-0.554 -0.446,-1 -1,-1 l 0,-0.96875 C 21,14.910764 20.108,14 19,14 Z m 0,1 c 0.554,0 1,0.442363 1,1 l 0,1 -2,0 0,-1 c 0,-0.557637 0.446,-1 1,-1 z"
-     id="path3095" />
+     sodipodi:nodetypes="cccc" />
 </svg>

--- a/Numix-Light/22/status/network-cellular-3g.svg
+++ b/Numix-Light/22/status/network-cellular-3g.svg
@@ -1,0 +1,1 @@
+nm-tech-3g.svg

--- a/Numix-Light/22/status/network-cellular-4g.svg
+++ b/Numix-Light/22/status/network-cellular-4g.svg
@@ -1,0 +1,1 @@
+nm-tech-4g.svg

--- a/Numix-Light/22/status/network-cellular-edge.svg
+++ b/Numix-Light/22/status/network-cellular-edge.svg
@@ -1,0 +1,1 @@
+nm-tech-edge.svg

--- a/Numix-Light/22/status/network-cellular-gprs.svg
+++ b/Numix-Light/22/status/network-cellular-gprs.svg
@@ -1,0 +1,1 @@
+nm-tech-gprs.svg

--- a/Numix-Light/22/status/network-cellular-hspa.svg
+++ b/Numix-Light/22/status/network-cellular-hspa.svg
@@ -1,0 +1,1 @@
+nm-tech-hspa.svg

--- a/Numix-Light/22/status/network-cellular-offline.svg
+++ b/Numix-Light/22/status/network-cellular-offline.svg
@@ -1,0 +1,1 @@
+gsm-3g-none.svg

--- a/Numix-Light/22/status/nm-tech-3g.svg
+++ b/Numix-Light/22/status/nm-tech-3g.svg
@@ -41,9 +41,9 @@
      inkscape:window-height="1056"
      id="namedview3071"
      showgrid="true"
-     inkscape:zoom="32"
-     inkscape:cx="14.833185"
-     inkscape:cy="6.3862657"
+     inkscape:zoom="21.454545"
+     inkscape:cx="1.5688104"
+     inkscape:cy="13.194377"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -52,40 +52,33 @@
        type="xygrid"
        id="grid4137" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4361"
-     width="2"
-     height="16"
-     x="15"
-     y="3"
-     rx="1"
-     ry="1" />
   <path
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     d="M 11 3 C 10.446 3 10 3.446 10 4 C 10 4.2444339 10.097572 4.4594594 10.242188 4.6328125 L 10.232422 4.640625 L 15.232422 10.640625 L 16 10 L 16.767578 10.640625 L 21.767578 4.640625 L 21.757812 4.6328125 C 21.902428 4.4594594 22 4.2444339 22 4 C 22 3.446 21.554 3 21 3 L 11 3 z M 13.134766 5 L 18.865234 5 L 16 8.4375 L 13.134766 5 z "
-     id="rect4363" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;"
-     x="-0.63467497"
-     y="18.798761"
-     id="text4155"
-     sodipodi:linespacing="125%"><tspan
-       sodipodi:role="line"
-       id="tspan4157"
-       x="-0.63467497"
-       y="18.798761"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#353535;fill-opacity:1;">3</tspan></text>
+     sodipodi:nodetypes="cccc"
+     inkscape:connector-curvature="0"
+     id="path4139"
+     d="M 20,20 20,3.9999996 4,20 Z"
+     style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <g
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="g4169"
+     transform="matrix(-1,0,0,1,-12.253709,-14.565582)" />
+  <g
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="text4155">
+    <path
+       d="m 2.6625387,10.999982 q -0.3560371,0 -0.7585139,-0.06192 Q 1.5170279,10.891623 1.1455108,10.814223 0.78947367,10.736824 0.47987614,10.643944 0.17027861,10.551065 -2.9087067e-8,10.473666 L 0.37151701,8.8792386 q 0.35603716,0.1547987 0.91331269,0.3250774 0.5727555,0.1702786 1.3622292,0.1702786 0.9752322,0 1.3622291,-0.4179567 0.4024768,-0.4179566 0.4024768,-1.0371517 0,-0.7585139 -0.6037152,-1.0526316 Q 3.2043344,6.5572571 2.2755418,6.5572571 l -0.5882353,0 0,-1.5789474 0.7120743,0 q 0.2941177,0 0.5882353,-0.061919 Q 3.2817338,4.8544707 3.5139319,4.7151518 3.7461301,4.5758329 3.885449,4.3436347 4.0402477,4.1114366 4.0402477,3.7553994 q 0,-0.5263158 -0.3250774,-0.8204334 -0.3095975,-0.3095976 -0.866873,-0.3095976 -0.5417957,0 -1.0835914,0.1857586 Q 1.2383901,2.9814056 0.85139318,3.2445635 L 0.17027861,1.8513746 Q 0.58823528,1.5727368 1.2693498,1.2940991 1.9659443,0.99998141 2.8328174,0.99998141 q 0.8049536,0 1.3931889,0.20123839 0.6037151,0.2012384 0.9907121,0.5727554 0.3869969,0.3560372 0.5727554,0.8513932 0.1857585,0.4953561 0.1857585,1.0681115 0,0.5727555 -0.3250774,1.0990713 -0.3250774,0.5263158 -0.8668731,0.8049535 0.7430341,0.3095976 1.1455109,0.9133128 0.4179566,0.6037151 0.4179566,1.4396285 0,0.6656347 -0.2167182,1.2229102 Q 5.9133128,9.7306318 5.4643964,10.148588 5.01548,10.551065 4.3188855,10.783263 3.6222911,10.999982 2.6625387,10.999982 Z"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#353535;fill-opacity:1"
+       id="path4140" />
+  </g>
   <g
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="text4380"
-     transform="matrix(1.0495652,0,0,1.0495652,-10.038526,-0.83689332)">
+     transform="matrix(1.0495652,0,0,1.0495652,-10.038526,-9.3369112)">
     <path
-       d="m 19.930451,10.831154 c -0.26463,0.01281 -0.457796,0.04053 -0.767707,0.205822 -0.309911,0.165285 -0.568171,0.397718 -0.774778,0.697299 -0.196277,0.289251 -0.340902,0.640483 -0.433875,1.053697 -0.08264,0.402884 -0.123965,0.852255 -0.123965,1.348112 0,1.146671 0.180782,1.993761 0.542345,2.54127 0.361563,0.537179 0.893576,0.805769 1.596041,0.805769 0.113634,0 0.07648,-0.0074 0.07648,-0.0074 l -2.4e-5,-3.339478 1.905951,0 0,4.571055 c -0.227267,0.08264 -0.576666,0.238122 -0.87971,0.305238 -0.411435,0.09112 -0.744278,0.128637 -1.257653,0.128637 -0.599161,0 -1.141505,-0.103304 -1.627032,-0.309911 -0.475197,-0.216937 -0.883246,-0.532013 -1.224148,-0.945228 -0.340902,-0.423544 -0.604326,-0.945227 -0.790273,-1.565049 -0.185946,-0.630153 -0.278919,-1.358444 -0.278919,-2.184873 0,-0.816098 0.108469,-1.534058 0.325406,-2.153879 0.216938,-0.630153 0.511353,-1.157001 0.883246,-1.580546 0.371893,-0.4235451 0.810934,-0.7386212 1.317121,-0.9452285 0.506189,-0.2169377 0.833472,-0.2405335 1.262956,-0.2684123 0.325962,-0.021159 0.654231,0.026801 0.976828,0.078086 0.262299,0.041699 0.557839,0.1136342 0.774777,0.1859466 0.216937,0.072313 0.392553,0.1497902 0.526848,0.2324331 l 0.325407,0.1859468 -0.495858,1.5185643 c -0.227268,-0.144626 -0.506188,-0.273756 -0.83676,-0.38739 -0.345293,-0.133943 -0.677503,-0.187195 -1.022704,-0.170481 z"
+       d="m 19.930451,11.784195 c -0.26463,0.01281 -0.457796,0.04053 -0.767707,0.205822 -0.309911,0.165285 -0.568171,0.397718 -0.774778,0.697299 -0.196277,0.289251 -0.34168,0.685213 -0.433875,1.053697 -0.09699,0.387667 -0.159149,0.795263 -0.119363,1.192895 0.06055,0.605143 0.145386,1.278777 0.537746,1.743446 0.384492,0.455351 0.893576,0.805769 1.596041,0.805769 0.113634,0 0.07648,-0.0074 0.07648,-0.0074 l -2.4e-5,-3.339478 1.905951,0 0,4.571055 c -0.227267,0.08264 -0.576666,0.238122 -0.87971,0.305238 -0.411435,0.09112 -0.744278,0.128637 -1.257653,0.128637 -0.599161,0 -1.141505,-0.103304 -1.627032,-0.309911 -0.475197,-0.216937 -0.883246,-0.532013 -1.224148,-0.945228 -0.340902,-0.423544 -0.604326,-0.945227 -0.790273,-1.565049 -0.185946,-0.630153 -0.219098,-1.059211 -0.216115,-1.596087 0.0034,-0.60292 0.04567,-1.169803 0.262602,-1.789624 0.216938,-0.630153 0.511353,-1.157001 0.883246,-1.580546 0.371893,-0.423546 0.810934,-0.738622 1.317121,-0.945229 0.506189,-0.216938 0.833472,-0.240534 1.262956,-0.268412 0.325962,-0.02116 0.654231,0.0268 0.976828,0.07809 0.262299,0.0417 0.557839,0.113634 0.774777,0.185946 0.216937,0.07231 0.392553,0.149791 0.526848,0.232433 l 0.325407,0.185947 -0.495858,1.518565 C 21.56265,12.19744 21.28373,12.06831 20.953158,11.954676 20.607865,11.820733 20.275655,11.76748 19.930451,11.784195 Z"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#353535;fill-opacity:1"
        id="path4403"
        inkscape:connector-curvature="0"
-       sodipodi:nodetypes="asccscsccccascccscscaascccca" />
+       sodipodi:nodetypes="ascaaasccccascccacscaascccca" />
   </g>
 </svg>

--- a/Numix-Light/22/status/nm-tech-4g.svg
+++ b/Numix-Light/22/status/nm-tech-4g.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 22 22"
+   id="svg3055"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="100%"
+   height="100%"
+   sodipodi:docname="nm-tech-4g.svg">
+  <metadata
+     id="metadata3075">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3073" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1056"
+     id="namedview3071"
+     showgrid="true"
+     inkscape:zoom="10.727273"
+     inkscape:cx="39.155382"
+     inkscape:cy="1.2340534"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3055">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4137" />
+  </sodipodi:namedview>
+  <path
+     sodipodi:nodetypes="cccc"
+     inkscape:connector-curvature="0"
+     id="path4139"
+     d="M 20,20 20,3.9999996 4,20 Z"
+     style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <g
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="g4169"
+     transform="matrix(-1,0,0,1,-12.253709,-14.565582)" />
+  <g
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="text4380"
+     transform="matrix(1.0495652,0,0,1.0495652,-10.038526,-8.8369112)">
+    <path
+       d="m 19.930451,11.784195 c -0.26463,0.01281 -0.457796,0.04053 -0.767707,0.205822 -0.309911,0.165285 -0.568171,0.397718 -0.774778,0.697299 -0.196277,0.289251 -0.34168,0.685213 -0.433875,1.053697 -0.09699,0.387667 -0.159149,0.795263 -0.119363,1.192895 0.06055,0.605143 0.145386,1.278777 0.537746,1.743446 0.384492,0.455351 0.893576,0.805769 1.596041,0.805769 0.113634,0 0.07648,-0.0074 0.07648,-0.0074 l -2.4e-5,-3.339478 1.905951,0 0,4.571055 c -0.227267,0.08264 -0.576666,0.238122 -0.87971,0.305238 -0.411435,0.09112 -0.744278,0.128637 -1.257653,0.128637 -0.599161,0 -1.141505,-0.103304 -1.627032,-0.309911 -0.475197,-0.216937 -0.883246,-0.532013 -1.224148,-0.945228 -0.340902,-0.423544 -0.604326,-0.945227 -0.790273,-1.565049 -0.185946,-0.630153 -0.219098,-1.059211 -0.216115,-1.596087 0.0034,-0.60292 0.04567,-1.169803 0.262602,-1.789624 0.216938,-0.630153 0.511353,-1.157001 0.883246,-1.580546 0.371893,-0.423546 0.810934,-0.738622 1.317121,-0.945229 0.506189,-0.216938 0.833472,-0.240534 1.262956,-0.268412 0.325962,-0.02116 0.654231,0.0268 0.976828,0.07809 0.262299,0.0417 0.557839,0.113634 0.774777,0.185946 0.216937,0.07231 0.392553,0.149791 0.526848,0.232433 l 0.325407,0.185947 -0.495858,1.518565 C 21.56265,12.19744 21.28373,12.06831 20.953158,11.954676 20.607865,11.820733 20.275655,11.76748 19.930451,11.784195 Z"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#353535;fill-opacity:1"
+       id="path4403"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ascaaasccccascccacscaascccca" />
+  </g>
+  <path
+     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 2.6218138,2.0001875 -5e-4,6.9628908 l 0,2.037109 3.00122,0 0,2.0000002 2,0 0,-2.0000002 1,0 0,-1.5999998 -1,0 0,-5.3490313 0,-0.050781 z M 3.00072,4.616 l 0,2.784 -1.41372,0 z"
+     id="rect4146"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccccccccccccccc" />
+</svg>

--- a/Numix-Light/22/status/nm-tech-cdma-1x.svg
+++ b/Numix-Light/22/status/nm-tech-cdma-1x.svg
@@ -41,9 +41,9 @@
      inkscape:window-height="1056"
      id="namedview3071"
      showgrid="true"
-     inkscape:zoom="15.170654"
-     inkscape:cx="7.6156757"
-     inkscape:cy="11.754875"
+     inkscape:zoom="30.341308"
+     inkscape:cx="5.9489147"
+     inkscape:cy="17.964"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -52,25 +52,20 @@
        type="xygrid"
        id="grid4137" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4361"
-     width="2"
-     height="16"
-     x="15"
-     y="3"
-     rx="1"
-     ry="1" />
   <path
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     d="M 11 3 C 10.446 3 10 3.446 10 4 C 10 4.2444339 10.097572 4.4594594 10.242188 4.6328125 L 10.232422 4.640625 L 15.232422 10.640625 L 16 10 L 16.767578 10.640625 L 21.767578 4.640625 L 21.757812 4.6328125 C 21.902428 4.4594594 22 4.2444339 22 4 C 22 3.446 21.554 3 21 3 L 11 3 z M 13.134766 5 L 18.865234 5 L 16 8.4375 L 13.134766 5 z "
-     id="rect4363" />
+     sodipodi:nodetypes="cccc"
+     inkscape:connector-curvature="0"
+     id="path4139"
+     d="M 20,20 20,3.9999996 4,20 Z"
+     style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <g
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="text4136">
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:13.93188858px;line-height:354.99999523%;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="text4137"
+     transform="translate(8.6680508,6.351483)">
     <path
-       d="M 7.1640869,19 Q 5.136223,19 4.0681116,17.69969 3.0000001,16.399381 3.0000001,14 q 0,-1.191951 0.3250774,-2.120743 0.3250774,-0.928793 0.8978328,-1.563468 0.5882353,-0.6501548 1.377709,-0.9752322 0.8049536,-0.3405573 1.7492261,-0.3405573 0.5108359,0 0.9133127,0.092879 0.4179567,0.077399 0.7275542,0.1857585 0.3095975,0.1083591 0.5108359,0.2321982 0.2167183,0.123839 0.3250774,0.1857585 l -0.495356,1.517028 Q 8.9752324,10.981424 8.4643965,10.826625 7.9690404,10.656346 7.3188856,10.656346 q -0.4489164,0 -0.8823529,0.170279 -0.4179567,0.154799 -0.758514,0.541796 -0.3250774,0.371517 -0.5417957,1.006192 -0.2012384,0.634675 -0.2012384,1.578947 0,1.640867 0.5572756,2.52322 0.5727554,0.866873 1.8575852,0.866873 0.743034,0 1.2229102,-0.170279 0.4953561,-0.170278 0.7894737,-0.340557 l 0.4798762,1.501548 Q 9.4396287,18.582043 8.7430343,18.798761 8.0619197,19 7.1640869,19 Z"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#353535;fill-opacity:1"
-       id="path4141" />
+       d="m -2.5279578,4.648517 q -1.8250774,0 -2.7863777,-1.1702786 -0.9613003,-1.1702787 -0.9613003,-3.3297214 0,-1.07275542 0.2925696,-1.9086687 0.2925697,-0.8359134 0.8080496,-1.4071208 0.5294117,-0.5851393 1.2399381,-0.877709 0.7244582,-0.3065015 1.5743034,-0.3065015 0.4597523,0 0.8219814,0.083591 0.376161,0.06966 0.65479875,0.1671827 0.27863778,0.097523 0.45975233,0.2089783 0.19504644,0.1114551 0.29256966,0.1671827 l -0.44582044,1.3653251 q -0.32043343,-0.2089784 -0.7801858,-0.3482973 -0.4458204,-0.1532507 -1.0309597,-0.1532507 -0.4040248,0 -0.7941177,0.1532507 -0.376161,0.1393189 -0.6826625,0.4876161 -0.2925697,0.3343654 -0.4876161,0.9055728 -0.1811146,0.57120743 -0.1811146,1.42105263 0,1.47678017 0.501548,2.27089787 0.5154799,0.7801857 1.6718267,0.7801857 0.6687306,0 1.1006192,-0.1532507 0.4458204,-0.1532508 0.71052628,-0.3065016 l 0.43188855,1.3513932 Q -0.47997018,4.272356 -1.1069052,4.4674025 -1.7199083,4.648517 -2.5279578,4.648517 Z"
+       style="line-height:354.99999523%;fill:#353535;fill-opacity:1"
+       id="path4142"
+       inkscape:connector-curvature="0" />
   </g>
 </svg>

--- a/Numix-Light/22/status/nm-tech-edge.svg
+++ b/Numix-Light/22/status/nm-tech-edge.svg
@@ -41,33 +41,32 @@
      inkscape:window-height="1056"
      id="namedview3071"
      showgrid="true"
-     inkscape:zoom="15.170654"
-     inkscape:cx="6.4336473"
-     inkscape:cy="12.098442"
+     inkscape:zoom="21.454545"
+     inkscape:cx="19.898187"
+     inkscape:cy="13.438756"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg3055">
+     inkscape:current-layer="svg3055"
+     showguides="false">
     <inkscape:grid
        type="xygrid"
        id="grid4137" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4361"
-     width="2"
-     height="16"
-     x="15"
-     y="3"
-     rx="1"
-     ry="1" />
   <path
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     d="M 11 3 C 10.446 3 10 3.446 10 4 C 10 4.2444339 10.097572 4.4594594 10.242188 4.6328125 L 10.232422 4.640625 L 15.232422 10.640625 L 16 10 L 16.767578 10.640625 L 21.767578 4.640625 L 21.757812 4.6328125 C 21.902428 4.4594594 22 4.2444339 22 4 C 22 3.446 21.554 3 21 3 L 11 3 z M 13.134766 5 L 18.865234 5 L 16 8.4375 L 13.134766 5 z "
-     id="rect4363" />
+     sodipodi:nodetypes="cccc"
+     inkscape:connector-curvature="0"
+     id="path4139"
+     d="M 20,20 20,3.9999996 4,20 Z"
+     style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <g
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="g4169"
+     transform="matrix(-1,0,0,1,-12.253709,-14.565582)" />
   <path
-     style="fill:#353535;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
-     d="m 3,9 0,10 7,0 0,-2 -5,0 0,-2 4,0 0,-2 -4,0 0,-2 5,0 0,-2 z"
+     style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 2,2 0,10 6,0 0,-1.999999 -4,0 L 4,8 7,8 7,6 4,6 4,4 8,4 8,2 Z"
      id="path4140"
-     inkscape:connector-curvature="0" />
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccccccccccc" />
 </svg>

--- a/Numix-Light/22/status/nm-tech-evdo.svg
+++ b/Numix-Light/22/status/nm-tech-evdo.svg
@@ -41,9 +41,9 @@
      inkscape:window-height="1056"
      id="namedview3071"
      showgrid="true"
-     inkscape:zoom="7.585327"
-     inkscape:cx="21.783232"
-     inkscape:cy="-0.75017996"
+     inkscape:zoom="42.909089"
+     inkscape:cx="10.844396"
+     inkscape:cy="16.971199"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -52,33 +52,22 @@
        type="xygrid"
        id="grid4137" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4361"
-     width="2"
-     height="16"
-     x="15"
-     y="3"
-     rx="1"
-     ry="1" />
   <path
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     d="M 11 3 C 10.446 3 10 3.446 10 4 C 10 4.2444339 10.097572 4.4594594 10.242188 4.6328125 L 10.232422 4.640625 L 15.232422 10.640625 L 16 10 L 16.767578 10.640625 L 21.767578 4.640625 L 21.757812 4.6328125 C 21.902428 4.4594594 22 4.2444339 22 4 C 22 3.446 21.554 3 21 3 L 11 3 z M 13.134766 5 L 18.865234 5 L 16 8.4375 L 13.134766 5 z "
-     id="rect4363" />
+     sodipodi:nodetypes="cccc"
+     inkscape:connector-curvature="0"
+     id="path4139"
+     d="M 20,20 20,3.9999996 4,20 Z"
+     style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <path
      style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 0,9 0,10 6,0 0,-2 -4,0 0,-2 3,0 0,-2 -3,0 0,-2 4,0 0,-2 z"
+     d="M 1,0.9999997 1,11 l 6,0 0,-2.0000003 -4,0 0,-2 3,0 0,-2 -3,0 0,-2 4,0 0,-2 z"
      id="path4140"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="ccccccccccccc" />
-  <g
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16.15508842px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="text4193">
-    <path
-       d="M 8.7945171,19 C 8.5587244,18.256866 8.3082892,17.416801 8.0430226,16.479806 7.7777558,15.542811 7.5272261,14.611201 7.2914334,13.684976 7.0556407,12.747981 6.8444098,11.864836 6.6577406,11.035541 6.4710715,10.206247 6.3335257,9.5277332 6.2451034,9.0000003 l 1.9158154,0 c 0.058949,0.5169628 0.1473708,1.1200857 0.2652668,1.8093697 0.1178962,0.678514 0.2456173,1.383953 0.3831631,2.116317 0.1473704,0.721594 0.2996531,1.437803 0.4568483,2.148627 0.1670198,0.700053 0.3290327,1.330102 0.4862279,1.890145 0.1571953,-0.549273 0.3143911,-1.173937 0.4715851,-1.87399 0.157196,-0.710824 0.304565,-1.427033 0.442111,-2.148627 0.137546,-0.732364 0.265268,-1.443188 0.383164,-2.132472 0.117897,-0.689284 0.216143,-1.2924069 0.29474,-1.8093697 l 1.901078,0 c -0.117896,0.6462035 -0.265267,1.3677977 -0.442111,2.1647817 -0.167019,0.796985 -0.363513,1.637049 -0.589481,2.520194 -0.216143,0.872375 -0.456849,1.76629 -0.722116,2.681745 C 11.226129,17.271406 10.951038,18.149165 10.666121,19 Z"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#353535;fill-opacity:1"
-       id="path4198"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cscsccccccccsccccccc" />
-  </g>
+  <path
+     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 7.4,1 2.6875,10.033203 1.863281,0 L 14.638281,1 12.567969,1 11.019141,8.183 9.470312,1 Z"
+     id="rect4137"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccc" />
 </svg>

--- a/Numix-Light/22/status/nm-tech-gprs.svg
+++ b/Numix-Light/22/status/nm-tech-gprs.svg
@@ -41,9 +41,9 @@
      inkscape:window-height="1056"
      id="namedview3071"
      showgrid="true"
-     inkscape:zoom="11.313709"
-     inkscape:cx="35.372663"
-     inkscape:cy="0.98918645"
+     inkscape:zoom="21.454545"
+     inkscape:cx="11.209139"
+     inkscape:cy="17.574861"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -52,28 +52,29 @@
        type="xygrid"
        id="grid4137" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4361"
-     width="2"
-     height="16"
-     x="15"
-     y="3"
-     rx="1"
-     ry="1" />
   <path
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     d="M 11 3 C 10.446 3 10 3.446 10 4 C 10 4.2444339 10.097572 4.4594594 10.242188 4.6328125 L 10.232422 4.640625 L 15.232422 10.640625 L 16 10 L 16.767578 10.640625 L 21.767578 4.640625 L 21.757812 4.6328125 C 21.902428 4.4594594 22 4.2444339 22 4 C 22 3.446 21.554 3 21 3 L 11 3 z M 13.134766 5 L 18.865234 5 L 16 8.4375 L 13.134766 5 z "
-     id="rect4363" />
+     sodipodi:nodetypes="cccc"
+     inkscape:connector-curvature="0"
+     id="path4139"
+     d="M 20,20 20,3.9999996 4,20 Z"
+     style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <g
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="g4169"
+     transform="matrix(-1,0,0,1,-12.253709,-14.565582)" />
+  <g
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="g4169-7"
+     transform="matrix(-1,0,0,1,-32.273053,-16.64442)" />
   <g
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="text4380"
-     transform="matrix(1.0495652,0,0,1.0495652,-13.038527,-0.83689332)">
+     transform="matrix(1.0495652,0,0,1.0495652,-14.138978,-8.8120389)">
     <path
-       d="m 19.642085,10.789047 c -0.454537,0 -0.83676,0.08264 -1.146671,0.247929 -0.309911,0.165285 -0.568171,0.397718 -0.774778,0.697299 -0.196277,0.289251 -0.340902,0.640483 -0.433875,1.053697 -0.08264,0.402884 -0.123965,0.852255 -0.123965,1.348112 0,1.146671 0.180782,1.993761 0.542345,2.54127 0.361563,0.537179 0.893576,0.805769 1.596041,0.805769 0.113634,0 0.237598,-0.0052 0.371893,-0.01549 0.134295,-0.01033 0.25826,-0.02582 0.371893,-0.04648 l 0,-3.284925 1.905951,0 0,4.571055 c -0.227267,0.08264 -0.583665,0.175616 -1.069192,0.278921 -0.475197,0.103303 -1.053697,0.154954 -1.735501,0.154954 -0.599161,0 -1.141505,-0.103304 -1.627032,-0.309911 -0.475197,-0.216937 -0.883246,-0.532013 -1.224148,-0.945228 -0.340902,-0.423544 -0.604326,-0.945227 -0.790273,-1.565049 -0.185946,-0.630153 -0.278919,-1.358444 -0.278919,-2.184873 0,-0.816098 0.108469,-1.534058 0.325406,-2.153879 0.216938,-0.630153 0.511353,-1.157001 0.883246,-1.580546 C 16.806399,9.9781269 17.24544,9.6630508 17.751627,9.4564435 18.257816,9.2395058 18.80016,9.131037 19.37866,9.131037 c 0.371893,0 0.702464,0.030991 0.991715,0.092973 0.29958,0.051652 0.557839,0.1136342 0.774777,0.1859466 0.216937,0.072313 0.392553,0.1497902 0.526848,0.2324331 l 0.325407,0.1859468 -0.495858,1.5185645 c -0.227268,-0.144626 -0.506188,-0.273756 -0.83676,-0.38739 -0.330571,-0.113634 -0.671473,-0.170451 -1.022704,-0.170451 z"
+       d="m 20.026025,11.760497 c -0.26463,0.01281 -0.457796,0.04053 -0.767707,0.205822 -0.309911,0.165285 -0.568171,0.397718 -0.774778,0.697299 -0.196277,0.289251 -0.34168,0.685213 -0.433875,1.053697 -0.09699,0.387667 -0.159149,0.795263 -0.119363,1.192895 0.06055,0.605143 0.145386,1.278777 0.537746,1.743446 0.384492,0.455351 0.893576,0.805769 1.596041,0.805769 0.113634,0 0.07648,-0.0074 0.07648,-0.0074 l -2.4e-5,-3.339478 1.905951,0 0,4.571055 c -0.227267,0.08264 -0.576666,0.238122 -0.87971,0.305238 -0.411435,0.09112 -0.744278,0.128637 -1.257653,0.128637 -0.599161,0 -1.141505,-0.103304 -1.627032,-0.309911 -0.475197,-0.216937 -0.883246,-0.532013 -1.224148,-0.945228 -0.340902,-0.423544 -0.604326,-0.945227 -0.790273,-1.565049 -0.185946,-0.630153 -0.219098,-1.059211 -0.216115,-1.596087 0.0034,-0.60292 0.04567,-1.169803 0.262602,-1.789624 0.216938,-0.630153 0.511353,-1.157001 0.883246,-1.580546 0.371893,-0.423546 0.810934,-0.738622 1.317121,-0.945229 0.506189,-0.216938 0.833472,-0.240534 1.262956,-0.268412 0.325962,-0.02116 0.654231,0.0268 0.976828,0.07809 0.262299,0.0417 0.557839,0.113634 0.774777,0.185946 0.216937,0.07231 0.392553,0.149791 0.526848,0.232433 l 0.325407,0.185947 -0.495858,1.518565 c -0.227268,-0.14463 -0.506188,-0.27376 -0.83676,-0.387394 -0.345293,-0.133943 -0.677503,-0.187196 -1.022707,-0.170481 z"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#353535;fill-opacity:1"
        id="path4403"
        inkscape:connector-curvature="0"
-       sodipodi:nodetypes="csccscsscccccscccscscscscccscc" />
+       sodipodi:nodetypes="ascaaasccccascccacscaascccca" />
   </g>
 </svg>

--- a/Numix-Light/22/status/nm-tech-hspa.svg
+++ b/Numix-Light/22/status/nm-tech-hspa.svg
@@ -42,7 +42,7 @@
      id="namedview3071"
      showgrid="true"
      inkscape:zoom="15.170654"
-     inkscape:cx="22.326251"
+     inkscape:cx="4.2980236"
      inkscape:cy="8.037358"
      inkscape:window-x="0"
      inkscape:window-y="24"
@@ -54,21 +54,14 @@
   </sodipodi:namedview>
   <path
      id="rect4134"
-     d="m 3,8.9999998 2,0 0,3.9999992 3,0 0,-3.9999992 2,0 L 10,19 8,19 8,15 5,15 5,19 3,19 Z"
+     d="m 2,3 2,0 0,2.9999082 3,0 L 7,3 l 2,0 0,8 -2,0 0,-3.0000908 -3,0 L 4,11 2,11 Z"
      style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.06666672;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="ccccccccccccc" />
-  <rect
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4361"
-     width="2"
-     height="16"
-     x="15"
-     y="3"
-     rx="1"
-     ry="1" />
   <path
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     d="M 11 3 C 10.446 3 10 3.446 10 4 C 10 4.2444339 10.097572 4.4594594 10.242188 4.6328125 L 10.232422 4.640625 L 15.232422 10.640625 L 16 10 L 16.767578 10.640625 L 21.767578 4.640625 L 21.757812 4.6328125 C 21.902428 4.4594594 22 4.2444339 22 4 C 22 3.446 21.554 3 21 3 L 11 3 z M 13.134766 5 L 18.865234 5 L 16 8.4375 L 13.134766 5 z "
-     id="rect4363" />
+     sodipodi:nodetypes="cccc"
+     inkscape:connector-curvature="0"
+     id="path4139"
+     d="M 20,20 20,3.9999996 4,20 Z"
+     style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
 </svg>

--- a/Numix-Light/22/status/nm-tech-umts.svg
+++ b/Numix-Light/22/status/nm-tech-umts.svg
@@ -41,9 +41,9 @@
      inkscape:window-height="1056"
      id="namedview3071"
      showgrid="true"
-     inkscape:zoom="16"
-     inkscape:cx="3.7468548"
-     inkscape:cy="7.8949834"
+     inkscape:zoom="15.170654"
+     inkscape:cx="13.309115"
+     inkscape:cy="11.371166"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -52,25 +52,18 @@
        type="xygrid"
        id="grid4137" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4361"
-     width="2"
-     height="16"
-     x="15"
-     y="3"
-     rx="1"
-     ry="1" />
   <path
-     style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     d="M 11 3 C 10.446 3 10 3.446 10 4 C 10 4.2444339 10.097572 4.4594594 10.242188 4.6328125 L 10.232422 4.640625 L 15.232422 10.640625 L 16 10 L 16.767578 10.640625 L 21.767578 4.640625 L 21.757812 4.6328125 C 21.902428 4.4594594 22 4.2444339 22 4 C 22 3.446 21.554 3 21 3 L 11 3 z M 13.134766 5 L 18.865234 5 L 16 8.4375 L 13.134766 5 z "
-     id="rect4363" />
+     sodipodi:nodetypes="cccc"
+     inkscape:connector-curvature="0"
+     id="path4139"
+     d="M 20,20 20,3.9999996 4,20 Z"
+     style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <g
-     transform="translate(0.0317792,0.3680156)"
+     transform="translate(-0.9682208,-7.6886254)"
      id="g4143"
      style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
     <path
-       d="m 3,10 0,5.525391 c 0,0.521398 0.068318,1.001578 0.2050781,1.4375 0.1453076,0.427374 0.3636817,0.798976 0.6542969,1.115234 0.2991627,0.307711 0.6739355,0.550971 1.1269531,0.730469 0.4261578,0.160815 0.9361562,0.248047 1.5136719,0.248047 0.5775157,0 1.0875141,-0.08723 1.5136719,-0.248047 C 8.4666895,18.629096 8.8414623,18.385836 9.140625,18.078125 9.4312402,17.761867 9.6496143,17.390265 9.7949219,16.962891 9.931682,16.526969 10,16.046789 10,15.525391 L 10,10 8,10 8,15.359375 C 8,15.71837 7.9616931,16.026778 7.8847656,16.283203 7.7992906,16.531081 7.6875414,16.736035 7.5507812,16.898438 7.4054737,17.052293 7.235655,17.162089 7.0390625,17.230469 6.8721752,17.2861 6.6897988,17.324219 6.5,17.324219 c -0.1897988,0 -0.3721752,-0.03812 -0.5390625,-0.09375 C 5.764345,17.162089 5.5945263,17.052293 5.4492188,16.898438 5.3124586,16.736035 5.2007094,16.531081 5.1152344,16.283203 5.0383069,16.026778 5,15.71837 5,15.359375 L 5,10 Z"
+       d="m 3,11.056641 0,4.46875 c 0,0.521398 0.068318,1.001578 0.2050781,1.4375 0.1453076,0.427374 0.3636817,0.798976 0.6542969,1.115234 0.2991627,0.307711 0.6739355,0.550971 1.1269531,0.730469 0.4261578,0.160815 0.9361562,0.248047 1.5136719,0.248047 0.5775157,0 1.0875141,-0.08723 1.5136719,-0.248047 C 8.4666895,18.629096 8.8414623,18.385836 9.140625,18.078125 9.4312402,17.761867 9.6496143,17.390265 9.7949219,16.962891 9.931682,16.526969 10,16.046789 10,15.525391 l 0,-4.46875 -2,0 0,4.302734 C 8,15.71837 7.9616931,16.026778 7.8847656,16.283203 7.7992906,16.531081 7.6875414,16.736035 7.5507812,16.898438 7.4054737,17.052293 7.235655,17.162089 7.0390625,17.230469 6.8721752,17.2861 6.6897988,17.324219 6.5,17.324219 c -0.1897988,0 -0.3721752,-0.03812 -0.5390625,-0.09375 C 5.764345,17.162089 5.5945263,17.052293 5.4492188,16.898438 5.3124586,16.736035 5.2007094,16.531081 5.1152344,16.283203 5.0383069,16.026778 5,15.71837 5,15.359375 l 0,-4.302734 z"
        transform="translate(-0.0317792,-0.3680156)"
        id="path4145"
        inkscape:connector-curvature="0"
@@ -80,5 +73,5 @@
   <g
      style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="g4169"
-     transform="matrix(-1,0,0,1,12.968221,0.3680156)" />
+     transform="matrix(-1,0,0,1,-12.253709,-14.565582)" />
 </svg>

--- a/Numix-Light/24/status/network-cellular-3g.svg
+++ b/Numix-Light/24/status/network-cellular-3g.svg
@@ -1,0 +1,1 @@
+nm-tech-3g.svg

--- a/Numix-Light/24/status/network-cellular-4g.svg
+++ b/Numix-Light/24/status/network-cellular-4g.svg
@@ -1,0 +1,1 @@
+nm-tech-4g.svg

--- a/Numix-Light/24/status/network-cellular-edge.svg
+++ b/Numix-Light/24/status/network-cellular-edge.svg
@@ -1,0 +1,1 @@
+nm-tech-edge.svg

--- a/Numix-Light/24/status/network-cellular-gprs.svg
+++ b/Numix-Light/24/status/network-cellular-gprs.svg
@@ -1,0 +1,1 @@
+nm-tech-gprs.svg

--- a/Numix-Light/24/status/network-cellular-hspa.svg
+++ b/Numix-Light/24/status/network-cellular-hspa.svg
@@ -1,0 +1,1 @@
+nm-tech-hspa.svg

--- a/Numix-Light/24/status/network-cellular-offline.svg
+++ b/Numix-Light/24/status/network-cellular-offline.svg
@@ -1,0 +1,1 @@
+gsm-3g-none.svg

--- a/Numix-Light/24/status/nm-tech-3g.svg
+++ b/Numix-Light/24/status/nm-tech-3g.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -15,7 +13,7 @@
    inkscape:version="0.91 r"
    sodipodi:docname="nm-tech-3g.svg">
   <metadata
-     id="metadata12">
+     id="metadata16">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -27,7 +25,7 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs10" />
+     id="defs14" />
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -39,58 +37,29 @@
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
      inkscape:window-height="1056"
-     id="namedview8"
-     showgrid="true"
-     inkscape:zoom="27.812867"
-     inkscape:cx="4.8671549"
-     inkscape:cy="12.808735"
+     id="namedview12"
+     showgrid="false"
+     inkscape:zoom="39.333333"
+     inkscape:cx="16.4479"
+     inkscape:cy="18.101244"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg2">
-    <inkscape:grid
-       type="xygrid"
-       id="grid4363" />
-  </sodipodi:namedview>
+     inkscape:current-layer="svg2" />
   <g
-     id="g4146"
-     transform="translate(0,1.79e-5)">
-    <rect
-       ry="1"
-       rx="1"
-       y="3.9999821"
-       x="16"
-       height="16"
-       width="2"
-       id="rect4361"
-       style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     fill="#353535"
+     id="g4">
     <path
+       d="m21 21v-16l-16 16"
+       fill-rule="evenodd"
+       id="path6" />
+    <path
+       d="m3.662 12q-.356 0-.759-.062-.387-.046-.759-.124-.356-.077-.666-.17-.31-.093-.48-.17l.372-1.594q.356.155.913.325.573.17 1.362.17.975 0 1.362-.418.402-.418.402-1.037 0-.759-.604-1.053-.604-.31-1.533-.31h-.588v-1.579h.712q.294 0 .588-.062.294-.062.526-.201.232-.139.372-.372.155-.232.155-.588 0-.526-.325-.82-.31-.31-.867-.31-.542 0-1.084.186-.526.17-.913.433l-.681-1.393q.418-.279 1.099-.557.697-.294 1.563-.294.805 0 1.393.201.604.201.991.573.387.356.573.851.186.495.186 1.068 0 .573-.325 1.099-.325.526-.867.805.743.31 1.146.913.418.604.418 1.44 0 .666-.217 1.223-.217.557-.666.975-.449.402-1.146.635-.697.217-1.656.217"
+       id="path8" />
+    <path
+       d="M 11.88,4.03 C 11.602,4.044 11.399,4.073 11.074,4.246 10.749,4.419 10.478,4.664 10.261,4.978 10.055,5.281 9.902,5.697 9.805,6.084 9.703,6.491 9.638,6.918 9.68,7.336 c 0.064,0.635 0.152,1.342 0.565,1.829 0.403,0.478 0.938,0.846 1.675,0.846 0.12,0 0.08,-0.007 0.08,-0.007 l 0,-3.504 2,0 0,4.797 c -0.238,0.087 -0.606,0.25 -0.924,0.32 -0.431,0.096 -0.781,0.135 -1.32,0.135 -0.629,0 -1.199,-0.108 -1.708,-0.325 C 9.549,11.199 9.121,10.869 8.763,10.435 8.405,9.99 8.129,9.443 7.934,8.792 7.739,8.131 7.704,7.681 7.707,7.117 7.71,6.484 7.755,5.889 7.983,5.238 8.211,4.577 8.519,4.024 8.91,3.579 9.3,3.134 9.761,2.803 10.292,2.587 c 0.531,-0.228 0.874,-0.253 1.326,-0.281 0.342,-0.022 0.686,0.028 1.025,0.082 0.275,0.044 0.586,0.12 0.813,0.195 0.228,0.076 0.412,0.157 0.553,0.244 L 14.35,3.022 13.829,4.616 C 13.591,4.464 13.298,4.328 12.951,4.21 12.589,4.069 12.239,4.014 11.877,4.032"
+       id="path10"
        inkscape:connector-curvature="0"
-       id="rect4363"
-       d="m 12,3.9999821 c -0.554,0 -1,0.446 -1,1 0,0.2444339 0.09757,0.4594594 0.242188,0.6328125 l -0.0098,0.00781 5,5.9999994 L 17,10.999982 l 0.767578,0.640625 5,-5.9999999 -0.0098,-0.00781 C 22.902428,5.4594415 23,5.244416 23,4.9999821 c 0,-0.554 -0.446,-1 -1,-1 l -10,0 z m 2.134766,2 5.730468,0 -2.865234,3.4375 -2.865234,-3.4375 z"
-       style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-    <text
-       sodipodi:linespacing="125%"
-       id="text4155"
-       y="19.798744"
-       x="0.36532506"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       xml:space="preserve"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#353535;fill-opacity:1"
-         y="19.798744"
-         x="0.36532506"
-         id="tspan4157"
-         sodipodi:role="line">3</tspan></text>
-    <g
-       transform="matrix(1.0495652,0,0,1.0495652,-9.038526,0.16308883)"
-       id="text4380"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
-      <path
-         sodipodi:nodetypes="asccscsccccascccscscaascccca"
-         inkscape:connector-curvature="0"
-         id="path4403"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#353535;fill-opacity:1"
-         d="m 19.930451,10.831154 c -0.26463,0.01281 -0.457796,0.04053 -0.767707,0.205822 -0.309911,0.165285 -0.568171,0.397718 -0.774778,0.697299 -0.196277,0.289251 -0.340902,0.640483 -0.433875,1.053697 -0.08264,0.402884 -0.123965,0.852255 -0.123965,1.348112 0,1.146671 0.180782,1.993761 0.542345,2.54127 0.361563,0.537179 0.893576,0.805769 1.596041,0.805769 0.113634,0 0.07648,-0.0074 0.07648,-0.0074 l -2.4e-5,-3.339478 1.905951,0 0,4.571055 c -0.227267,0.08264 -0.576666,0.238122 -0.87971,0.305238 -0.411435,0.09112 -0.744278,0.128637 -1.257653,0.128637 -0.599161,0 -1.141505,-0.103304 -1.627032,-0.309911 -0.475197,-0.216937 -0.883246,-0.532013 -1.224148,-0.945228 -0.340902,-0.423544 -0.604326,-0.945227 -0.790273,-1.565049 -0.185946,-0.630153 -0.278919,-1.358444 -0.278919,-2.184873 0,-0.816098 0.108469,-1.534058 0.325406,-2.153879 0.216938,-0.630153 0.511353,-1.157001 0.883246,-1.580546 0.371893,-0.4235451 0.810934,-0.7386212 1.317121,-0.9452285 0.506189,-0.2169377 0.833472,-0.2405335 1.262956,-0.2684123 0.325962,-0.021159 0.654231,0.026801 0.976828,0.078086 0.262299,0.041699 0.557839,0.1136342 0.774777,0.1859466 0.216937,0.072313 0.392553,0.1497902 0.526848,0.2324331 l 0.325407,0.1859468 -0.495858,1.5185643 c -0.227268,-0.144626 -0.506188,-0.273756 -0.83676,-0.38739 -0.345293,-0.133943 -0.677503,-0.187195 -1.022704,-0.170481 z" />
-    </g>
+       sodipodi:nodetypes="csccccscccccsccccccccccccccc" />
   </g>
 </svg>

--- a/Numix-Light/24/status/nm-tech-4g.svg
+++ b/Numix-Light/24/status/nm-tech-4g.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 24 24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="nm-tech-4g.svg">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1056"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="19.666667"
+     inkscape:cx="1.1540596"
+     inkscape:cy="17.641988"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4149" />
+  </sodipodi:namedview>
+  <g
+     id="g4147"
+     transform="matrix(0.999975,0,0,1,2.4999375e-5,0)">
+    <path
+       style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 21.0005,21 0,-16.0000004 L 5.0005,21 Z"
+       id="path4139-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <g
+       transform="matrix(-1,0,0,1,-12.253709,-12.565582)"
+       id="g4169"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="matrix(1.0495652,0,0,1.0495652,-9.038026,-7.8369112)"
+       id="text4380"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
+      <path
+         sodipodi:nodetypes="ascaaasccccascccacscaascccca"
+         inkscape:connector-curvature="0"
+         id="path4403"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#353535;fill-opacity:1"
+         d="m 19.930451,11.784195 c -0.26463,0.01281 -0.457796,0.04053 -0.767707,0.205822 -0.309911,0.165285 -0.568171,0.397718 -0.774778,0.697299 -0.196277,0.289251 -0.34168,0.685213 -0.433875,1.053697 -0.09699,0.387667 -0.159149,0.795263 -0.119363,1.192895 0.06055,0.605143 0.145386,1.278777 0.537746,1.743446 0.384492,0.455351 0.893576,0.805769 1.596041,0.805769 0.113634,0 0.07648,-0.0074 0.07648,-0.0074 l -2.4e-5,-3.339478 1.905951,0 0,4.571055 c -0.227267,0.08264 -0.576666,0.238122 -0.87971,0.305238 -0.411435,0.09112 -0.744278,0.128637 -1.257653,0.128637 -0.599161,0 -1.141505,-0.103304 -1.627032,-0.309911 -0.475197,-0.216937 -0.883246,-0.532013 -1.224148,-0.945228 -0.340902,-0.423544 -0.604326,-0.945227 -0.790273,-1.565049 -0.185946,-0.630153 -0.219098,-1.059211 -0.216115,-1.596087 0.0034,-0.60292 0.04567,-1.169803 0.262602,-1.789624 0.216938,-0.630153 0.511353,-1.157001 0.883246,-1.580546 0.371893,-0.423546 0.810934,-0.738622 1.317121,-0.945229 0.506189,-0.216938 0.833472,-0.240534 1.262956,-0.268412 0.325962,-0.02116 0.654231,0.0268 0.976828,0.07809 0.262299,0.0417 0.557839,0.113634 0.774777,0.185946 0.216937,0.07231 0.392553,0.149791 0.526848,0.232433 l 0.325407,0.185947 -0.495858,1.518565 C 21.56265,12.19744 21.28373,12.06831 20.953158,11.954676 20.607865,11.820733 20.275655,11.76748 19.930451,11.784195 Z" />
+    </g>
+    <path
+       sodipodi:nodetypes="ccccccccccccccccc"
+       inkscape:connector-curvature="0"
+       id="rect4146"
+       d="M 3.6223138,3.0001875 1,7.9628908 1,10 l 3.00122,0 0,2 2,0 0,-2 1,0 0,-1.6 -1,0 0,-5.3490313 0,-0.050781 z M 4.00122,5.616 l 0,2.784 -1.41372,0 z"
+       style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+</svg>

--- a/Numix-Light/24/status/nm-tech-cdma-1x.svg
+++ b/Numix-Light/24/status/nm-tech-cdma-1x.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -15,7 +13,7 @@
    inkscape:version="0.91 r"
    sodipodi:docname="nm-tech-cdma-1x.svg">
   <metadata
-     id="metadata12">
+     id="metadata16">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -27,7 +25,7 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs10" />
+     id="defs14" />
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -39,44 +37,36 @@
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
      inkscape:window-height="1056"
-     id="namedview8"
+     id="namedview12"
      showgrid="true"
-     inkscape:zoom="27.812867"
-     inkscape:cx="4.8671549"
-     inkscape:cy="7.0560021"
+     inkscape:zoom="19.666667"
+     inkscape:cx="15.060839"
+     inkscape:cy="17.641988"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
        type="xygrid"
-       id="grid4363" />
+       id="grid4149" />
   </sodipodi:namedview>
   <g
      id="g4144">
-    <rect
-       ry="1"
-       rx="1"
-       y="4"
-       x="16"
-       height="16"
-       width="2"
-       id="rect4361"
-       style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
+       style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 20.999585,21 0,-16.0000004 L 4.999585,21 Z"
+       id="path4139"
        inkscape:connector-curvature="0"
-       id="rect4363"
-       d="m 12,4 c -0.554,0 -1,0.446 -1,1 0,0.2444339 0.09757,0.4594594 0.242188,0.6328125 l -0.0098,0.00781 5,5.9999995 L 17,11 l 0.767578,0.640625 5,-6 -0.0098,-0.00781 C 22.902428,5.4594594 23,5.2444339 23,5 23,4.446 22.554,4 22,4 L 12,4 Z M 14.134766,6 19.865234,6 17,9.4375 14.134766,6 Z"
-       style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+       sodipodi:nodetypes="cccc" />
     <g
-       transform="translate(0.9999999,1)"
-       id="text4136"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
+       transform="translate(9.6676358,7.351483)"
+       id="text4137"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:13.93188858px;line-height:354.99999523%;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
       <path
          inkscape:connector-curvature="0"
-         id="path4141"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#353535;fill-opacity:1"
-         d="M 7.1640869,19 Q 5.136223,19 4.0681116,17.69969 3.0000001,16.399381 3.0000001,14 q 0,-1.191951 0.3250774,-2.120743 0.3250774,-0.928793 0.8978328,-1.563468 0.5882353,-0.6501548 1.377709,-0.9752322 0.8049536,-0.3405573 1.7492261,-0.3405573 0.5108359,0 0.9133127,0.092879 0.4179567,0.077399 0.7275542,0.1857585 0.3095975,0.1083591 0.5108359,0.2321982 0.2167183,0.123839 0.3250774,0.1857585 L 9.3312696,11.213622 Q 8.9752324,10.981424 8.4643965,10.826625 7.9690404,10.656346 7.3188856,10.656346 q -0.4489164,0 -0.8823529,0.170279 -0.4179567,0.154799 -0.758514,0.541796 -0.3250774,0.371517 -0.5417957,1.006192 -0.2012384,0.634675 -0.2012384,1.578947 0,1.640867 0.5572756,2.52322 0.5727554,0.866873 1.8575852,0.866873 0.743034,0 1.2229102,-0.170279 0.4953561,-0.170278 0.7894737,-0.340557 l 0.4798762,1.501548 Q 9.4396287,18.582043 8.7430343,18.798761 8.0619197,19 7.1640869,19 Z" />
+         id="path4142"
+         style="line-height:354.99999523%;fill:#353535;fill-opacity:1"
+         d="m -2.5279578,4.648517 q -1.8250774,0 -2.7863777,-1.1702786 -0.9613003,-1.1702787 -0.9613003,-3.3297214 0,-1.07275542 0.2925696,-1.9086687 0.2925697,-0.8359134 0.8080496,-1.4071208 0.5294117,-0.5851393 1.2399381,-0.877709 0.7244582,-0.3065015 1.5743034,-0.3065015 0.4597523,0 0.8219814,0.083591 0.376161,0.06966 0.65479875,0.1671827 0.27863778,0.097523 0.45975233,0.2089783 0.19504644,0.1114551 0.29256966,0.1671827 l -0.44582044,1.3653251 q -0.32043343,-0.2089784 -0.7801858,-0.3482973 -0.4458204,-0.1532507 -1.0309597,-0.1532507 -0.4040248,0 -0.7941177,0.1532507 -0.376161,0.1393189 -0.6826625,0.4876161 -0.2925697,0.3343654 -0.4876161,0.9055728 -0.1811146,0.57120743 -0.1811146,1.42105263 0,1.47678017 0.501548,2.27089787 0.5154799,0.7801857 1.6718267,0.7801857 0.6687306,0 1.1006192,-0.1532507 0.4458204,-0.1532508 0.71052628,-0.3065016 l 0.43188855,1.3513932 Q -0.47997018,4.272356 -1.1069052,4.4674025 -1.7199083,4.648517 -2.5279578,4.648517 Z" />
     </g>
   </g>
 </svg>

--- a/Numix-Light/24/status/nm-tech-edge.svg
+++ b/Numix-Light/24/status/nm-tech-edge.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -15,7 +13,7 @@
    inkscape:version="0.91 r"
    sodipodi:docname="nm-tech-edge.svg">
   <metadata
-     id="metadata12">
+     id="metadata16">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -27,7 +25,7 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs10" />
+     id="defs14" />
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -39,39 +37,36 @@
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
      inkscape:window-height="1056"
-     id="namedview8"
+     id="namedview12"
      showgrid="true"
-     inkscape:zoom="9.8333334"
-     inkscape:cx="-28.612398"
-     inkscape:cy="7.0601576"
+     inkscape:zoom="19.666667"
+     inkscape:cx="15.060839"
+     inkscape:cy="17.641988"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
        type="xygrid"
-       id="grid4363" />
+       id="grid4149" />
   </sodipodi:namedview>
   <g
-     id="g4146">
-    <rect
-       ry="1"
-       rx="1"
-       y="4"
-       x="16"
-       height="16"
-       width="2"
-       id="rect4361-2"
-       style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     id="g4217">
     <path
+       style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 21,21 21,4.9999996 5,21 Z"
+       id="path4139-8"
        inkscape:connector-curvature="0"
-       id="rect4363-6"
-       d="m 12,4 c -0.554,0 -1,0.446 -1,1 0,0.2444339 0.09757,0.4594594 0.242188,0.6328125 l -0.0098,0.00781 5,5.9999995 L 17,11 l 0.767578,0.640625 5,-6 -0.0098,-0.00781 C 22.902428,5.4594594 23,5.2444339 23,5 23,4.446 22.554,4 22,4 L 12,4 Z M 14.134766,6 19.865234,6 17,9.4375 14.134766,6 Z"
-       style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+       sodipodi:nodetypes="cccc" />
+    <g
+       transform="matrix(-1,0,0,1,-11.253709,-13.565582)"
+       id="g4169"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
+       sodipodi:nodetypes="ccccccccccccc"
        inkscape:connector-curvature="0"
        id="path4140"
-       d="m 4,10 0,10 7,0 0,-2 -5,0 0,-2 4,0 0,-2 -4,0 0,-2 5,0 0,-2 z"
+       d="m 3,3 0,10 6,0 0,-1.999999 -4,0 L 5,9 8,9 8,7 5,7 5,5 9,5 9,3 Z"
        style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   </g>
 </svg>

--- a/Numix-Light/24/status/nm-tech-evdo.svg
+++ b/Numix-Light/24/status/nm-tech-evdo.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -15,7 +13,7 @@
    inkscape:version="0.91 r"
    sodipodi:docname="nm-tech-evdo.svg">
   <metadata
-     id="metadata12">
+     id="metadata16">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -27,7 +25,7 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs10" />
+     id="defs14" />
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -39,51 +37,38 @@
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
      inkscape:window-height="1056"
-     id="namedview8"
+     id="namedview12"
      showgrid="true"
-     inkscape:zoom="13.906433"
-     inkscape:cx="-0.76147829"
-     inkscape:cy="6.1957962"
+     inkscape:zoom="19.666667"
+     inkscape:cx="1.1540596"
+     inkscape:cy="17.641988"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
        type="xygrid"
-       id="grid4363" />
+       id="grid4149" />
   </sodipodi:namedview>
   <g
-     id="g4147"
-     transform="translate(1,1)">
-    <rect
-       ry="1"
-       rx="1"
-       y="3"
-       x="15"
-       height="16"
-       width="2"
-       id="rect4361"
-       style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     id="g4145">
     <path
-       id="rect4363"
-       d="m 11,3 c -0.554,0 -1,0.446 -1,1 0,0.2444339 0.09757,0.4594594 0.242188,0.6328125 l -0.0098,0.00781 5,5.9999995 L 16,10 l 0.767578,0.640625 5,-6 -0.0098,-0.00781 C 21.902428,4.4594594 22,4.2444339 22,4 22,3.446 21.554,3 21,3 L 11,3 Z M 13.134766,5 18.865234,5 16,8.4375 13.134766,5 Z"
-       style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       inkscape:connector-curvature="0" />
+       style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 21,21 21,4.9999996 5,21 Z"
+       id="path4139"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
     <path
        sodipodi:nodetypes="ccccccccccccc"
        inkscape:connector-curvature="0"
-       id="path4140-2"
-       d="m 0,9 0,10 6,0 0,-2 -4,0 0,-2 3,0 0,-2 -3,0 0,-2 4,0 0,-2 z"
+       id="path4140-4"
+       d="M 2,1.9999997 2,12 l 6,0 0,-2 -4,0 0,-2.0000003 3,0 0,-2 -3,0 0,-2 4,0 0,-2 z"
        style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-    <g
-       id="text4193"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16.15508842px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
-      <path
-         sodipodi:nodetypes="cscsccccccccsccccccc"
-         inkscape:connector-curvature="0"
-         id="path4198"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#353535;fill-opacity:1"
-         d="M 8.7945171,19 C 8.5587244,18.256866 8.3082892,17.416801 8.0430226,16.479806 7.7777558,15.542811 7.5272261,14.611201 7.2914334,13.684976 7.0556407,12.747981 6.8444098,11.864836 6.6577406,11.035541 6.4710715,10.206247 6.3335257,9.5277332 6.2451034,9.0000003 l 1.9158154,0 c 0.058949,0.5169628 0.1473708,1.1200857 0.2652668,1.8093697 0.1178962,0.678514 0.2456173,1.383953 0.3831631,2.116317 0.1473704,0.721594 0.2996531,1.437803 0.4568483,2.148627 0.1670198,0.700053 0.3290327,1.330102 0.4862279,1.890145 0.1571953,-0.549273 0.3143911,-1.173937 0.4715851,-1.87399 0.157196,-0.710824 0.304565,-1.427033 0.442111,-2.148627 0.137546,-0.732364 0.265268,-1.443188 0.383164,-2.132472 0.117897,-0.689284 0.216143,-1.2924069 0.29474,-1.8093697 l 1.901078,0 c -0.117896,0.6462035 -0.265267,1.3677977 -0.442111,2.1647817 -0.167019,0.796985 -0.363513,1.637049 -0.589481,2.520194 -0.216143,0.872375 -0.456849,1.76629 -0.722116,2.681745 C 11.226129,17.271406 10.951038,18.149165 10.666121,19 Z" />
-    </g>
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       id="rect4137"
+       d="m 8.4,2 2.6875,10.033203 1.863281,0 L 15.638281,2 13.567969,2 12.019141,9.183 10.470312,2 Z"
+       style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   </g>
 </svg>

--- a/Numix-Light/24/status/nm-tech-gprs.svg
+++ b/Numix-Light/24/status/nm-tech-gprs.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -15,7 +13,7 @@
    inkscape:version="0.91 r"
    sodipodi:docname="nm-tech-gprs.svg">
   <metadata
-     id="metadata12">
+     id="metadata16">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -27,7 +25,7 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs10" />
+     id="defs14" />
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -39,46 +37,45 @@
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
      inkscape:window-height="1056"
-     id="namedview8"
+     id="namedview12"
      showgrid="true"
-     inkscape:zoom="13.906433"
-     inkscape:cx="-8.9231686"
-     inkscape:cy="9.0721628"
+     inkscape:zoom="19.666667"
+     inkscape:cx="-4.6171267"
+     inkscape:cy="17.641988"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
        type="xygrid"
-       id="grid4363" />
+       id="grid4149" />
   </sodipodi:namedview>
   <g
-     id="g4148"
-     transform="translate(1.0000005,1)">
-    <rect
-       ry="1"
-       rx="1"
-       y="3"
-       x="15"
-       height="16"
-       width="2"
-       id="rect4361-5"
-       style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     id="g4147">
     <path
-       id="rect4363-1"
-       d="m 11,3 c -0.554,0 -1,0.446 -1,1 0,0.2444339 0.09757,0.4594594 0.242188,0.6328125 l -0.0098,0.00781 5,5.9999995 L 16,10 l 0.767578,0.640625 5,-6 -0.0098,-0.00781 C 21.902428,4.4594594 22,4.2444339 22,4 22,3.446 21.554,3 21,3 L 11,3 Z M 13.134766,5 18.865234,5 16,8.4375 13.134766,5 Z"
-       style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       inkscape:connector-curvature="0" />
+       style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 21,21 21,4.9999996 5,21 Z"
+       id="path4139-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
     <g
-       transform="matrix(1.0495652,0,0,1.0495652,-13.038527,-0.83689332)"
+       transform="matrix(-1,0,0,1,-11.253709,-13.565582)"
+       id="g4169"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="matrix(-1,0,0,1,-31.273053,-15.64442)"
+       id="g4169-7"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="matrix(1.0495652,0,0,1.0495652,-13.138978,-7.8120389)"
        id="text4380"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
       <path
-         sodipodi:nodetypes="csccscsscccccscccscscscscccscc"
+         sodipodi:nodetypes="ascaaasccccascccacscaascccca"
          inkscape:connector-curvature="0"
          id="path4403"
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#353535;fill-opacity:1"
-         d="m 19.642085,10.789047 c -0.454537,0 -0.83676,0.08264 -1.146671,0.247929 -0.309911,0.165285 -0.568171,0.397718 -0.774778,0.697299 -0.196277,0.289251 -0.340902,0.640483 -0.433875,1.053697 -0.08264,0.402884 -0.123965,0.852255 -0.123965,1.348112 0,1.146671 0.180782,1.993761 0.542345,2.54127 0.361563,0.537179 0.893576,0.805769 1.596041,0.805769 0.113634,0 0.237598,-0.0052 0.371893,-0.01549 0.134295,-0.01033 0.25826,-0.02582 0.371893,-0.04648 l 0,-3.284925 1.905951,0 0,4.571055 c -0.227267,0.08264 -0.583665,0.175616 -1.069192,0.278921 -0.475197,0.103303 -1.053697,0.154954 -1.735501,0.154954 -0.599161,0 -1.141505,-0.103304 -1.627032,-0.309911 -0.475197,-0.216937 -0.883246,-0.532013 -1.224148,-0.945228 -0.340902,-0.423544 -0.604326,-0.945227 -0.790273,-1.565049 -0.185946,-0.630153 -0.278919,-1.358444 -0.278919,-2.184873 0,-0.816098 0.108469,-1.534058 0.325406,-2.153879 0.216938,-0.630153 0.511353,-1.157001 0.883246,-1.580546 C 16.806399,9.9781269 17.24544,9.6630508 17.751627,9.4564435 18.257816,9.2395058 18.80016,9.131037 19.37866,9.131037 c 0.371893,0 0.702464,0.030991 0.991715,0.092973 0.29958,0.051652 0.557839,0.1136342 0.774777,0.1859466 0.216937,0.072313 0.392553,0.1497902 0.526848,0.2324331 l 0.325407,0.1859468 -0.495858,1.5185645 c -0.227268,-0.144626 -0.506188,-0.273756 -0.83676,-0.38739 -0.330571,-0.113634 -0.671473,-0.170451 -1.022704,-0.170451 z" />
+         d="m 20.026025,11.760497 c -0.26463,0.01281 -0.457796,0.04053 -0.767707,0.205822 -0.309911,0.165285 -0.568171,0.397718 -0.774778,0.697299 -0.196277,0.289251 -0.34168,0.685213 -0.433875,1.053697 -0.09699,0.387667 -0.159149,0.795263 -0.119363,1.192895 0.06055,0.605143 0.145386,1.278777 0.537746,1.743446 0.384492,0.455351 0.893576,0.805769 1.596041,0.805769 0.113634,0 0.07648,-0.0074 0.07648,-0.0074 l -2.4e-5,-3.339478 1.905951,0 0,4.571055 c -0.227267,0.08264 -0.576666,0.238122 -0.87971,0.305238 -0.411435,0.09112 -0.744278,0.128637 -1.257653,0.128637 -0.599161,0 -1.141505,-0.103304 -1.627032,-0.309911 -0.475197,-0.216937 -0.883246,-0.532013 -1.224148,-0.945228 -0.340902,-0.423544 -0.604326,-0.945227 -0.790273,-1.565049 -0.185946,-0.630153 -0.219098,-1.059211 -0.216115,-1.596087 0.0034,-0.60292 0.04567,-1.169803 0.262602,-1.789624 0.216938,-0.630153 0.511353,-1.157001 0.883246,-1.580546 0.371893,-0.423546 0.810934,-0.738622 1.317121,-0.945229 0.506189,-0.216938 0.833472,-0.240534 1.262956,-0.268412 0.325962,-0.02116 0.654231,0.0268 0.976828,0.07809 0.262299,0.0417 0.557839,0.113634 0.774777,0.185946 0.216937,0.07231 0.392553,0.149791 0.526848,0.232433 l 0.325407,0.185947 -0.495858,1.518565 c -0.227268,-0.14463 -0.506188,-0.27376 -0.83676,-0.387394 -0.345293,-0.133943 -0.677503,-0.187196 -1.022707,-0.170481 z" />
     </g>
   </g>
 </svg>

--- a/Numix-Light/24/status/nm-tech-hspa.svg
+++ b/Numix-Light/24/status/nm-tech-hspa.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -15,7 +13,7 @@
    inkscape:version="0.91 r"
    sodipodi:docname="nm-tech-hspa.svg">
   <metadata
-     id="metadata12">
+     id="metadata16">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -27,7 +25,7 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs10" />
+     id="defs14" />
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -39,41 +37,32 @@
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
      inkscape:window-height="1056"
-     id="namedview8"
+     id="namedview12"
      showgrid="true"
-     inkscape:zoom="27.812867"
-     inkscape:cx="-4.9664232"
-     inkscape:cy="7.0560021"
+     inkscape:zoom="19.666667"
+     inkscape:cx="5.8828731"
+     inkscape:cy="21.709785"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
        type="xygrid"
-       id="grid4363" />
+       id="grid4149" />
   </sodipodi:namedview>
   <g
-     id="g4146"
-     transform="translate(1,1)">
+     id="g4146">
     <path
        sodipodi:nodetypes="ccccccccccccc"
        inkscape:connector-curvature="0"
        style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.06666672;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 3,8.9999998 2,0 0,3.9999992 3,0 0,-3.9999992 2,0 L 10,19 8,19 8,15 5,15 5,19 3,19 Z"
+       d="m 3,4 2,0 0,2.9999082 3,0 L 8,4 l 2,0 0,8 -2,0 0,-3.0000908 -3,0 L 5,12 3,12 Z"
        id="rect4134" />
-    <rect
-       ry="1"
-       rx="1"
-       y="3"
-       x="15"
-       height="16"
-       width="2"
-       id="rect4361"
-       style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
-       id="rect4363"
-       d="m 11,3 c -0.554,0 -1,0.446 -1,1 0,0.2444339 0.09757,0.4594594 0.242188,0.6328125 l -0.0098,0.00781 5,5.9999995 L 16,10 l 0.767578,0.640625 5,-6 -0.0098,-0.00781 C 21.902428,4.4594594 22,4.2444339 22,4 22,3.446 21.554,3 21,3 L 11,3 Z M 13.134766,5 18.865234,5 16,8.4375 13.134766,5 Z"
-       style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       inkscape:connector-curvature="0" />
+       style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 21,21 21,4.9999996 5,21 Z"
+       id="path4139"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
   </g>
 </svg>

--- a/Numix-Light/24/status/nm-tech-umts.svg
+++ b/Numix-Light/24/status/nm-tech-umts.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -15,7 +13,7 @@
    inkscape:version="0.91 r"
    sodipodi:docname="nm-tech-umts.svg">
   <metadata
-     id="metadata12">
+     id="metadata16">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -27,7 +25,7 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs10" />
+     id="defs14" />
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -39,50 +37,41 @@
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
      inkscape:window-height="1056"
-     id="namedview8"
+     id="namedview12"
      showgrid="true"
      inkscape:zoom="19.666667"
-     inkscape:cx="0.52423956"
-     inkscape:cy="14.641316"
+     inkscape:cx="4.1794833"
+     inkscape:cy="21.709785"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
        type="xygrid"
-       id="grid4363" />
+       id="grid4149" />
   </sodipodi:namedview>
   <g
-     id="g4147"
-     transform="translate(1,1)">
-    <rect
-       ry="1"
-       rx="1"
-       y="3"
-       x="15"
-       height="16"
-       width="2"
-       id="rect4361-7"
-       style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     id="g4145">
     <path
-       id="rect4363-7"
-       d="m 11,3 c -0.554,0 -1,0.446 -1,1 0,0.2444339 0.09757,0.4594594 0.242188,0.6328125 l -0.0098,0.00781 5,5.9999995 L 16,10 l 0.767578,0.640625 5,-6 -0.0098,-0.00781 C 21.902428,4.4594594 22,4.2444339 22,4 22,3.446 21.554,3 21,3 L 11,3 Z M 13.134766,5 18.865234,5 16,8.4375 13.134766,5 Z"
-       style="opacity:1;fill:#353535;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       inkscape:connector-curvature="0" />
+       style="fill:#353535;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 21,21 21,4.9999996 5,21 Z"
+       id="path4139-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
     <g
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#353535;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        id="g4143"
-       transform="translate(0.0317792,0.3680156)">
+       transform="translate(0.0317792,-6.6886254)">
       <path
          style="fill:#353535;fill-opacity:1"
          sodipodi:nodetypes="csccczcccsccsccczcccscc"
          inkscape:connector-curvature="0"
          id="path4145"
          transform="translate(-0.0317792,-0.3680156)"
-         d="m 3,10 0,5.525391 c 0,0.521398 0.068318,1.001578 0.2050781,1.4375 0.1453076,0.427374 0.3636817,0.798976 0.6542969,1.115234 0.2991627,0.307711 0.6739355,0.550971 1.1269531,0.730469 0.4261578,0.160815 0.9361562,0.248047 1.5136719,0.248047 0.5775157,0 1.0875141,-0.08723 1.5136719,-0.248047 C 8.4666895,18.629096 8.8414623,18.385836 9.140625,18.078125 9.4312402,17.761867 9.6496143,17.390265 9.7949219,16.962891 9.931682,16.526969 10,16.046789 10,15.525391 L 10,10 8,10 8,15.359375 C 8,15.71837 7.9616931,16.026778 7.8847656,16.283203 7.7992906,16.531081 7.6875414,16.736035 7.5507812,16.898438 7.4054737,17.052293 7.235655,17.162089 7.0390625,17.230469 6.8721752,17.2861 6.6897988,17.324219 6.5,17.324219 c -0.1897988,0 -0.3721752,-0.03812 -0.5390625,-0.09375 C 5.764345,17.162089 5.5945263,17.052293 5.4492188,16.898438 5.3124586,16.736035 5.2007094,16.531081 5.1152344,16.283203 5.0383069,16.026778 5,15.71837 5,15.359375 L 5,10 Z" />
+         d="m 3,11.056641 0,4.46875 c 0,0.521398 0.068318,1.001578 0.2050781,1.4375 0.1453076,0.427374 0.3636817,0.798976 0.6542969,1.115234 0.2991627,0.307711 0.6739355,0.550971 1.1269531,0.730469 0.4261578,0.160815 0.9361562,0.248047 1.5136719,0.248047 0.5775157,0 1.0875141,-0.08723 1.5136719,-0.248047 C 8.4666895,18.629096 8.8414623,18.385836 9.140625,18.078125 9.4312402,17.761867 9.6496143,17.390265 9.7949219,16.962891 9.931682,16.526969 10,16.046789 10,15.525391 l 0,-4.46875 -2,0 0,4.302734 C 8,15.71837 7.9616931,16.026778 7.8847656,16.283203 7.7992906,16.531081 7.6875414,16.736035 7.5507812,16.898438 7.4054737,17.052293 7.235655,17.162089 7.0390625,17.230469 6.8721752,17.2861 6.6897988,17.324219 6.5,17.324219 c -0.1897988,0 -0.3721752,-0.03812 -0.5390625,-0.09375 C 5.764345,17.162089 5.5945263,17.052293 5.4492188,16.898438 5.3124586,16.736035 5.2007094,16.531081 5.1152344,16.283203 5.0383069,16.026778 5,15.71837 5,15.359375 l 0,-4.302734 z" />
     </g>
     <g
-       transform="matrix(-1,0,0,1,12.968221,0.3680156)"
+       transform="matrix(-1,0,0,1,-12.253709,-12.565582)"
        id="g4169"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   </g>

--- a/Numix/16/status/network-cellular-3g.svg
+++ b/Numix/16/status/network-cellular-3g.svg
@@ -1,0 +1,1 @@
+nm-tech-3g.svg

--- a/Numix/16/status/network-cellular-4g.svg
+++ b/Numix/16/status/network-cellular-4g.svg
@@ -1,0 +1,1 @@
+nm-tech-4g.svg

--- a/Numix/16/status/network-cellular-edge.svg
+++ b/Numix/16/status/network-cellular-edge.svg
@@ -1,0 +1,1 @@
+nm-tech-edge.svg

--- a/Numix/16/status/network-cellular-gprs.svg
+++ b/Numix/16/status/network-cellular-gprs.svg
@@ -1,0 +1,1 @@
+nm-tech-gprs.svg

--- a/Numix/16/status/network-cellular-hspa.svg
+++ b/Numix/16/status/network-cellular-hspa.svg
@@ -1,0 +1,1 @@
+nm-tech-hspa.svg

--- a/Numix/16/status/network-cellular-offline.svg
+++ b/Numix/16/status/network-cellular-offline.svg
@@ -1,0 +1,1 @@
+gsm-3g-none.svg

--- a/Numix/16/status/nm-tech-3g.svg
+++ b/Numix/16/status/nm-tech-3g.svg
@@ -41,9 +41,9 @@
      inkscape:window-height="1056"
      id="namedview3373"
      showgrid="true"
-     inkscape:zoom="20.85965"
-     inkscape:cx="13.581944"
-     inkscape:cy="0.9419594"
+     inkscape:zoom="29.5"
+     inkscape:cx="0.59701127"
+     inkscape:cy="5.3503583"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -52,43 +52,38 @@
        type="xygrid"
        id="grid3411" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4143"
-     width="9"
-     height="1"
-     x="7"
-     y="2"
-     rx="0.5"
-     ry="0.5" />
-  <rect
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4145"
-     width="1"
-     height="12"
-     x="11"
-     y="2"
-     rx="0.5"
-     ry="0.49999997" />
-  <path
-     style="fill:none;fill-rule:evenodd;stroke:#ececec;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 7.5,2.5 4,5.5 4,-5.5"
-     id="path4147"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccc" />
   <g
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.38390064px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="text4218"
-     transform="matrix(0.6562625,0,0,0.6562625,1.6790482,3.6110078)">
+     id="g4146">
     <path
-       d="m 1.8937715,15.432832 q -0.2848297,0 -0.6068111,-0.04954 -0.30959751,-0.03715 -0.60681113,-0.09907 -0.28482971,-0.06192 -0.53250773,-0.136223 -0.24767801,-0.0743 -0.38390092,-0.136223 l 0.29721362,-1.275542 q 0.28482971,0.123839 0.73065014,0.260062 0.45820432,0.136223 1.08978322,0.136223 0.7801858,0 1.0897833,-0.334365 0.3219814,-0.334365 0.3219814,-0.829721 0,-0.606812 -0.4829721,-0.842106 Q 2.3272081,11.878652 1.584174,11.878652 l -0.4705882,0 0,-1.263158 0.5696594,0 q 0.2352941,0 0.4705882,-0.04954 0.2352942,-0.04954 0.4210527,-0.160991 0.1857585,-0.111455 0.2972136,-0.297214 0.123839,-0.185758 0.123839,-0.4705877 0,-0.4210527 -0.2600619,-0.6563468 -0.247678,-0.247678 -0.6934985,-0.247678 -0.4334365,0 -0.866873,0.1486068 Q 0.75445268,9.0179712 0.44485516,9.2284975 L -0.10003647,8.1139465 Q 0.23432885,7.8910363 0.77922048,7.6681261 1.336496,7.4328319 2.0299944,7.4328319 q 0.6439629,0 1.1145511,0.1609908 0.4829721,0.1609907 0.7925696,0.4582043 0.3095976,0.2848297 0.4582044,0.6811145 0.1486068,0.3962848 0.1486068,0.8544892 0,0.4582043 -0.2600619,0.8792573 -0.260062,0.421052 -0.6934985,0.643962 0.5944273,0.247678 0.9164087,0.730651 0.3343653,0.482972 0.3343653,1.151702 0,0.532508 -0.1733746,0.978328 -0.1733746,0.445821 -0.5325077,0.780186 -0.3591332,0.321982 -0.9164087,0.50774 -0.5572755,0.173375 -1.3250774,0.173375 z"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#ececec;fill-opacity:1"
-       id="path4223"
-       inkscape:connector-curvature="0" />
-    <path
-       d="m 9.3104893,8.7579093 q -0.5448916,0 -0.9164086,0.1981424 -0.371517,0.1981424 -0.6191951,0.5572756 -0.2352941,0.3467492 -0.3467492,0.8421047 -0.099071,0.482973 -0.099071,1.0774 0,1.374613 0.4334365,2.03096 0.4334366,0.643962 1.2755418,0.643962 0.1362229,0 0.2972136,-0.01238 0.1609907,-0.01238 0.2972136,-0.03715 l 0,-2.798762 1.5232191,0 0,3.826626 q -0.272446,0.09907 -0.854489,0.22291 -0.5696589,0.123839 -1.3869963,0.123839 -0.7182662,0 -1.3003096,-0.247678 Q 7.0442357,14.925097 6.635567,14.429741 6.2268983,13.922001 6.003988,13.178967 5.7810778,12.423549 5.7810778,11.432837 q 0,-0.978328 0.2600619,-1.7213623 0.260062,-0.755418 0.7058824,-1.2631579 0.4458204,-0.5077399 1.0526315,-0.7554179 0.6068112,-0.260062 1.3003096,-0.260062 0.4458204,0 0.7925696,0.074303 0.3591322,0.06192 0.6191942,0.1486069 0.260062,0.086687 0.421053,0.1857585 0.173375,0.099071 0.260062,0.1486068 L 10.796557,9.2037297 Q 10.524111,9.0303551 10.127826,8.8941322 9.7315419,8.7579093 9.3104893,8.7579093 Z"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#ececec;fill-opacity:1"
-       id="path4225"
-       inkscape:connector-curvature="0" />
+       style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 15,15 15,1 1,15 Z"
+       id="path4139"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <g
+       transform="matrix(-1,0,0,1,-12.253709,-20.565582)"
+       id="g4169"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="matrix(0.49999997,0,0,0.49999997,1.499,1.2500093)"
+       id="text4155"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4140"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#ececec;fill-opacity:1"
+         d="m 2.6625387,10.999982 q -0.3560371,0 -0.7585139,-0.06192 Q 1.5170279,10.891623 1.1455108,10.814223 0.78947367,10.736824 0.47987614,10.643944 0.17027861,10.551065 -2.9087067e-8,10.473666 L 0.37151701,8.8792386 q 0.35603716,0.1547987 0.91331269,0.3250774 0.5727555,0.1702786 1.3622292,0.1702786 0.9752322,0 1.3622291,-0.4179567 0.4024768,-0.4179566 0.4024768,-1.0371517 0,-0.7585139 -0.6037152,-1.0526316 Q 3.2043344,6.5572571 2.2755418,6.5572571 l -0.5882353,0 0,-1.5789474 0.7120743,0 q 0.2941177,0 0.5882353,-0.061919 Q 3.2817338,4.8544707 3.5139319,4.7151518 3.7461301,4.5758329 3.885449,4.3436347 4.0402477,4.1114366 4.0402477,3.7553994 q 0,-0.5263158 -0.3250774,-0.8204334 -0.3095975,-0.3095976 -0.866873,-0.3095976 -0.5417957,0 -1.0835914,0.1857586 Q 1.2383901,2.9814056 0.85139318,3.2445635 L 0.17027861,1.8513746 Q 0.58823528,1.5727368 1.2693498,1.2940991 1.9659443,0.99998141 2.8328174,0.99998141 q 0.8049536,0 1.3931889,0.20123839 0.6037151,0.2012384 0.9907121,0.5727554 0.3869969,0.3560372 0.5727554,0.8513932 0.1857585,0.4953561 0.1857585,1.0681115 0,0.5727555 -0.3250774,1.0990713 -0.3250774,0.5263158 -0.8668731,0.8049535 0.7430341,0.3095976 1.1455109,0.9133128 0.4179566,0.6037151 0.4179566,1.4396285 0,0.6656347 -0.2167182,1.2229102 Q 5.9133128,9.7306318 5.4643964,10.148588 5.01548,10.551065 4.3188855,10.783263 3.6222911,10.999982 2.6625387,10.999982 Z" />
+    </g>
+    <g
+       transform="matrix(0.52478257,0,0,0.52478257,-3.4927796,-3.4110486)"
+       id="text4380"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
+      <path
+         sodipodi:nodetypes="ascaaasccccascccacscaascccca"
+         inkscape:connector-curvature="0"
+         id="path4403"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#ececec;fill-opacity:1"
+         d="m 19.878081,11.770099 c -0.26463,0.01281 -0.457796,0.04053 -0.767707,0.205822 -0.309911,0.165285 -0.568171,0.397718 -0.774778,0.697299 -0.196277,0.289251 -0.34168,0.685213 -0.433875,1.053697 -0.09699,0.387667 -0.159149,0.795263 -0.119363,1.192895 0.06055,0.605143 0.145386,1.278777 0.537746,1.743446 0.384492,0.455351 0.893576,0.805769 1.596041,0.805769 0.113634,0 0.07648,-0.0074 0.07648,-0.0074 l -2.4e-5,-3.339478 1.905951,0 0,4.571055 c -0.227267,0.08264 -0.576666,0.238122 -0.87971,0.305238 -0.411435,0.09112 -0.744278,0.128637 -1.257653,0.128637 -0.599161,0 -1.141505,-0.103304 -1.627032,-0.309911 -0.475197,-0.216937 -0.883246,-0.532013 -1.224148,-0.945228 -0.340902,-0.423544 -0.604326,-0.945227 -0.790273,-1.565049 -0.185946,-0.630153 -0.219098,-1.059211 -0.216115,-1.596087 0.0034,-0.60292 0.04567,-1.169803 0.262602,-1.789624 0.216938,-0.630153 0.511353,-1.157001 0.883246,-1.580546 0.371893,-0.423546 0.810934,-0.738622 1.317121,-0.945229 0.506189,-0.216938 0.833472,-0.240534 1.262956,-0.268412 0.325962,-0.02116 0.654231,0.0268 0.976828,0.07809 0.262299,0.0417 0.557839,0.113634 0.774777,0.185946 0.216937,0.07231 0.392553,0.149791 0.526848,0.232433 l 0.325407,0.185947 -0.495858,1.518565 c -0.227268,-0.14463 -0.506188,-0.27376 -0.83676,-0.387394 -0.345293,-0.133943 -0.677503,-0.187196 -1.022707,-0.170481 z" />
+    </g>
   </g>
 </svg>

--- a/Numix/16/status/nm-tech-4g.svg
+++ b/Numix/16/status/nm-tech-4g.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg3351"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="nm-tech-4g.svg">
+  <metadata
+     id="metadata3377">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3375" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1056"
+     id="namedview3373"
+     showgrid="true"
+     inkscape:zoom="20.85965"
+     inkscape:cx="-3.7722479"
+     inkscape:cy="7.1733974"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3351">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3411" />
+  </sodipodi:namedview>
+  <g
+     id="g4150">
+    <path
+       style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 15,15 15,1 1,15 Z"
+       id="path4139-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <g
+       transform="matrix(-1,0,0,1,-12.253709,-20.565582)"
+       id="g4169-4"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="matrix(0.52476889,0,0,0.52476889,-3.5188818,-3.4186932)"
+       id="text4380-5"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
+      <path
+         sodipodi:nodetypes="ascaaasccccascccacscaascccca"
+         inkscape:connector-curvature="0"
+         id="path4403-9"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#ececec;fill-opacity:1"
+         d="m 19.930451,11.784195 c -0.26463,0.01281 -0.457796,0.04053 -0.767707,0.205822 -0.309911,0.165285 -0.568171,0.397718 -0.774778,0.697299 -0.196277,0.289251 -0.34168,0.685213 -0.433875,1.053697 -0.09699,0.387667 -0.159149,0.795263 -0.119363,1.192895 0.06055,0.605143 0.145386,1.278777 0.537746,1.743446 0.384492,0.455351 0.893576,0.805769 1.596041,0.805769 0.113634,0 0.07648,-0.0074 0.07648,-0.0074 l -2.4e-5,-3.339478 1.905951,0 0,4.571055 c -0.227267,0.08264 -0.576666,0.238122 -0.87971,0.305238 -0.411435,0.09112 -0.744278,0.128637 -1.257653,0.128637 -0.599161,0 -1.141505,-0.103304 -1.627032,-0.309911 -0.475197,-0.216937 -0.883246,-0.532013 -1.224148,-0.945228 -0.340902,-0.423544 -0.604326,-0.945227 -0.790273,-1.565049 -0.185946,-0.630153 -0.219098,-1.059211 -0.216115,-1.596087 0.0034,-0.60292 0.04567,-1.169803 0.262602,-1.789624 0.216938,-0.630153 0.511353,-1.157001 0.883246,-1.580546 0.371893,-0.423546 0.810934,-0.738622 1.317121,-0.945229 0.506189,-0.216938 0.833472,-0.240534 1.262956,-0.268412 0.325962,-0.02116 0.654231,0.0268 0.976828,0.07809 0.262299,0.0417 0.557839,0.113634 0.774777,0.185946 0.216937,0.07231 0.392553,0.149791 0.526848,0.232433 l 0.325407,0.185947 -0.495858,1.518565 C 21.56265,12.19744 21.28373,12.06831 20.953158,11.954676 20.607865,11.820733 20.275655,11.76748 19.930451,11.784195 Z" />
+    </g>
+    <path
+       sodipodi:nodetypes="ccccccccccccccccc"
+       inkscape:connector-curvature="0"
+       id="rect4146"
+       d="M 2.8111226,1.9997144 1.5,4.4810012 l 0,1.018528 1.5005708,0 0,0.9999739 0.9999739,0 0,-0.9999739 0.4999869,0 0,-0.7999791 -0.4999869,0 0,-2.6744458 0,-0.02539 z m 0.1894482,1.3078721 0,1.3919636 -0.7068415,0 z"
+       style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+</svg>

--- a/Numix/16/status/nm-tech-cdma-1x.svg
+++ b/Numix/16/status/nm-tech-cdma-1x.svg
@@ -41,9 +41,9 @@
      inkscape:window-height="1056"
      id="namedview3373"
      showgrid="true"
-     inkscape:zoom="41.7193"
-     inkscape:cx="3.9584721"
-     inkscape:cy="9.3375749"
+     inkscape:zoom="14.75"
+     inkscape:cx="-13.043165"
+     inkscape:cy="6.8682833"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -52,38 +52,23 @@
        type="xygrid"
        id="grid3411" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4143"
-     width="9"
-     height="1"
-     x="7"
-     y="2"
-     rx="0.5"
-     ry="0.5" />
-  <rect
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4145"
-     width="1"
-     height="12"
-     x="11"
-     y="2"
-     rx="0.5"
-     ry="0.49999997" />
-  <path
-     style="fill:none;fill-rule:evenodd;stroke:#ececec;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 7.5,2.5 4,5.5 4,-5.5"
-     id="path4147"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccc" />
   <g
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.28792572px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="text4139"
-     transform="matrix(1.1666667,0,0,1.1666667,-0.50000013,-2.3333339)">
+     id="g4143">
     <path
-       d="M 5.4984521,14 Q 4.2817338,14 3.640867,13.219814 3.0000001,12.439629 3.0000001,11 q 0,-0.71517 0.1950464,-1.2724456 Q 3.390093,9.1702789 3.7337462,8.7894739 4.0866874,8.399381 4.5603716,8.2043346 5.0433437,8.0000002 5.6099072,8.0000002 q 0.3065016,0 0.5479876,0.055728 0.250774,0.04644 0.4365325,0.1114551 0.1857586,0.065015 0.3065016,0.1393189 0.130031,0.074303 0.1950464,0.1114551 L 6.7987617,9.3281736 Q 6.5851394,9.1888547 6.2786379,9.0959755 5.9814242,8.9938083 5.5913314,8.9938083 q -0.2693499,0 -0.5294118,0.1021672 -0.250774,0.092879 -0.4551084,0.3250774 -0.1950464,0.2229102 -0.3250774,0.6037151 -0.120743,0.380805 -0.120743,0.947368 0,0.984521 0.3343653,1.513932 0.3436533,0.520124 1.1145511,0.520124 0.4458204,0 0.7337461,-0.102167 0.2972137,-0.102167 0.4736843,-0.204334 l 0.2879257,0.900928 Q 6.8637772,13.749226 6.4458205,13.879257 6.0371518,14 5.4984521,14 Z"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#ececec;fill-opacity:1"
-       id="path4144"
-       inkscape:connector-curvature="0" />
+       style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 15,15 15,1 1,15 Z"
+       id="path4139"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <g
+       transform="matrix(0.55555556,0,0,0.55555556,5.8788793,4.4174906)"
+       id="text4137"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:13.93188858px;line-height:354.99999523%;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4142"
+         style="line-height:354.99999523%;fill:#ececec;fill-opacity:1"
+         d="m -2.5279578,4.648517 q -1.8250774,0 -2.7863777,-1.1702786 -0.9613003,-1.1702787 -0.9613003,-3.3297214 0,-1.07275542 0.2925696,-1.9086687 0.2925697,-0.8359134 0.8080496,-1.4071208 0.5294117,-0.5851393 1.2399381,-0.877709 0.7244582,-0.3065015 1.5743034,-0.3065015 0.4597523,0 0.8219814,0.083591 0.376161,0.06966 0.65479875,0.1671827 0.27863778,0.097523 0.45975233,0.2089783 0.19504644,0.1114551 0.29256966,0.1671827 l -0.44582044,1.3653251 q -0.32043343,-0.2089784 -0.7801858,-0.3482973 -0.4458204,-0.1532507 -1.0309597,-0.1532507 -0.4040248,0 -0.7941177,0.1532507 -0.376161,0.1393189 -0.6826625,0.4876161 -0.2925697,0.3343654 -0.4876161,0.9055728 -0.1811146,0.57120743 -0.1811146,1.42105263 0,1.47678017 0.501548,2.27089787 0.5154799,0.7801857 1.6718267,0.7801857 0.6687306,0 1.1006192,-0.1532507 0.4458204,-0.1532508 0.71052628,-0.3065016 l 0.43188855,1.3513932 Q -0.47997018,4.272356 -1.1069052,4.4674025 -1.7199083,4.648517 -2.5279578,4.648517 Z" />
+    </g>
   </g>
 </svg>

--- a/Numix/16/status/nm-tech-edge.svg
+++ b/Numix/16/status/nm-tech-edge.svg
@@ -41,9 +41,9 @@
      inkscape:window-height="1056"
      id="namedview3373"
      showgrid="true"
-     inkscape:zoom="29.5"
-     inkscape:cx="6.3273665"
-     inkscape:cy="5.8581559"
+     inkscape:zoom="14.75"
+     inkscape:cx="-20.246276"
+     inkscape:cy="6.8682833"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -52,34 +52,23 @@
        type="xygrid"
        id="grid3411" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4143"
-     width="9"
-     height="1"
-     x="7"
-     y="2"
-     rx="0.5"
-     ry="0.5" />
-  <rect
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4145"
-     width="1"
-     height="12"
-     x="11"
-     y="2"
-     rx="0.5"
-     ry="0.49999997" />
-  <path
-     style="fill:none;fill-rule:evenodd;stroke:#ececec;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 7.5,2.5 4,5.5 4,-5.5"
-     id="path4147"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccc" />
-  <path
-     style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 7,6.9999996 -4,0 L 3,14 l 4,0 0,-1 -3,0 0,-2 2,0 0,-1.0000004 -2,0 0,-2 3,0 z"
-     id="path4206"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccccccccccc" />
+  <g
+     id="g4145">
+    <path
+       style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 15,15 15,1 1,15 Z"
+       id="path4139-0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <g
+       transform="matrix(-1,0,0,1,-15.253709,-19.565582)"
+       id="g4169"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccccccccccccc"
+       inkscape:connector-curvature="0"
+       id="path4140"
+       d="m 2,2 0,5 3,0 0,-0.9999995 -2,0 L 3,5 4.5,5 4.5,4 3,4 3,3 5,3 5,2 Z"
+       style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
 </svg>

--- a/Numix/16/status/nm-tech-evdo.svg
+++ b/Numix/16/status/nm-tech-evdo.svg
@@ -41,9 +41,9 @@
      inkscape:window-height="1056"
      id="namedview3373"
      showgrid="true"
-     inkscape:zoom="29.5"
-     inkscape:cx="6.3273665"
-     inkscape:cy="6.980932"
+     inkscape:zoom="14.75"
+     inkscape:cx="-25.229327"
+     inkscape:cy="12.292012"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -52,43 +52,25 @@
        type="xygrid"
        id="grid3411" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4143"
-     width="9"
-     height="1"
-     x="7"
-     y="2"
-     rx="0.5"
-     ry="0.5" />
-  <rect
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4145"
-     width="1"
-     height="12"
-     x="11"
-     y="2"
-     rx="0.5"
-     ry="0.49999997" />
-  <path
-     style="fill:none;fill-rule:evenodd;stroke:#ececec;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 7.5,2.5 4,5.5 4,-5.5"
-     id="path4147"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccc" />
-  <path
-     style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 4,6.9999996 -4,0 L 0,14 l 4,0 0,-1 -3,0 0,-2 2,0 0,-1.0000004 -2,0 0,-2 3,0 z"
-     id="path4206"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccccccccccc" />
   <g
-     transform="scale(0.9647938,1.0364909)"
-     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.91043091px;line-height:125%;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="text4325">
+     id="g4146">
     <path
-       d="M 6.5517138,13.507113 Q 6.2898635,12.754294 5.9952818,11.805086 5.7007002,10.855879 5.4388499,9.9175817 5.1769995,8.9683742 4.9697013,8.128271 4.7624032,7.2881678 4.6642093,6.7535567 l 1.418356,0 q 0.065463,0.5237007 0.1963878,1.2219683 0.1309251,0.6873571 0.2836712,1.4292664 0.1636564,0.7309986 0.3382233,1.4510876 0.1854773,0.709178 0.3600442,1.27652 0.1745669,-0.556432 0.3491338,-1.26561 Q 7.7845925,10.146701 7.9373386,9.4157019 8.0900846,8.6737926 8.2210098,7.975525 8.3519349,7.2772574 8.4392184,6.7535567 l 1.4074456,0 Q 9.7157388,7.4081826 9.519351,8.2155545 9.3338737,9.0229264 9.0829338,9.9175817 8.8429043,10.801327 8.5483227,11.728713 8.253741,12.645189 7.9373386,13.507113 l -1.3856248,0 z"
-       style="fill:#ececec;fill-opacity:1"
-       id="path4330" />
+       style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 15,15 15,1 1,15 Z"
+       id="path4139"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       sodipodi:nodetypes="ccccccccccccc"
+       inkscape:connector-curvature="0"
+       id="path4140-0"
+       d="m 2,2 0,5.0003988 2.9999392,0 0,-0.9999799 -1.9999595,0 0,-0.9999797 1.4999696,0 0,-0.9999797 -1.4999696,0 0,-0.9999798 1.9999595,0 0,-1.0004797 z"
+       style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       id="rect4137"
+       d="M 5.1999352,2 6.5436579,7 7.4752796,7 8.8190023,2 7.7838673,2 7.009469,5.5919274 6.2350702,2 Z"
+       style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   </g>
 </svg>

--- a/Numix/16/status/nm-tech-gprs.svg
+++ b/Numix/16/status/nm-tech-gprs.svg
@@ -41,9 +41,9 @@
      inkscape:window-height="1056"
      id="namedview3373"
      showgrid="true"
-     inkscape:zoom="14.75"
-     inkscape:cx="-12.843399"
-     inkscape:cy="10.547058"
+     inkscape:zoom="118"
+     inkscape:cx="1.448317"
+     inkscape:cy="11.951515"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -52,38 +52,29 @@
        type="xygrid"
        id="grid3411" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4143"
-     width="9"
-     height="1"
-     x="7"
-     y="2"
-     rx="0.5"
-     ry="0.5" />
-  <rect
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4145"
-     width="1"
-     height="12"
-     x="11"
-     y="2"
-     rx="0.5"
-     ry="0.49999997" />
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#ececec;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 7.5,2.5 4,5.5 4,-5.5"
-     id="path4147"
+     sodipodi:nodetypes="cccc"
      inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccc" />
+     id="path4139"
+     d="M 15,15 15,1 1,15 Z"
+     style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <g
-     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:37.5px;line-height:125%;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="text4137"
-     transform="matrix(0.28895769,0,0,0.28895769,3.8164303,11.547472)">
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="g4169"
+     transform="matrix(-1,0,0,1,-44.963641,-18.34766)" />
+  <g
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="g4169-7"
+     transform="matrix(-1,0,0,1,-64.982985,-20.426498)" />
+  <g
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="text4380"
+     transform="matrix(0.52480727,0,0,0.52480727,-5.5231927,-3.4441309)">
     <path
-       d="m 5.4291859,-11.725 q -1.65,0 -2.775,0.6 -1.125,0.6 -1.87500003,1.6875 -0.7125,1.05 -1.05,2.55 -0.3,1.4625 -0.3,3.2625 0,4.1625 1.3125,6.15 1.31250003,1.95 3.86250003,1.95 0.4125,0 0.9,-0.0375 0.4875,-0.0375 0.9,-0.1125 l 0,-8.475 4.6125001,0 0,11.5875 q -0.825,0.3 -2.5875001,0.675 -1.725,0.375 -4.2,0.375 -2.175,0 -3.93750003,-0.75 Q -1.4333141,6.95 -2.6708141,5.45 q -1.2375,-1.5375 -1.9125,-3.7875 -0.675,-2.2875 -0.675,-5.2875 0,-2.9625 0.7875,-5.2125 0.7875,-2.2875 2.1375,-3.825 1.34999998,-1.5375 3.18749997,-2.2875 1.83750003,-0.7875 3.93750003,-0.7875 1.35,0 2.4,0.225 1.0875,0.1875 1.875,0.45 0.7875,0.2625 1.2750001,0.5625 0.525,0.3 0.7875,0.45 l -1.2000001,3.675 q -0.825,-0.525 -2.025,-0.9375 -1.2,-0.4125 -2.475,-0.4125 z"
-       id="path4142"
+       d="m 19.937055,11.833171 c -0.26463,0.01281 -0.457796,0.04053 -0.767707,0.205822 -0.309911,0.165285 -0.568171,0.397718 -0.774778,0.697299 -0.196277,0.289251 -0.34168,0.685213 -0.433875,1.053697 -0.09699,0.387667 -0.159149,0.795263 -0.119363,1.192895 0.06055,0.605143 0.145386,1.278777 0.537746,1.743446 0.384492,0.455351 0.893576,0.805769 1.596041,0.805769 0.113634,0 0.07648,-0.0074 0.07648,-0.0074 l -2.4e-5,-3.339478 1.905951,0 0,4.571055 c -0.227267,0.08264 -0.576666,0.238122 -0.87971,0.305238 -0.411435,0.09112 -0.744278,0.128637 -1.257653,0.128637 -0.599161,0 -1.141505,-0.103304 -1.627032,-0.309911 -0.475197,-0.216937 -0.883246,-0.532013 -1.224148,-0.945228 -0.340902,-0.423544 -0.604326,-0.945227 -0.790273,-1.565049 -0.185946,-0.630153 -0.219098,-1.059211 -0.216115,-1.596087 0.0034,-0.60292 0.04567,-1.169803 0.262602,-1.789624 0.216938,-0.630153 0.511353,-1.157001 0.883246,-1.580546 0.371893,-0.423546 0.810934,-0.738622 1.317121,-0.945229 0.506189,-0.216938 0.833472,-0.240534 1.262956,-0.268412 0.325962,-0.02116 0.654231,0.0268 0.976828,0.07809 0.262299,0.0417 0.557839,0.113634 0.774777,0.185946 0.216937,0.07231 0.392553,0.149791 0.526848,0.232433 l 0.325407,0.185947 -0.495858,1.518565 c -0.227268,-0.14463 -0.506188,-0.27376 -0.83676,-0.387394 -0.345293,-0.133943 -0.677503,-0.187196 -1.022707,-0.170481 z"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#ececec;fill-opacity:1"
+       id="path4403"
        inkscape:connector-curvature="0"
-       style="fill:#ececec;fill-opacity:1" />
+       sodipodi:nodetypes="ascaaasccccascccacscaascccca" />
   </g>
 </svg>

--- a/Numix/16/status/nm-tech-hspa.svg
+++ b/Numix/16/status/nm-tech-hspa.svg
@@ -41,9 +41,9 @@
      inkscape:window-height="1056"
      id="namedview3373"
      showgrid="true"
-     inkscape:zoom="29.5"
-     inkscape:cx="-2.9438199"
-     inkscape:cy="5.8581559"
+     inkscape:zoom="41.7193"
+     inkscape:cx="9.2775326"
+     inkscape:cy="7.4238073"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -52,33 +52,24 @@
        type="xygrid"
        id="grid3411" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4143"
-     width="9"
-     height="1"
-     x="7"
-     y="2"
-     rx="0.5"
-     ry="0.5" />
-  <rect
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4145"
-     width="1"
-     height="12"
-     x="11"
-     y="2"
-     rx="0.5"
-     ry="0.49999997" />
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#ececec;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 7.5,2.5 4,5.5 4,-5.5"
-     id="path4147"
+     sodipodi:nodetypes="cccc"
      inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccc" />
+     id="path4139"
+     d="M 15,15 15,1 1,15 Z"
+     style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <g
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="g4169"
+     transform="matrix(-1,0,0,1,-44.963641,-18.34766)" />
+  <g
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="g4169-7"
+     transform="matrix(-1,0,0,1,-64.982985,-20.426498)" />
   <path
-     style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 3,7 0,7 1,0 0,-3 2,0 0,3 1,0 0,-7 -1,0 0,3 -2,0 0,-3 z"
-     id="path4137"
-     inkscape:connector-curvature="0" />
+     id="rect4134"
+     d="m 2,2 1,0 0,1.499954 1,0 L 4,2 5,2 5,6 4,6 4,4.499955 l -1,0 L 3,6 2,6 Z"
+     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.06666672;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccccccccccc" />
 </svg>

--- a/Numix/16/status/nm-tech-umts.svg
+++ b/Numix/16/status/nm-tech-umts.svg
@@ -41,9 +41,9 @@
      inkscape:window-height="1056"
      id="namedview3373"
      showgrid="true"
-     inkscape:zoom="29.5"
-     inkscape:cx="4.6568816"
-     inkscape:cy="3.2401823"
+     inkscape:zoom="14.75"
+     inkscape:cx="32.139656"
+     inkscape:cy="10.32072"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -52,38 +52,38 @@
        type="xygrid"
        id="grid3411" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4143"
-     width="9"
-     height="1"
-     x="7"
-     y="2"
-     rx="0.5"
-     ry="0.5" />
-  <rect
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4145"
-     width="1"
-     height="12"
-     x="11"
-     y="2"
-     rx="0.5"
-     ry="0.49999997" />
   <path
-     style="fill:none;fill-rule:evenodd;stroke:#ececec;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 7.5,2.5 4,5.5 4,-5.5"
-     id="path4147"
+     sodipodi:nodetypes="cccc"
      inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccc" />
+     id="path4139"
+     d="M 15,15 15,1 1,15 Z"
+     style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <g
-     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11.14466667px;line-height:125%;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="text4231"
-     transform="matrix(0.91493818,0,0,0.91493818,0.25518545,1.1945232)">
-    <path
-       d="m 5.2918848,13.275735 q -0.6579575,0 -1.1075617,-0.175455 Q 3.745685,12.91386 3.4825021,12.573915 3.2193191,12.233969 3.1096595,11.751467 2.9999999,11.268964 2.9999999,10.676802 l 0,-4.3315514 1.3597785,0 0,4.2438254 q 0,0.427672 0.043865,0.723753 0.043865,0.285115 0.1425573,0.46057 0.1096596,0.175457 0.2960809,0.252216 0.1864214,0.07676 0.471536,0.07676 0.2851148,0 0.4715362,-0.07676 0.1864213,-0.07676 0.2960809,-0.252216 0.1096595,-0.186421 0.1535233,-0.471535 0.043865,-0.296081 0.043865,-0.723753 l 0,-4.2328604 1.3488127,0 0,4.3315514 q 0,0.592162 -0.1096597,1.074665 -0.1096604,0.482502 -0.3838091,0.822448 -0.2741498,0.339945 -0.723754,0.526365 -0.4496044,0.175455 -1.1185276,0.175455 z"
-       id="path4236"
-       style="fill:#ececec;fill-opacity:1"
-       inkscape:connector-curvature="0" />
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="g4169"
+     transform="matrix(-1,0,0,1,-44.963641,-18.34766)" />
+  <g
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="g4169-7"
+     transform="matrix(-1,0,0,1,-64.982985,-20.426498)" />
+  <g
+     id="g4443"
+     transform="matrix(0.5,0,0,0.5,1,0.5)">
+    <g
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="g4143"
+       transform="translate(-0.9682208,-7.6886254)">
+      <path
+         style="fill:#ececec;fill-opacity:1"
+         sodipodi:nodetypes="csccczcccsccsccczcccscc"
+         inkscape:connector-curvature="0"
+         id="path4145"
+         transform="translate(-0.0317792,-0.3680156)"
+         d="m 3,11.056641 0,4.46875 c 0,0.521398 0.068318,1.001578 0.2050781,1.4375 0.1453076,0.427374 0.3636817,0.798976 0.6542969,1.115234 0.2991627,0.307711 0.6739355,0.550971 1.1269531,0.730469 0.4261578,0.160815 0.9361562,0.248047 1.5136719,0.248047 0.5775157,0 1.0875141,-0.08723 1.5136719,-0.248047 C 8.4666895,18.629096 8.8414623,18.385836 9.140625,18.078125 9.4312402,17.761867 9.6496143,17.390265 9.7949219,16.962891 9.931682,16.526969 10,16.046789 10,15.525391 l 0,-4.46875 -2,0 0,4.302734 C 8,15.71837 7.9616931,16.026778 7.8847656,16.283203 7.7992906,16.531081 7.6875414,16.736035 7.5507812,16.898438 7.4054737,17.052293 7.235655,17.162089 7.0390625,17.230469 6.8721752,17.2861 6.6897988,17.324219 6.5,17.324219 c -0.1897988,0 -0.3721752,-0.03812 -0.5390625,-0.09375 C 5.764345,17.162089 5.5945263,17.052293 5.4492188,16.898438 5.3124586,16.736035 5.2007094,16.531081 5.1152344,16.283203 5.0383069,16.026778 5,15.71837 5,15.359375 l 0,-4.302734 z" />
+    </g>
+    <g
+       transform="matrix(-1,0,0,1,-12.253709,-14.565582)"
+       id="g4169-6"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   </g>
 </svg>

--- a/Numix/22/status/gsm-3g-none.svg
+++ b/Numix/22/status/gsm-3g-none.svg
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -42,8 +42,8 @@
      id="namedview3071"
      showgrid="true"
      inkscape:zoom="21.454545"
-     inkscape:cx="-2.4859186"
-     inkscape:cy="5.4670416"
+     inkscape:cx="9.42298"
+     inkscape:cy="4.7212789"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -53,14 +53,9 @@
        id="grid4137" />
   </sodipodi:namedview>
   <path
-     style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;opacity:0.4"
-     d="m 19,3 -16,16 11.5,0 0,-1 c 0,-0.779849 0.423009,-1.407283 1,-1.869141 l 0,-0.09961 C 15.5,14.114682 17.070012,12.5 19,12.5 Z"
+     style="opacity:0.4;fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 19,3 3,19 19,19 Z"
      id="path4139"
      inkscape:connector-curvature="0"
-     sodipodi:nodetypes="cccscscc" />
-  <path
-     inkscape:connector-curvature="0"
-     style="fill:#ececec;fill-opacity:1"
-     d="m 19,14 c -1.108,0 -2,0.910763 -2,2.03125 L 17,17 c -0.554,0 -1,0.446 -1,1 l 0,3 c 0,0.554 0.446,1 1,1 l 4,0 c 0.554,0 1,-0.446 1,-1 l 0,-3 c 0,-0.554 -0.446,-1 -1,-1 l 0,-0.96875 C 21,14.910764 20.108,14 19,14 Z m 0,1 c 0.554,0 1,0.442363 1,1 l 0,1 -2,0 0,-1 c 0,-0.557637 0.446,-1 1,-1 z"
-     id="path3095" />
+     sodipodi:nodetypes="cccc" />
 </svg>

--- a/Numix/22/status/network-cellular-3g.svg
+++ b/Numix/22/status/network-cellular-3g.svg
@@ -1,0 +1,1 @@
+nm-tech-3g.svg

--- a/Numix/22/status/network-cellular-4g.svg
+++ b/Numix/22/status/network-cellular-4g.svg
@@ -1,0 +1,1 @@
+nm-tech-4g.svg

--- a/Numix/22/status/network-cellular-edge.svg
+++ b/Numix/22/status/network-cellular-edge.svg
@@ -1,0 +1,1 @@
+nm-tech-edge.svg

--- a/Numix/22/status/network-cellular-gprs.svg
+++ b/Numix/22/status/network-cellular-gprs.svg
@@ -1,0 +1,1 @@
+nm-tech-gprs.svg

--- a/Numix/22/status/network-cellular-hspa.svg
+++ b/Numix/22/status/network-cellular-hspa.svg
@@ -1,0 +1,1 @@
+nm-tech-hspa.svg

--- a/Numix/22/status/network-cellular-offline.svg
+++ b/Numix/22/status/network-cellular-offline.svg
@@ -1,0 +1,1 @@
+gsm-3g-none.svg

--- a/Numix/22/status/nm-tech-3g.svg
+++ b/Numix/22/status/nm-tech-3g.svg
@@ -41,9 +41,9 @@
      inkscape:window-height="1056"
      id="namedview3071"
      showgrid="true"
-     inkscape:zoom="32"
-     inkscape:cx="14.833185"
-     inkscape:cy="6.3862657"
+     inkscape:zoom="21.454545"
+     inkscape:cx="1.5688104"
+     inkscape:cy="13.194377"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -52,40 +52,33 @@
        type="xygrid"
        id="grid4137" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4361"
-     width="2"
-     height="16"
-     x="15"
-     y="3"
-     rx="1"
-     ry="1" />
   <path
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     d="M 11 3 C 10.446 3 10 3.446 10 4 C 10 4.2444339 10.097572 4.4594594 10.242188 4.6328125 L 10.232422 4.640625 L 15.232422 10.640625 L 16 10 L 16.767578 10.640625 L 21.767578 4.640625 L 21.757812 4.6328125 C 21.902428 4.4594594 22 4.2444339 22 4 C 22 3.446 21.554 3 21 3 L 11 3 z M 13.134766 5 L 18.865234 5 L 16 8.4375 L 13.134766 5 z "
-     id="rect4363" />
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;"
-     x="-0.63467497"
-     y="18.798761"
-     id="text4155"
-     sodipodi:linespacing="125%"><tspan
-       sodipodi:role="line"
-       id="tspan4157"
-       x="-0.63467497"
-       y="18.798761"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#ececec;fill-opacity:1;">3</tspan></text>
+     sodipodi:nodetypes="cccc"
+     inkscape:connector-curvature="0"
+     id="path4139"
+     d="M 20,20 20,3.9999996 4,20 Z"
+     style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <g
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="g4169"
+     transform="matrix(-1,0,0,1,-12.253709,-14.565582)" />
+  <g
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="text4155">
+    <path
+       d="m 2.6625387,10.999982 q -0.3560371,0 -0.7585139,-0.06192 Q 1.5170279,10.891623 1.1455108,10.814223 0.78947367,10.736824 0.47987614,10.643944 0.17027861,10.551065 -2.9087067e-8,10.473666 L 0.37151701,8.8792386 q 0.35603716,0.1547987 0.91331269,0.3250774 0.5727555,0.1702786 1.3622292,0.1702786 0.9752322,0 1.3622291,-0.4179567 0.4024768,-0.4179566 0.4024768,-1.0371517 0,-0.7585139 -0.6037152,-1.0526316 Q 3.2043344,6.5572571 2.2755418,6.5572571 l -0.5882353,0 0,-1.5789474 0.7120743,0 q 0.2941177,0 0.5882353,-0.061919 Q 3.2817338,4.8544707 3.5139319,4.7151518 3.7461301,4.5758329 3.885449,4.3436347 4.0402477,4.1114366 4.0402477,3.7553994 q 0,-0.5263158 -0.3250774,-0.8204334 -0.3095975,-0.3095976 -0.866873,-0.3095976 -0.5417957,0 -1.0835914,0.1857586 Q 1.2383901,2.9814056 0.85139318,3.2445635 L 0.17027861,1.8513746 Q 0.58823528,1.5727368 1.2693498,1.2940991 1.9659443,0.99998141 2.8328174,0.99998141 q 0.8049536,0 1.3931889,0.20123839 0.6037151,0.2012384 0.9907121,0.5727554 0.3869969,0.3560372 0.5727554,0.8513932 0.1857585,0.4953561 0.1857585,1.0681115 0,0.5727555 -0.3250774,1.0990713 -0.3250774,0.5263158 -0.8668731,0.8049535 0.7430341,0.3095976 1.1455109,0.9133128 0.4179566,0.6037151 0.4179566,1.4396285 0,0.6656347 -0.2167182,1.2229102 Q 5.9133128,9.7306318 5.4643964,10.148588 5.01548,10.551065 4.3188855,10.783263 3.6222911,10.999982 2.6625387,10.999982 Z"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#ececec;fill-opacity:1"
+       id="path4140" />
+  </g>
   <g
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="text4380"
-     transform="matrix(1.0495652,0,0,1.0495652,-10.038526,-0.83689332)">
+     transform="matrix(1.0495652,0,0,1.0495652,-10.038526,-9.3369112)">
     <path
-       d="m 19.930451,10.831154 c -0.26463,0.01281 -0.457796,0.04053 -0.767707,0.205822 -0.309911,0.165285 -0.568171,0.397718 -0.774778,0.697299 -0.196277,0.289251 -0.340902,0.640483 -0.433875,1.053697 -0.08264,0.402884 -0.123965,0.852255 -0.123965,1.348112 0,1.146671 0.180782,1.993761 0.542345,2.54127 0.361563,0.537179 0.893576,0.805769 1.596041,0.805769 0.113634,0 0.07648,-0.0074 0.07648,-0.0074 l -2.4e-5,-3.339478 1.905951,0 0,4.571055 c -0.227267,0.08264 -0.576666,0.238122 -0.87971,0.305238 -0.411435,0.09112 -0.744278,0.128637 -1.257653,0.128637 -0.599161,0 -1.141505,-0.103304 -1.627032,-0.309911 -0.475197,-0.216937 -0.883246,-0.532013 -1.224148,-0.945228 -0.340902,-0.423544 -0.604326,-0.945227 -0.790273,-1.565049 -0.185946,-0.630153 -0.278919,-1.358444 -0.278919,-2.184873 0,-0.816098 0.108469,-1.534058 0.325406,-2.153879 0.216938,-0.630153 0.511353,-1.157001 0.883246,-1.580546 0.371893,-0.4235451 0.810934,-0.7386212 1.317121,-0.9452285 0.506189,-0.2169377 0.833472,-0.2405335 1.262956,-0.2684123 0.325962,-0.021159 0.654231,0.026801 0.976828,0.078086 0.262299,0.041699 0.557839,0.1136342 0.774777,0.1859466 0.216937,0.072313 0.392553,0.1497902 0.526848,0.2324331 l 0.325407,0.1859468 -0.495858,1.5185643 c -0.227268,-0.144626 -0.506188,-0.273756 -0.83676,-0.38739 -0.345293,-0.133943 -0.677503,-0.187195 -1.022704,-0.170481 z"
+       d="m 19.930451,11.784195 c -0.26463,0.01281 -0.457796,0.04053 -0.767707,0.205822 -0.309911,0.165285 -0.568171,0.397718 -0.774778,0.697299 -0.196277,0.289251 -0.34168,0.685213 -0.433875,1.053697 -0.09699,0.387667 -0.159149,0.795263 -0.119363,1.192895 0.06055,0.605143 0.145386,1.278777 0.537746,1.743446 0.384492,0.455351 0.893576,0.805769 1.596041,0.805769 0.113634,0 0.07648,-0.0074 0.07648,-0.0074 l -2.4e-5,-3.339478 1.905951,0 0,4.571055 c -0.227267,0.08264 -0.576666,0.238122 -0.87971,0.305238 -0.411435,0.09112 -0.744278,0.128637 -1.257653,0.128637 -0.599161,0 -1.141505,-0.103304 -1.627032,-0.309911 -0.475197,-0.216937 -0.883246,-0.532013 -1.224148,-0.945228 -0.340902,-0.423544 -0.604326,-0.945227 -0.790273,-1.565049 -0.185946,-0.630153 -0.219098,-1.059211 -0.216115,-1.596087 0.0034,-0.60292 0.04567,-1.169803 0.262602,-1.789624 0.216938,-0.630153 0.511353,-1.157001 0.883246,-1.580546 0.371893,-0.423546 0.810934,-0.738622 1.317121,-0.945229 0.506189,-0.216938 0.833472,-0.240534 1.262956,-0.268412 0.325962,-0.02116 0.654231,0.0268 0.976828,0.07809 0.262299,0.0417 0.557839,0.113634 0.774777,0.185946 0.216937,0.07231 0.392553,0.149791 0.526848,0.232433 l 0.325407,0.185947 -0.495858,1.518565 C 21.56265,12.19744 21.28373,12.06831 20.953158,11.954676 20.607865,11.820733 20.275655,11.76748 19.930451,11.784195 Z"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#ececec;fill-opacity:1"
        id="path4403"
        inkscape:connector-curvature="0"
-       sodipodi:nodetypes="asccscsccccascccscscaascccca" />
+       sodipodi:nodetypes="ascaaasccccascccacscaascccca" />
   </g>
 </svg>

--- a/Numix/22/status/nm-tech-4g.svg
+++ b/Numix/22/status/nm-tech-4g.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 22 22"
+   id="svg3055"
+   version="1.1"
+   inkscape:version="0.91 r"
+   width="100%"
+   height="100%"
+   sodipodi:docname="nm-tech-4g.svg">
+  <metadata
+     id="metadata3075">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3073" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1056"
+     id="namedview3071"
+     showgrid="true"
+     inkscape:zoom="10.727273"
+     inkscape:cx="39.155382"
+     inkscape:cy="1.2340534"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3055">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4137" />
+  </sodipodi:namedview>
+  <path
+     sodipodi:nodetypes="cccc"
+     inkscape:connector-curvature="0"
+     id="path4139"
+     d="M 20,20 20,3.9999996 4,20 Z"
+     style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <g
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="g4169"
+     transform="matrix(-1,0,0,1,-12.253709,-14.565582)" />
+  <g
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="text4380"
+     transform="matrix(1.0495652,0,0,1.0495652,-10.038526,-8.8369112)">
+    <path
+       d="m 19.930451,11.784195 c -0.26463,0.01281 -0.457796,0.04053 -0.767707,0.205822 -0.309911,0.165285 -0.568171,0.397718 -0.774778,0.697299 -0.196277,0.289251 -0.34168,0.685213 -0.433875,1.053697 -0.09699,0.387667 -0.159149,0.795263 -0.119363,1.192895 0.06055,0.605143 0.145386,1.278777 0.537746,1.743446 0.384492,0.455351 0.893576,0.805769 1.596041,0.805769 0.113634,0 0.07648,-0.0074 0.07648,-0.0074 l -2.4e-5,-3.339478 1.905951,0 0,4.571055 c -0.227267,0.08264 -0.576666,0.238122 -0.87971,0.305238 -0.411435,0.09112 -0.744278,0.128637 -1.257653,0.128637 -0.599161,0 -1.141505,-0.103304 -1.627032,-0.309911 -0.475197,-0.216937 -0.883246,-0.532013 -1.224148,-0.945228 -0.340902,-0.423544 -0.604326,-0.945227 -0.790273,-1.565049 -0.185946,-0.630153 -0.219098,-1.059211 -0.216115,-1.596087 0.0034,-0.60292 0.04567,-1.169803 0.262602,-1.789624 0.216938,-0.630153 0.511353,-1.157001 0.883246,-1.580546 0.371893,-0.423546 0.810934,-0.738622 1.317121,-0.945229 0.506189,-0.216938 0.833472,-0.240534 1.262956,-0.268412 0.325962,-0.02116 0.654231,0.0268 0.976828,0.07809 0.262299,0.0417 0.557839,0.113634 0.774777,0.185946 0.216937,0.07231 0.392553,0.149791 0.526848,0.232433 l 0.325407,0.185947 -0.495858,1.518565 C 21.56265,12.19744 21.28373,12.06831 20.953158,11.954676 20.607865,11.820733 20.275655,11.76748 19.930451,11.784195 Z"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#ececec;fill-opacity:1"
+       id="path4403"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ascaaasccccascccacscaascccca" />
+  </g>
+  <path
+     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 2.6218138,2.0001875 -5e-4,6.9628908 l 0,2.037109 3.00122,0 0,2.0000002 2,0 0,-2.0000002 1,0 0,-1.5999998 -1,0 0,-5.3490313 0,-0.050781 z M 3.00072,4.616 l 0,2.784 -1.41372,0 z"
+     id="rect4146"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccccccccccccccc" />
+</svg>

--- a/Numix/22/status/nm-tech-cdma-1x.svg
+++ b/Numix/22/status/nm-tech-cdma-1x.svg
@@ -41,9 +41,9 @@
      inkscape:window-height="1056"
      id="namedview3071"
      showgrid="true"
-     inkscape:zoom="15.170654"
-     inkscape:cx="7.6156757"
-     inkscape:cy="11.754875"
+     inkscape:zoom="30.341308"
+     inkscape:cx="5.9489147"
+     inkscape:cy="17.964"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -52,25 +52,20 @@
        type="xygrid"
        id="grid4137" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4361"
-     width="2"
-     height="16"
-     x="15"
-     y="3"
-     rx="1"
-     ry="1" />
   <path
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     d="M 11 3 C 10.446 3 10 3.446 10 4 C 10 4.2444339 10.097572 4.4594594 10.242188 4.6328125 L 10.232422 4.640625 L 15.232422 10.640625 L 16 10 L 16.767578 10.640625 L 21.767578 4.640625 L 21.757812 4.6328125 C 21.902428 4.4594594 22 4.2444339 22 4 C 22 3.446 21.554 3 21 3 L 11 3 z M 13.134766 5 L 18.865234 5 L 16 8.4375 L 13.134766 5 z "
-     id="rect4363" />
+     sodipodi:nodetypes="cccc"
+     inkscape:connector-curvature="0"
+     id="path4139"
+     d="M 20,20 20,3.9999996 4,20 Z"
+     style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <g
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="text4136">
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:13.93188858px;line-height:354.99999523%;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="text4137"
+     transform="translate(8.6680508,6.351483)">
     <path
-       d="M 7.1640869,19 Q 5.136223,19 4.0681116,17.69969 3.0000001,16.399381 3.0000001,14 q 0,-1.191951 0.3250774,-2.120743 0.3250774,-0.928793 0.8978328,-1.563468 0.5882353,-0.6501548 1.377709,-0.9752322 0.8049536,-0.3405573 1.7492261,-0.3405573 0.5108359,0 0.9133127,0.092879 0.4179567,0.077399 0.7275542,0.1857585 0.3095975,0.1083591 0.5108359,0.2321982 0.2167183,0.123839 0.3250774,0.1857585 l -0.495356,1.517028 Q 8.9752324,10.981424 8.4643965,10.826625 7.9690404,10.656346 7.3188856,10.656346 q -0.4489164,0 -0.8823529,0.170279 -0.4179567,0.154799 -0.758514,0.541796 -0.3250774,0.371517 -0.5417957,1.006192 -0.2012384,0.634675 -0.2012384,1.578947 0,1.640867 0.5572756,2.52322 0.5727554,0.866873 1.8575852,0.866873 0.743034,0 1.2229102,-0.170279 0.4953561,-0.170278 0.7894737,-0.340557 l 0.4798762,1.501548 Q 9.4396287,18.582043 8.7430343,18.798761 8.0619197,19 7.1640869,19 Z"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#ececec;fill-opacity:1"
-       id="path4141" />
+       d="m -2.5279578,4.648517 q -1.8250774,0 -2.7863777,-1.1702786 -0.9613003,-1.1702787 -0.9613003,-3.3297214 0,-1.07275542 0.2925696,-1.9086687 0.2925697,-0.8359134 0.8080496,-1.4071208 0.5294117,-0.5851393 1.2399381,-0.877709 0.7244582,-0.3065015 1.5743034,-0.3065015 0.4597523,0 0.8219814,0.083591 0.376161,0.06966 0.65479875,0.1671827 0.27863778,0.097523 0.45975233,0.2089783 0.19504644,0.1114551 0.29256966,0.1671827 l -0.44582044,1.3653251 q -0.32043343,-0.2089784 -0.7801858,-0.3482973 -0.4458204,-0.1532507 -1.0309597,-0.1532507 -0.4040248,0 -0.7941177,0.1532507 -0.376161,0.1393189 -0.6826625,0.4876161 -0.2925697,0.3343654 -0.4876161,0.9055728 -0.1811146,0.57120743 -0.1811146,1.42105263 0,1.47678017 0.501548,2.27089787 0.5154799,0.7801857 1.6718267,0.7801857 0.6687306,0 1.1006192,-0.1532507 0.4458204,-0.1532508 0.71052628,-0.3065016 l 0.43188855,1.3513932 Q -0.47997018,4.272356 -1.1069052,4.4674025 -1.7199083,4.648517 -2.5279578,4.648517 Z"
+       style="line-height:354.99999523%;fill:#ececec;fill-opacity:1"
+       id="path4142"
+       inkscape:connector-curvature="0" />
   </g>
 </svg>

--- a/Numix/22/status/nm-tech-edge.svg
+++ b/Numix/22/status/nm-tech-edge.svg
@@ -41,33 +41,32 @@
      inkscape:window-height="1056"
      id="namedview3071"
      showgrid="true"
-     inkscape:zoom="15.170654"
-     inkscape:cx="6.4336473"
-     inkscape:cy="12.098442"
+     inkscape:zoom="21.454545"
+     inkscape:cx="19.898187"
+     inkscape:cy="13.438756"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg3055">
+     inkscape:current-layer="svg3055"
+     showguides="false">
     <inkscape:grid
        type="xygrid"
        id="grid4137" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4361"
-     width="2"
-     height="16"
-     x="15"
-     y="3"
-     rx="1"
-     ry="1" />
   <path
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     d="M 11 3 C 10.446 3 10 3.446 10 4 C 10 4.2444339 10.097572 4.4594594 10.242188 4.6328125 L 10.232422 4.640625 L 15.232422 10.640625 L 16 10 L 16.767578 10.640625 L 21.767578 4.640625 L 21.757812 4.6328125 C 21.902428 4.4594594 22 4.2444339 22 4 C 22 3.446 21.554 3 21 3 L 11 3 z M 13.134766 5 L 18.865234 5 L 16 8.4375 L 13.134766 5 z "
-     id="rect4363" />
+     sodipodi:nodetypes="cccc"
+     inkscape:connector-curvature="0"
+     id="path4139"
+     d="M 20,20 20,3.9999996 4,20 Z"
+     style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <g
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="g4169"
+     transform="matrix(-1,0,0,1,-12.253709,-14.565582)" />
   <path
-     style="fill:#ececec;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
-     d="m 3,9 0,10 7,0 0,-2 -5,0 0,-2 4,0 0,-2 -4,0 0,-2 5,0 0,-2 z"
+     style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 2,2 0,10 6,0 0,-1.999999 -4,0 L 4,8 7,8 7,6 4,6 4,4 8,4 8,2 Z"
      id="path4140"
-     inkscape:connector-curvature="0" />
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccccccccccc" />
 </svg>

--- a/Numix/22/status/nm-tech-evdo.svg
+++ b/Numix/22/status/nm-tech-evdo.svg
@@ -41,9 +41,9 @@
      inkscape:window-height="1056"
      id="namedview3071"
      showgrid="true"
-     inkscape:zoom="7.585327"
-     inkscape:cx="21.783232"
-     inkscape:cy="-0.75017996"
+     inkscape:zoom="42.909089"
+     inkscape:cx="10.844396"
+     inkscape:cy="16.971199"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -52,33 +52,22 @@
        type="xygrid"
        id="grid4137" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4361"
-     width="2"
-     height="16"
-     x="15"
-     y="3"
-     rx="1"
-     ry="1" />
   <path
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     d="M 11 3 C 10.446 3 10 3.446 10 4 C 10 4.2444339 10.097572 4.4594594 10.242188 4.6328125 L 10.232422 4.640625 L 15.232422 10.640625 L 16 10 L 16.767578 10.640625 L 21.767578 4.640625 L 21.757812 4.6328125 C 21.902428 4.4594594 22 4.2444339 22 4 C 22 3.446 21.554 3 21 3 L 11 3 z M 13.134766 5 L 18.865234 5 L 16 8.4375 L 13.134766 5 z "
-     id="rect4363" />
+     sodipodi:nodetypes="cccc"
+     inkscape:connector-curvature="0"
+     id="path4139"
+     d="M 20,20 20,3.9999996 4,20 Z"
+     style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <path
      style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 0,9 0,10 6,0 0,-2 -4,0 0,-2 3,0 0,-2 -3,0 0,-2 4,0 0,-2 z"
+     d="M 1,0.9999997 1,11 l 6,0 0,-2.0000003 -4,0 0,-2 3,0 0,-2 -3,0 0,-2 4,0 0,-2 z"
      id="path4140"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="ccccccccccccc" />
-  <g
-     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16.15508842px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="text4193">
-    <path
-       d="M 8.7945171,19 C 8.5587244,18.256866 8.3082892,17.416801 8.0430226,16.479806 7.7777558,15.542811 7.5272261,14.611201 7.2914334,13.684976 7.0556407,12.747981 6.8444098,11.864836 6.6577406,11.035541 6.4710715,10.206247 6.3335257,9.5277332 6.2451034,9.0000003 l 1.9158154,0 c 0.058949,0.5169628 0.1473708,1.1200857 0.2652668,1.8093697 0.1178962,0.678514 0.2456173,1.383953 0.3831631,2.116317 0.1473704,0.721594 0.2996531,1.437803 0.4568483,2.148627 0.1670198,0.700053 0.3290327,1.330102 0.4862279,1.890145 0.1571953,-0.549273 0.3143911,-1.173937 0.4715851,-1.87399 0.157196,-0.710824 0.304565,-1.427033 0.442111,-2.148627 0.137546,-0.732364 0.265268,-1.443188 0.383164,-2.132472 0.117897,-0.689284 0.216143,-1.2924069 0.29474,-1.8093697 l 1.901078,0 c -0.117896,0.6462035 -0.265267,1.3677977 -0.442111,2.1647817 -0.167019,0.796985 -0.363513,1.637049 -0.589481,2.520194 -0.216143,0.872375 -0.456849,1.76629 -0.722116,2.681745 C 11.226129,17.271406 10.951038,18.149165 10.666121,19 Z"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#ececec;fill-opacity:1"
-       id="path4198"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cscsccccccccsccccccc" />
-  </g>
+  <path
+     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 7.4,1 2.6875,10.033203 1.863281,0 L 14.638281,1 12.567969,1 11.019141,8.183 9.470312,1 Z"
+     id="rect4137"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccc" />
 </svg>

--- a/Numix/22/status/nm-tech-gprs.svg
+++ b/Numix/22/status/nm-tech-gprs.svg
@@ -41,9 +41,9 @@
      inkscape:window-height="1056"
      id="namedview3071"
      showgrid="true"
-     inkscape:zoom="11.313709"
-     inkscape:cx="35.372663"
-     inkscape:cy="0.98918645"
+     inkscape:zoom="21.454545"
+     inkscape:cx="11.209139"
+     inkscape:cy="17.574861"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -52,28 +52,29 @@
        type="xygrid"
        id="grid4137" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4361"
-     width="2"
-     height="16"
-     x="15"
-     y="3"
-     rx="1"
-     ry="1" />
   <path
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     d="M 11 3 C 10.446 3 10 3.446 10 4 C 10 4.2444339 10.097572 4.4594594 10.242188 4.6328125 L 10.232422 4.640625 L 15.232422 10.640625 L 16 10 L 16.767578 10.640625 L 21.767578 4.640625 L 21.757812 4.6328125 C 21.902428 4.4594594 22 4.2444339 22 4 C 22 3.446 21.554 3 21 3 L 11 3 z M 13.134766 5 L 18.865234 5 L 16 8.4375 L 13.134766 5 z "
-     id="rect4363" />
+     sodipodi:nodetypes="cccc"
+     inkscape:connector-curvature="0"
+     id="path4139"
+     d="M 20,20 20,3.9999996 4,20 Z"
+     style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <g
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="g4169"
+     transform="matrix(-1,0,0,1,-12.253709,-14.565582)" />
+  <g
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="g4169-7"
+     transform="matrix(-1,0,0,1,-32.273053,-16.64442)" />
   <g
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="text4380"
-     transform="matrix(1.0495652,0,0,1.0495652,-13.038527,-0.83689332)">
+     transform="matrix(1.0495652,0,0,1.0495652,-14.138978,-8.8120389)">
     <path
-       d="m 19.642085,10.789047 c -0.454537,0 -0.83676,0.08264 -1.146671,0.247929 -0.309911,0.165285 -0.568171,0.397718 -0.774778,0.697299 -0.196277,0.289251 -0.340902,0.640483 -0.433875,1.053697 -0.08264,0.402884 -0.123965,0.852255 -0.123965,1.348112 0,1.146671 0.180782,1.993761 0.542345,2.54127 0.361563,0.537179 0.893576,0.805769 1.596041,0.805769 0.113634,0 0.237598,-0.0052 0.371893,-0.01549 0.134295,-0.01033 0.25826,-0.02582 0.371893,-0.04648 l 0,-3.284925 1.905951,0 0,4.571055 c -0.227267,0.08264 -0.583665,0.175616 -1.069192,0.278921 -0.475197,0.103303 -1.053697,0.154954 -1.735501,0.154954 -0.599161,0 -1.141505,-0.103304 -1.627032,-0.309911 -0.475197,-0.216937 -0.883246,-0.532013 -1.224148,-0.945228 -0.340902,-0.423544 -0.604326,-0.945227 -0.790273,-1.565049 -0.185946,-0.630153 -0.278919,-1.358444 -0.278919,-2.184873 0,-0.816098 0.108469,-1.534058 0.325406,-2.153879 0.216938,-0.630153 0.511353,-1.157001 0.883246,-1.580546 C 16.806399,9.9781269 17.24544,9.6630508 17.751627,9.4564435 18.257816,9.2395058 18.80016,9.131037 19.37866,9.131037 c 0.371893,0 0.702464,0.030991 0.991715,0.092973 0.29958,0.051652 0.557839,0.1136342 0.774777,0.1859466 0.216937,0.072313 0.392553,0.1497902 0.526848,0.2324331 l 0.325407,0.1859468 -0.495858,1.5185645 c -0.227268,-0.144626 -0.506188,-0.273756 -0.83676,-0.38739 -0.330571,-0.113634 -0.671473,-0.170451 -1.022704,-0.170451 z"
+       d="m 20.026025,11.760497 c -0.26463,0.01281 -0.457796,0.04053 -0.767707,0.205822 -0.309911,0.165285 -0.568171,0.397718 -0.774778,0.697299 -0.196277,0.289251 -0.34168,0.685213 -0.433875,1.053697 -0.09699,0.387667 -0.159149,0.795263 -0.119363,1.192895 0.06055,0.605143 0.145386,1.278777 0.537746,1.743446 0.384492,0.455351 0.893576,0.805769 1.596041,0.805769 0.113634,0 0.07648,-0.0074 0.07648,-0.0074 l -2.4e-5,-3.339478 1.905951,0 0,4.571055 c -0.227267,0.08264 -0.576666,0.238122 -0.87971,0.305238 -0.411435,0.09112 -0.744278,0.128637 -1.257653,0.128637 -0.599161,0 -1.141505,-0.103304 -1.627032,-0.309911 -0.475197,-0.216937 -0.883246,-0.532013 -1.224148,-0.945228 -0.340902,-0.423544 -0.604326,-0.945227 -0.790273,-1.565049 -0.185946,-0.630153 -0.219098,-1.059211 -0.216115,-1.596087 0.0034,-0.60292 0.04567,-1.169803 0.262602,-1.789624 0.216938,-0.630153 0.511353,-1.157001 0.883246,-1.580546 0.371893,-0.423546 0.810934,-0.738622 1.317121,-0.945229 0.506189,-0.216938 0.833472,-0.240534 1.262956,-0.268412 0.325962,-0.02116 0.654231,0.0268 0.976828,0.07809 0.262299,0.0417 0.557839,0.113634 0.774777,0.185946 0.216937,0.07231 0.392553,0.149791 0.526848,0.232433 l 0.325407,0.185947 -0.495858,1.518565 c -0.227268,-0.14463 -0.506188,-0.27376 -0.83676,-0.387394 -0.345293,-0.133943 -0.677503,-0.187196 -1.022707,-0.170481 z"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#ececec;fill-opacity:1"
        id="path4403"
        inkscape:connector-curvature="0"
-       sodipodi:nodetypes="csccscsscccccscccscscscscccscc" />
+       sodipodi:nodetypes="ascaaasccccascccacscaascccca" />
   </g>
 </svg>

--- a/Numix/22/status/nm-tech-hspa.svg
+++ b/Numix/22/status/nm-tech-hspa.svg
@@ -42,7 +42,7 @@
      id="namedview3071"
      showgrid="true"
      inkscape:zoom="15.170654"
-     inkscape:cx="22.326251"
+     inkscape:cx="4.2980236"
      inkscape:cy="8.037358"
      inkscape:window-x="0"
      inkscape:window-y="24"
@@ -54,21 +54,14 @@
   </sodipodi:namedview>
   <path
      id="rect4134"
-     d="m 3,8.9999998 2,0 0,3.9999992 3,0 0,-3.9999992 2,0 L 10,19 8,19 8,15 5,15 5,19 3,19 Z"
+     d="m 2,3 2,0 0,2.9999082 3,0 L 7,3 l 2,0 0,8 -2,0 0,-3.0000908 -3,0 L 4,11 2,11 Z"
      style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.06666672;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="ccccccccccccc" />
-  <rect
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4361"
-     width="2"
-     height="16"
-     x="15"
-     y="3"
-     rx="1"
-     ry="1" />
   <path
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     d="M 11 3 C 10.446 3 10 3.446 10 4 C 10 4.2444339 10.097572 4.4594594 10.242188 4.6328125 L 10.232422 4.640625 L 15.232422 10.640625 L 16 10 L 16.767578 10.640625 L 21.767578 4.640625 L 21.757812 4.6328125 C 21.902428 4.4594594 22 4.2444339 22 4 C 22 3.446 21.554 3 21 3 L 11 3 z M 13.134766 5 L 18.865234 5 L 16 8.4375 L 13.134766 5 z "
-     id="rect4363" />
+     sodipodi:nodetypes="cccc"
+     inkscape:connector-curvature="0"
+     id="path4139"
+     d="M 20,20 20,3.9999996 4,20 Z"
+     style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
 </svg>

--- a/Numix/22/status/nm-tech-umts.svg
+++ b/Numix/22/status/nm-tech-umts.svg
@@ -41,9 +41,9 @@
      inkscape:window-height="1056"
      id="namedview3071"
      showgrid="true"
-     inkscape:zoom="16"
-     inkscape:cx="3.7468548"
-     inkscape:cy="7.8949834"
+     inkscape:zoom="15.170654"
+     inkscape:cx="13.309115"
+     inkscape:cy="11.371166"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -52,25 +52,18 @@
        type="xygrid"
        id="grid4137" />
   </sodipodi:namedview>
-  <rect
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect4361"
-     width="2"
-     height="16"
-     x="15"
-     y="3"
-     rx="1"
-     ry="1" />
   <path
-     style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     d="M 11 3 C 10.446 3 10 3.446 10 4 C 10 4.2444339 10.097572 4.4594594 10.242188 4.6328125 L 10.232422 4.640625 L 15.232422 10.640625 L 16 10 L 16.767578 10.640625 L 21.767578 4.640625 L 21.757812 4.6328125 C 21.902428 4.4594594 22 4.2444339 22 4 C 22 3.446 21.554 3 21 3 L 11 3 z M 13.134766 5 L 18.865234 5 L 16 8.4375 L 13.134766 5 z "
-     id="rect4363" />
+     sodipodi:nodetypes="cccc"
+     inkscape:connector-curvature="0"
+     id="path4139"
+     d="M 20,20 20,3.9999996 4,20 Z"
+     style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <g
-     transform="translate(0.0317792,0.3680156)"
+     transform="translate(-0.9682208,-7.6886254)"
      id="g4143"
      style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
     <path
-       d="m 3,10 0,5.525391 c 0,0.521398 0.068318,1.001578 0.2050781,1.4375 0.1453076,0.427374 0.3636817,0.798976 0.6542969,1.115234 0.2991627,0.307711 0.6739355,0.550971 1.1269531,0.730469 0.4261578,0.160815 0.9361562,0.248047 1.5136719,0.248047 0.5775157,0 1.0875141,-0.08723 1.5136719,-0.248047 C 8.4666895,18.629096 8.8414623,18.385836 9.140625,18.078125 9.4312402,17.761867 9.6496143,17.390265 9.7949219,16.962891 9.931682,16.526969 10,16.046789 10,15.525391 L 10,10 8,10 8,15.359375 C 8,15.71837 7.9616931,16.026778 7.8847656,16.283203 7.7992906,16.531081 7.6875414,16.736035 7.5507812,16.898438 7.4054737,17.052293 7.235655,17.162089 7.0390625,17.230469 6.8721752,17.2861 6.6897988,17.324219 6.5,17.324219 c -0.1897988,0 -0.3721752,-0.03812 -0.5390625,-0.09375 C 5.764345,17.162089 5.5945263,17.052293 5.4492188,16.898438 5.3124586,16.736035 5.2007094,16.531081 5.1152344,16.283203 5.0383069,16.026778 5,15.71837 5,15.359375 L 5,10 Z"
+       d="m 3,11.056641 0,4.46875 c 0,0.521398 0.068318,1.001578 0.2050781,1.4375 0.1453076,0.427374 0.3636817,0.798976 0.6542969,1.115234 0.2991627,0.307711 0.6739355,0.550971 1.1269531,0.730469 0.4261578,0.160815 0.9361562,0.248047 1.5136719,0.248047 0.5775157,0 1.0875141,-0.08723 1.5136719,-0.248047 C 8.4666895,18.629096 8.8414623,18.385836 9.140625,18.078125 9.4312402,17.761867 9.6496143,17.390265 9.7949219,16.962891 9.931682,16.526969 10,16.046789 10,15.525391 l 0,-4.46875 -2,0 0,4.302734 C 8,15.71837 7.9616931,16.026778 7.8847656,16.283203 7.7992906,16.531081 7.6875414,16.736035 7.5507812,16.898438 7.4054737,17.052293 7.235655,17.162089 7.0390625,17.230469 6.8721752,17.2861 6.6897988,17.324219 6.5,17.324219 c -0.1897988,0 -0.3721752,-0.03812 -0.5390625,-0.09375 C 5.764345,17.162089 5.5945263,17.052293 5.4492188,16.898438 5.3124586,16.736035 5.2007094,16.531081 5.1152344,16.283203 5.0383069,16.026778 5,15.71837 5,15.359375 l 0,-4.302734 z"
        transform="translate(-0.0317792,-0.3680156)"
        id="path4145"
        inkscape:connector-curvature="0"
@@ -80,5 +73,5 @@
   <g
      style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
      id="g4169"
-     transform="matrix(-1,0,0,1,12.968221,0.3680156)" />
+     transform="matrix(-1,0,0,1,-12.253709,-14.565582)" />
 </svg>

--- a/Numix/24/status/network-cellular-3g.svg
+++ b/Numix/24/status/network-cellular-3g.svg
@@ -1,0 +1,1 @@
+nm-tech-3g.svg

--- a/Numix/24/status/network-cellular-4g.svg
+++ b/Numix/24/status/network-cellular-4g.svg
@@ -1,0 +1,1 @@
+nm-tech-4g.svg

--- a/Numix/24/status/network-cellular-edge.svg
+++ b/Numix/24/status/network-cellular-edge.svg
@@ -1,0 +1,1 @@
+nm-tech-edge.svg

--- a/Numix/24/status/network-cellular-gprs.svg
+++ b/Numix/24/status/network-cellular-gprs.svg
@@ -1,0 +1,1 @@
+nm-tech-gprs.svg

--- a/Numix/24/status/network-cellular-hspa.svg
+++ b/Numix/24/status/network-cellular-hspa.svg
@@ -1,0 +1,1 @@
+nm-tech-hspa.svg

--- a/Numix/24/status/network-cellular-offline.svg
+++ b/Numix/24/status/network-cellular-offline.svg
@@ -1,0 +1,1 @@
+gsm-3g-none.svg

--- a/Numix/24/status/nm-tech-3g.svg
+++ b/Numix/24/status/nm-tech-3g.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -15,7 +13,7 @@
    inkscape:version="0.91 r"
    sodipodi:docname="nm-tech-3g.svg">
   <metadata
-     id="metadata12">
+     id="metadata16">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -27,7 +25,7 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs10" />
+     id="defs14" />
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -39,58 +37,29 @@
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
      inkscape:window-height="1056"
-     id="namedview8"
-     showgrid="true"
-     inkscape:zoom="27.812867"
-     inkscape:cx="4.8671549"
-     inkscape:cy="12.808735"
+     id="namedview12"
+     showgrid="false"
+     inkscape:zoom="39.333333"
+     inkscape:cx="16.4479"
+     inkscape:cy="18.101244"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg2">
-    <inkscape:grid
-       type="xygrid"
-       id="grid4363" />
-  </sodipodi:namedview>
+     inkscape:current-layer="svg2" />
   <g
-     id="g4146"
-     transform="translate(0,1.79e-5)">
-    <rect
-       ry="1"
-       rx="1"
-       y="3.9999821"
-       x="16"
-       height="16"
-       width="2"
-       id="rect4361"
-       style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     fill="#ececec"
+     id="g4">
     <path
+       d="m21 21v-16l-16 16"
+       fill-rule="evenodd"
+       id="path6" />
+    <path
+       d="m3.662 12q-.356 0-.759-.062-.387-.046-.759-.124-.356-.077-.666-.17-.31-.093-.48-.17l.372-1.594q.356.155.913.325.573.17 1.362.17.975 0 1.362-.418.402-.418.402-1.037 0-.759-.604-1.053-.604-.31-1.533-.31h-.588v-1.579h.712q.294 0 .588-.062.294-.062.526-.201.232-.139.372-.372.155-.232.155-.588 0-.526-.325-.82-.31-.31-.867-.31-.542 0-1.084.186-.526.17-.913.433l-.681-1.393q.418-.279 1.099-.557.697-.294 1.563-.294.805 0 1.393.201.604.201.991.573.387.356.573.851.186.495.186 1.068 0 .573-.325 1.099-.325.526-.867.805.743.31 1.146.913.418.604.418 1.44 0 .666-.217 1.223-.217.557-.666.975-.449.402-1.146.635-.697.217-1.656.217"
+       id="path8" />
+    <path
+       d="M 11.88,4.03 C 11.602,4.044 11.399,4.073 11.074,4.246 10.749,4.419 10.478,4.664 10.261,4.978 10.055,5.281 9.902,5.697 9.805,6.084 9.703,6.491 9.638,6.918 9.68,7.336 c 0.064,0.635 0.152,1.342 0.565,1.829 0.403,0.478 0.938,0.846 1.675,0.846 0.12,0 0.08,-0.007 0.08,-0.007 l 0,-3.504 2,0 0,4.797 c -0.238,0.087 -0.606,0.25 -0.924,0.32 -0.431,0.096 -0.781,0.135 -1.32,0.135 -0.629,0 -1.199,-0.108 -1.708,-0.325 C 9.549,11.199 9.121,10.869 8.763,10.435 8.405,9.99 8.129,9.443 7.934,8.792 7.739,8.131 7.704,7.681 7.707,7.117 7.71,6.484 7.755,5.889 7.983,5.238 8.211,4.577 8.519,4.024 8.91,3.579 9.3,3.134 9.761,2.803 10.292,2.587 c 0.531,-0.228 0.874,-0.253 1.326,-0.281 0.342,-0.022 0.686,0.028 1.025,0.082 0.275,0.044 0.586,0.12 0.813,0.195 0.228,0.076 0.412,0.157 0.553,0.244 L 14.35,3.022 13.829,4.616 C 13.591,4.464 13.298,4.328 12.951,4.21 12.589,4.069 12.239,4.014 11.877,4.032"
+       id="path10"
        inkscape:connector-curvature="0"
-       id="rect4363"
-       d="m 12,3.9999821 c -0.554,0 -1,0.446 -1,1 0,0.2444339 0.09757,0.4594594 0.242188,0.6328125 l -0.0098,0.00781 5,5.9999994 L 17,10.999982 l 0.767578,0.640625 5,-5.9999999 -0.0098,-0.00781 C 22.902428,5.4594415 23,5.244416 23,4.9999821 c 0,-0.554 -0.446,-1 -1,-1 l -10,0 z m 2.134766,2 5.730468,0 -2.865234,3.4375 -2.865234,-3.4375 z"
-       style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-    <text
-       sodipodi:linespacing="125%"
-       id="text4155"
-       y="19.798744"
-       x="0.36532506"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       xml:space="preserve"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#ececec;fill-opacity:1"
-         y="19.798744"
-         x="0.36532506"
-         id="tspan4157"
-         sodipodi:role="line">3</tspan></text>
-    <g
-       transform="matrix(1.0495652,0,0,1.0495652,-9.038526,0.16308883)"
-       id="text4380"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
-      <path
-         sodipodi:nodetypes="asccscsccccascccscscaascccca"
-         inkscape:connector-curvature="0"
-         id="path4403"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#ececec;fill-opacity:1"
-         d="m 19.930451,10.831154 c -0.26463,0.01281 -0.457796,0.04053 -0.767707,0.205822 -0.309911,0.165285 -0.568171,0.397718 -0.774778,0.697299 -0.196277,0.289251 -0.340902,0.640483 -0.433875,1.053697 -0.08264,0.402884 -0.123965,0.852255 -0.123965,1.348112 0,1.146671 0.180782,1.993761 0.542345,2.54127 0.361563,0.537179 0.893576,0.805769 1.596041,0.805769 0.113634,0 0.07648,-0.0074 0.07648,-0.0074 l -2.4e-5,-3.339478 1.905951,0 0,4.571055 c -0.227267,0.08264 -0.576666,0.238122 -0.87971,0.305238 -0.411435,0.09112 -0.744278,0.128637 -1.257653,0.128637 -0.599161,0 -1.141505,-0.103304 -1.627032,-0.309911 -0.475197,-0.216937 -0.883246,-0.532013 -1.224148,-0.945228 -0.340902,-0.423544 -0.604326,-0.945227 -0.790273,-1.565049 -0.185946,-0.630153 -0.278919,-1.358444 -0.278919,-2.184873 0,-0.816098 0.108469,-1.534058 0.325406,-2.153879 0.216938,-0.630153 0.511353,-1.157001 0.883246,-1.580546 0.371893,-0.4235451 0.810934,-0.7386212 1.317121,-0.9452285 0.506189,-0.2169377 0.833472,-0.2405335 1.262956,-0.2684123 0.325962,-0.021159 0.654231,0.026801 0.976828,0.078086 0.262299,0.041699 0.557839,0.1136342 0.774777,0.1859466 0.216937,0.072313 0.392553,0.1497902 0.526848,0.2324331 l 0.325407,0.1859468 -0.495858,1.5185643 c -0.227268,-0.144626 -0.506188,-0.273756 -0.83676,-0.38739 -0.345293,-0.133943 -0.677503,-0.187195 -1.022704,-0.170481 z" />
-    </g>
+       sodipodi:nodetypes="csccccscccccsccccccccccccccc" />
   </g>
 </svg>

--- a/Numix/24/status/nm-tech-4g.svg
+++ b/Numix/24/status/nm-tech-4g.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 24 24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="nm-tech-4g.svg">
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1056"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="19.666667"
+     inkscape:cx="1.1540596"
+     inkscape:cy="17.641988"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4149" />
+  </sodipodi:namedview>
+  <g
+     id="g4147"
+     transform="matrix(0.999975,0,0,1,2.4999375e-5,0)">
+    <path
+       style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 21.0005,21 0,-16.0000004 L 5.0005,21 Z"
+       id="path4139-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <g
+       transform="matrix(-1,0,0,1,-12.253709,-12.565582)"
+       id="g4169"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="matrix(1.0495652,0,0,1.0495652,-9.038026,-7.8369112)"
+       id="text4380"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
+      <path
+         sodipodi:nodetypes="ascaaasccccascccacscaascccca"
+         inkscape:connector-curvature="0"
+         id="path4403"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#ececec;fill-opacity:1"
+         d="m 19.930451,11.784195 c -0.26463,0.01281 -0.457796,0.04053 -0.767707,0.205822 -0.309911,0.165285 -0.568171,0.397718 -0.774778,0.697299 -0.196277,0.289251 -0.34168,0.685213 -0.433875,1.053697 -0.09699,0.387667 -0.159149,0.795263 -0.119363,1.192895 0.06055,0.605143 0.145386,1.278777 0.537746,1.743446 0.384492,0.455351 0.893576,0.805769 1.596041,0.805769 0.113634,0 0.07648,-0.0074 0.07648,-0.0074 l -2.4e-5,-3.339478 1.905951,0 0,4.571055 c -0.227267,0.08264 -0.576666,0.238122 -0.87971,0.305238 -0.411435,0.09112 -0.744278,0.128637 -1.257653,0.128637 -0.599161,0 -1.141505,-0.103304 -1.627032,-0.309911 -0.475197,-0.216937 -0.883246,-0.532013 -1.224148,-0.945228 -0.340902,-0.423544 -0.604326,-0.945227 -0.790273,-1.565049 -0.185946,-0.630153 -0.219098,-1.059211 -0.216115,-1.596087 0.0034,-0.60292 0.04567,-1.169803 0.262602,-1.789624 0.216938,-0.630153 0.511353,-1.157001 0.883246,-1.580546 0.371893,-0.423546 0.810934,-0.738622 1.317121,-0.945229 0.506189,-0.216938 0.833472,-0.240534 1.262956,-0.268412 0.325962,-0.02116 0.654231,0.0268 0.976828,0.07809 0.262299,0.0417 0.557839,0.113634 0.774777,0.185946 0.216937,0.07231 0.392553,0.149791 0.526848,0.232433 l 0.325407,0.185947 -0.495858,1.518565 C 21.56265,12.19744 21.28373,12.06831 20.953158,11.954676 20.607865,11.820733 20.275655,11.76748 19.930451,11.784195 Z" />
+    </g>
+    <path
+       sodipodi:nodetypes="ccccccccccccccccc"
+       inkscape:connector-curvature="0"
+       id="rect4146"
+       d="M 3.6223138,3.0001875 1,7.9628908 1,10 l 3.00122,0 0,2 2,0 0,-2 1,0 0,-1.6 -1,0 0,-5.3490313 0,-0.050781 z M 4.00122,5.616 l 0,2.784 -1.41372,0 z"
+       style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+</svg>

--- a/Numix/24/status/nm-tech-cdma-1x.svg
+++ b/Numix/24/status/nm-tech-cdma-1x.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -15,7 +13,7 @@
    inkscape:version="0.91 r"
    sodipodi:docname="nm-tech-cdma-1x.svg">
   <metadata
-     id="metadata12">
+     id="metadata16">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -27,7 +25,7 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs10" />
+     id="defs14" />
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -39,44 +37,36 @@
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
      inkscape:window-height="1056"
-     id="namedview8"
+     id="namedview12"
      showgrid="true"
-     inkscape:zoom="27.812867"
-     inkscape:cx="4.8671549"
-     inkscape:cy="7.0560021"
+     inkscape:zoom="19.666667"
+     inkscape:cx="15.060839"
+     inkscape:cy="17.641988"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
        type="xygrid"
-       id="grid4363" />
+       id="grid4149" />
   </sodipodi:namedview>
   <g
      id="g4144">
-    <rect
-       ry="1"
-       rx="1"
-       y="4"
-       x="16"
-       height="16"
-       width="2"
-       id="rect4361"
-       style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
+       style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 20.999585,21 0,-16.0000004 L 4.999585,21 Z"
+       id="path4139"
        inkscape:connector-curvature="0"
-       id="rect4363"
-       d="m 12,4 c -0.554,0 -1,0.446 -1,1 0,0.2444339 0.09757,0.4594594 0.242188,0.6328125 l -0.0098,0.00781 5,5.9999995 L 17,11 l 0.767578,0.640625 5,-6 -0.0098,-0.00781 C 22.902428,5.4594594 23,5.2444339 23,5 23,4.446 22.554,4 22,4 L 12,4 Z M 14.134766,6 19.865234,6 17,9.4375 14.134766,6 Z"
-       style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+       sodipodi:nodetypes="cccc" />
     <g
-       transform="translate(0.9999999,1)"
-       id="text4136"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
+       transform="translate(9.6676358,7.351483)"
+       id="text4137"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:13.93188858px;line-height:354.99999523%;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
       <path
          inkscape:connector-curvature="0"
-         id="path4141"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#ececec;fill-opacity:1"
-         d="M 7.1640869,19 Q 5.136223,19 4.0681116,17.69969 3.0000001,16.399381 3.0000001,14 q 0,-1.191951 0.3250774,-2.120743 0.3250774,-0.928793 0.8978328,-1.563468 0.5882353,-0.6501548 1.377709,-0.9752322 0.8049536,-0.3405573 1.7492261,-0.3405573 0.5108359,0 0.9133127,0.092879 0.4179567,0.077399 0.7275542,0.1857585 0.3095975,0.1083591 0.5108359,0.2321982 0.2167183,0.123839 0.3250774,0.1857585 L 9.3312696,11.213622 Q 8.9752324,10.981424 8.4643965,10.826625 7.9690404,10.656346 7.3188856,10.656346 q -0.4489164,0 -0.8823529,0.170279 -0.4179567,0.154799 -0.758514,0.541796 -0.3250774,0.371517 -0.5417957,1.006192 -0.2012384,0.634675 -0.2012384,1.578947 0,1.640867 0.5572756,2.52322 0.5727554,0.866873 1.8575852,0.866873 0.743034,0 1.2229102,-0.170279 0.4953561,-0.170278 0.7894737,-0.340557 l 0.4798762,1.501548 Q 9.4396287,18.582043 8.7430343,18.798761 8.0619197,19 7.1640869,19 Z" />
+         id="path4142"
+         style="line-height:354.99999523%;fill:#ececec;fill-opacity:1"
+         d="m -2.5279578,4.648517 q -1.8250774,0 -2.7863777,-1.1702786 -0.9613003,-1.1702787 -0.9613003,-3.3297214 0,-1.07275542 0.2925696,-1.9086687 0.2925697,-0.8359134 0.8080496,-1.4071208 0.5294117,-0.5851393 1.2399381,-0.877709 0.7244582,-0.3065015 1.5743034,-0.3065015 0.4597523,0 0.8219814,0.083591 0.376161,0.06966 0.65479875,0.1671827 0.27863778,0.097523 0.45975233,0.2089783 0.19504644,0.1114551 0.29256966,0.1671827 l -0.44582044,1.3653251 q -0.32043343,-0.2089784 -0.7801858,-0.3482973 -0.4458204,-0.1532507 -1.0309597,-0.1532507 -0.4040248,0 -0.7941177,0.1532507 -0.376161,0.1393189 -0.6826625,0.4876161 -0.2925697,0.3343654 -0.4876161,0.9055728 -0.1811146,0.57120743 -0.1811146,1.42105263 0,1.47678017 0.501548,2.27089787 0.5154799,0.7801857 1.6718267,0.7801857 0.6687306,0 1.1006192,-0.1532507 0.4458204,-0.1532508 0.71052628,-0.3065016 l 0.43188855,1.3513932 Q -0.47997018,4.272356 -1.1069052,4.4674025 -1.7199083,4.648517 -2.5279578,4.648517 Z" />
     </g>
   </g>
 </svg>

--- a/Numix/24/status/nm-tech-edge.svg
+++ b/Numix/24/status/nm-tech-edge.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -15,7 +13,7 @@
    inkscape:version="0.91 r"
    sodipodi:docname="nm-tech-edge.svg">
   <metadata
-     id="metadata12">
+     id="metadata16">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -27,7 +25,7 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs10" />
+     id="defs14" />
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -39,39 +37,36 @@
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
      inkscape:window-height="1056"
-     id="namedview8"
+     id="namedview12"
      showgrid="true"
-     inkscape:zoom="9.8333334"
-     inkscape:cx="-28.612398"
-     inkscape:cy="7.0601576"
+     inkscape:zoom="19.666667"
+     inkscape:cx="15.060839"
+     inkscape:cy="17.641988"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
        type="xygrid"
-       id="grid4363" />
+       id="grid4149" />
   </sodipodi:namedview>
   <g
-     id="g4146">
-    <rect
-       ry="1"
-       rx="1"
-       y="4"
-       x="16"
-       height="16"
-       width="2"
-       id="rect4361-2"
-       style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     id="g4217">
     <path
+       style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 21,21 21,4.9999996 5,21 Z"
+       id="path4139-8"
        inkscape:connector-curvature="0"
-       id="rect4363-6"
-       d="m 12,4 c -0.554,0 -1,0.446 -1,1 0,0.2444339 0.09757,0.4594594 0.242188,0.6328125 l -0.0098,0.00781 5,5.9999995 L 17,11 l 0.767578,0.640625 5,-6 -0.0098,-0.00781 C 22.902428,5.4594594 23,5.2444339 23,5 23,4.446 22.554,4 22,4 L 12,4 Z M 14.134766,6 19.865234,6 17,9.4375 14.134766,6 Z"
-       style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+       sodipodi:nodetypes="cccc" />
+    <g
+       transform="matrix(-1,0,0,1,-11.253709,-13.565582)"
+       id="g4169"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
+       sodipodi:nodetypes="ccccccccccccc"
        inkscape:connector-curvature="0"
        id="path4140"
-       d="m 4,10 0,10 7,0 0,-2 -5,0 0,-2 4,0 0,-2 -4,0 0,-2 5,0 0,-2 z"
+       d="m 3,3 0,10 6,0 0,-1.999999 -4,0 L 5,9 8,9 8,7 5,7 5,5 9,5 9,3 Z"
        style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   </g>
 </svg>

--- a/Numix/24/status/nm-tech-evdo.svg
+++ b/Numix/24/status/nm-tech-evdo.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -15,7 +13,7 @@
    inkscape:version="0.91 r"
    sodipodi:docname="nm-tech-evdo.svg">
   <metadata
-     id="metadata12">
+     id="metadata16">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -27,7 +25,7 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs10" />
+     id="defs14" />
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -39,51 +37,38 @@
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
      inkscape:window-height="1056"
-     id="namedview8"
+     id="namedview12"
      showgrid="true"
-     inkscape:zoom="13.906433"
-     inkscape:cx="-0.76147829"
-     inkscape:cy="6.1957962"
+     inkscape:zoom="19.666667"
+     inkscape:cx="1.1540596"
+     inkscape:cy="17.641988"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
        type="xygrid"
-       id="grid4363" />
+       id="grid4149" />
   </sodipodi:namedview>
   <g
-     id="g4147"
-     transform="translate(1,1)">
-    <rect
-       ry="1"
-       rx="1"
-       y="3"
-       x="15"
-       height="16"
-       width="2"
-       id="rect4361"
-       style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     id="g4145">
     <path
-       id="rect4363"
-       d="m 11,3 c -0.554,0 -1,0.446 -1,1 0,0.2444339 0.09757,0.4594594 0.242188,0.6328125 l -0.0098,0.00781 5,5.9999995 L 16,10 l 0.767578,0.640625 5,-6 -0.0098,-0.00781 C 21.902428,4.4594594 22,4.2444339 22,4 22,3.446 21.554,3 21,3 L 11,3 Z M 13.134766,5 18.865234,5 16,8.4375 13.134766,5 Z"
-       style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       inkscape:connector-curvature="0" />
+       style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 21,21 21,4.9999996 5,21 Z"
+       id="path4139"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
     <path
        sodipodi:nodetypes="ccccccccccccc"
        inkscape:connector-curvature="0"
-       id="path4140-2"
-       d="m 0,9 0,10 6,0 0,-2 -4,0 0,-2 3,0 0,-2 -3,0 0,-2 4,0 0,-2 z"
+       id="path4140-4"
+       d="M 2,1.9999997 2,12 l 6,0 0,-2 -4,0 0,-2.0000003 3,0 0,-2 -3,0 0,-2 4,0 0,-2 z"
        style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-    <g
-       id="text4193"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16.15508842px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
-      <path
-         sodipodi:nodetypes="cscsccccccccsccccccc"
-         inkscape:connector-curvature="0"
-         id="path4198"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#ececec;fill-opacity:1"
-         d="M 8.7945171,19 C 8.5587244,18.256866 8.3082892,17.416801 8.0430226,16.479806 7.7777558,15.542811 7.5272261,14.611201 7.2914334,13.684976 7.0556407,12.747981 6.8444098,11.864836 6.6577406,11.035541 6.4710715,10.206247 6.3335257,9.5277332 6.2451034,9.0000003 l 1.9158154,0 c 0.058949,0.5169628 0.1473708,1.1200857 0.2652668,1.8093697 0.1178962,0.678514 0.2456173,1.383953 0.3831631,2.116317 0.1473704,0.721594 0.2996531,1.437803 0.4568483,2.148627 0.1670198,0.700053 0.3290327,1.330102 0.4862279,1.890145 0.1571953,-0.549273 0.3143911,-1.173937 0.4715851,-1.87399 0.157196,-0.710824 0.304565,-1.427033 0.442111,-2.148627 0.137546,-0.732364 0.265268,-1.443188 0.383164,-2.132472 0.117897,-0.689284 0.216143,-1.2924069 0.29474,-1.8093697 l 1.901078,0 c -0.117896,0.6462035 -0.265267,1.3677977 -0.442111,2.1647817 -0.167019,0.796985 -0.363513,1.637049 -0.589481,2.520194 -0.216143,0.872375 -0.456849,1.76629 -0.722116,2.681745 C 11.226129,17.271406 10.951038,18.149165 10.666121,19 Z" />
-    </g>
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       id="rect4137"
+       d="m 8.4,2 2.6875,10.033203 1.863281,0 L 15.638281,2 13.567969,2 12.019141,9.183 10.470312,2 Z"
+       style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   </g>
 </svg>

--- a/Numix/24/status/nm-tech-gprs.svg
+++ b/Numix/24/status/nm-tech-gprs.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -15,7 +13,7 @@
    inkscape:version="0.91 r"
    sodipodi:docname="nm-tech-gprs.svg">
   <metadata
-     id="metadata12">
+     id="metadata16">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -27,7 +25,7 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs10" />
+     id="defs14" />
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -39,46 +37,45 @@
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
      inkscape:window-height="1056"
-     id="namedview8"
+     id="namedview12"
      showgrid="true"
-     inkscape:zoom="13.906433"
-     inkscape:cx="-8.9231686"
-     inkscape:cy="9.0721628"
+     inkscape:zoom="19.666667"
+     inkscape:cx="-4.6171267"
+     inkscape:cy="17.641988"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
        type="xygrid"
-       id="grid4363" />
+       id="grid4149" />
   </sodipodi:namedview>
   <g
-     id="g4148"
-     transform="translate(1.0000005,1)">
-    <rect
-       ry="1"
-       rx="1"
-       y="3"
-       x="15"
-       height="16"
-       width="2"
-       id="rect4361-5"
-       style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     id="g4147">
     <path
-       id="rect4363-1"
-       d="m 11,3 c -0.554,0 -1,0.446 -1,1 0,0.2444339 0.09757,0.4594594 0.242188,0.6328125 l -0.0098,0.00781 5,5.9999995 L 16,10 l 0.767578,0.640625 5,-6 -0.0098,-0.00781 C 21.902428,4.4594594 22,4.2444339 22,4 22,3.446 21.554,3 21,3 L 11,3 Z M 13.134766,5 18.865234,5 16,8.4375 13.134766,5 Z"
-       style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       inkscape:connector-curvature="0" />
+       style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 21,21 21,4.9999996 5,21 Z"
+       id="path4139-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
     <g
-       transform="matrix(1.0495652,0,0,1.0495652,-13.038527,-0.83689332)"
+       transform="matrix(-1,0,0,1,-11.253709,-13.565582)"
+       id="g4169"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="matrix(-1,0,0,1,-31.273053,-15.64442)"
+       id="g4169-7"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="matrix(1.0495652,0,0,1.0495652,-13.138978,-7.8120389)"
        id="text4380"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15.47987652px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
       <path
-         sodipodi:nodetypes="csccscsscccccscccscscscscccscc"
+         sodipodi:nodetypes="ascaaasccccascccacscaascccca"
          inkscape:connector-curvature="0"
          id="path4403"
          style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Ubuntu Mono';-inkscape-font-specification:'Ubuntu Mono Bold';fill:#ececec;fill-opacity:1"
-         d="m 19.642085,10.789047 c -0.454537,0 -0.83676,0.08264 -1.146671,0.247929 -0.309911,0.165285 -0.568171,0.397718 -0.774778,0.697299 -0.196277,0.289251 -0.340902,0.640483 -0.433875,1.053697 -0.08264,0.402884 -0.123965,0.852255 -0.123965,1.348112 0,1.146671 0.180782,1.993761 0.542345,2.54127 0.361563,0.537179 0.893576,0.805769 1.596041,0.805769 0.113634,0 0.237598,-0.0052 0.371893,-0.01549 0.134295,-0.01033 0.25826,-0.02582 0.371893,-0.04648 l 0,-3.284925 1.905951,0 0,4.571055 c -0.227267,0.08264 -0.583665,0.175616 -1.069192,0.278921 -0.475197,0.103303 -1.053697,0.154954 -1.735501,0.154954 -0.599161,0 -1.141505,-0.103304 -1.627032,-0.309911 -0.475197,-0.216937 -0.883246,-0.532013 -1.224148,-0.945228 -0.340902,-0.423544 -0.604326,-0.945227 -0.790273,-1.565049 -0.185946,-0.630153 -0.278919,-1.358444 -0.278919,-2.184873 0,-0.816098 0.108469,-1.534058 0.325406,-2.153879 0.216938,-0.630153 0.511353,-1.157001 0.883246,-1.580546 C 16.806399,9.9781269 17.24544,9.6630508 17.751627,9.4564435 18.257816,9.2395058 18.80016,9.131037 19.37866,9.131037 c 0.371893,0 0.702464,0.030991 0.991715,0.092973 0.29958,0.051652 0.557839,0.1136342 0.774777,0.1859466 0.216937,0.072313 0.392553,0.1497902 0.526848,0.2324331 l 0.325407,0.1859468 -0.495858,1.5185645 c -0.227268,-0.144626 -0.506188,-0.273756 -0.83676,-0.38739 -0.330571,-0.113634 -0.671473,-0.170451 -1.022704,-0.170451 z" />
+         d="m 20.026025,11.760497 c -0.26463,0.01281 -0.457796,0.04053 -0.767707,0.205822 -0.309911,0.165285 -0.568171,0.397718 -0.774778,0.697299 -0.196277,0.289251 -0.34168,0.685213 -0.433875,1.053697 -0.09699,0.387667 -0.159149,0.795263 -0.119363,1.192895 0.06055,0.605143 0.145386,1.278777 0.537746,1.743446 0.384492,0.455351 0.893576,0.805769 1.596041,0.805769 0.113634,0 0.07648,-0.0074 0.07648,-0.0074 l -2.4e-5,-3.339478 1.905951,0 0,4.571055 c -0.227267,0.08264 -0.576666,0.238122 -0.87971,0.305238 -0.411435,0.09112 -0.744278,0.128637 -1.257653,0.128637 -0.599161,0 -1.141505,-0.103304 -1.627032,-0.309911 -0.475197,-0.216937 -0.883246,-0.532013 -1.224148,-0.945228 -0.340902,-0.423544 -0.604326,-0.945227 -0.790273,-1.565049 -0.185946,-0.630153 -0.219098,-1.059211 -0.216115,-1.596087 0.0034,-0.60292 0.04567,-1.169803 0.262602,-1.789624 0.216938,-0.630153 0.511353,-1.157001 0.883246,-1.580546 0.371893,-0.423546 0.810934,-0.738622 1.317121,-0.945229 0.506189,-0.216938 0.833472,-0.240534 1.262956,-0.268412 0.325962,-0.02116 0.654231,0.0268 0.976828,0.07809 0.262299,0.0417 0.557839,0.113634 0.774777,0.185946 0.216937,0.07231 0.392553,0.149791 0.526848,0.232433 l 0.325407,0.185947 -0.495858,1.518565 c -0.227268,-0.14463 -0.506188,-0.27376 -0.83676,-0.387394 -0.345293,-0.133943 -0.677503,-0.187196 -1.022707,-0.170481 z" />
     </g>
   </g>
 </svg>

--- a/Numix/24/status/nm-tech-hspa.svg
+++ b/Numix/24/status/nm-tech-hspa.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -15,7 +13,7 @@
    inkscape:version="0.91 r"
    sodipodi:docname="nm-tech-hspa.svg">
   <metadata
-     id="metadata12">
+     id="metadata16">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -27,7 +25,7 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs10" />
+     id="defs14" />
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -39,41 +37,32 @@
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
      inkscape:window-height="1056"
-     id="namedview8"
+     id="namedview12"
      showgrid="true"
-     inkscape:zoom="27.812867"
-     inkscape:cx="-4.9664232"
-     inkscape:cy="7.0560021"
+     inkscape:zoom="19.666667"
+     inkscape:cx="5.8828731"
+     inkscape:cy="21.709785"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
        type="xygrid"
-       id="grid4363" />
+       id="grid4149" />
   </sodipodi:namedview>
   <g
-     id="g4146"
-     transform="translate(1,1)">
+     id="g4146">
     <path
        sodipodi:nodetypes="ccccccccccccc"
        inkscape:connector-curvature="0"
        style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.06666672;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 3,8.9999998 2,0 0,3.9999992 3,0 0,-3.9999992 2,0 L 10,19 8,19 8,15 5,15 5,19 3,19 Z"
+       d="m 3,4 2,0 0,2.9999082 3,0 L 8,4 l 2,0 0,8 -2,0 0,-3.0000908 -3,0 L 5,12 3,12 Z"
        id="rect4134" />
-    <rect
-       ry="1"
-       rx="1"
-       y="3"
-       x="15"
-       height="16"
-       width="2"
-       id="rect4361"
-       style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
-       id="rect4363"
-       d="m 11,3 c -0.554,0 -1,0.446 -1,1 0,0.2444339 0.09757,0.4594594 0.242188,0.6328125 l -0.0098,0.00781 5,5.9999995 L 16,10 l 0.767578,0.640625 5,-6 -0.0098,-0.00781 C 21.902428,4.4594594 22,4.2444339 22,4 22,3.446 21.554,3 21,3 L 11,3 Z M 13.134766,5 18.865234,5 16,8.4375 13.134766,5 Z"
-       style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       inkscape:connector-curvature="0" />
+       style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 21,21 21,4.9999996 5,21 Z"
+       id="path4139"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
   </g>
 </svg>

--- a/Numix/24/status/nm-tech-umts.svg
+++ b/Numix/24/status/nm-tech-umts.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -15,7 +13,7 @@
    inkscape:version="0.91 r"
    sodipodi:docname="nm-tech-umts.svg">
   <metadata
-     id="metadata12">
+     id="metadata16">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -27,7 +25,7 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs10" />
+     id="defs14" />
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -39,50 +37,41 @@
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
      inkscape:window-height="1056"
-     id="namedview8"
+     id="namedview12"
      showgrid="true"
      inkscape:zoom="19.666667"
-     inkscape:cx="0.52423956"
-     inkscape:cy="14.641316"
+     inkscape:cx="4.1794833"
+     inkscape:cy="21.709785"
      inkscape:window-x="0"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
        type="xygrid"
-       id="grid4363" />
+       id="grid4149" />
   </sodipodi:namedview>
   <g
-     id="g4147"
-     transform="translate(1,1)">
-    <rect
-       ry="1"
-       rx="1"
-       y="3"
-       x="15"
-       height="16"
-       width="2"
-       id="rect4361-7"
-       style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     id="g4145">
     <path
-       id="rect4363-7"
-       d="m 11,3 c -0.554,0 -1,0.446 -1,1 0,0.2444339 0.09757,0.4594594 0.242188,0.6328125 l -0.0098,0.00781 5,5.9999995 L 16,10 l 0.767578,0.640625 5,-6 -0.0098,-0.00781 C 21.902428,4.4594594 22,4.2444339 22,4 22,3.446 21.554,3 21,3 L 11,3 Z M 13.134766,5 18.865234,5 16,8.4375 13.134766,5 Z"
-       style="opacity:1;fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       inkscape:connector-curvature="0" />
+       style="fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 21,21 21,4.9999996 5,21 Z"
+       id="path4139-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
     <g
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#ececec;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        id="g4143"
-       transform="translate(0.0317792,0.3680156)">
+       transform="translate(0.0317792,-6.6886254)">
       <path
          style="fill:#ececec;fill-opacity:1"
          sodipodi:nodetypes="csccczcccsccsccczcccscc"
          inkscape:connector-curvature="0"
          id="path4145"
          transform="translate(-0.0317792,-0.3680156)"
-         d="m 3,10 0,5.525391 c 0,0.521398 0.068318,1.001578 0.2050781,1.4375 0.1453076,0.427374 0.3636817,0.798976 0.6542969,1.115234 0.2991627,0.307711 0.6739355,0.550971 1.1269531,0.730469 0.4261578,0.160815 0.9361562,0.248047 1.5136719,0.248047 0.5775157,0 1.0875141,-0.08723 1.5136719,-0.248047 C 8.4666895,18.629096 8.8414623,18.385836 9.140625,18.078125 9.4312402,17.761867 9.6496143,17.390265 9.7949219,16.962891 9.931682,16.526969 10,16.046789 10,15.525391 L 10,10 8,10 8,15.359375 C 8,15.71837 7.9616931,16.026778 7.8847656,16.283203 7.7992906,16.531081 7.6875414,16.736035 7.5507812,16.898438 7.4054737,17.052293 7.235655,17.162089 7.0390625,17.230469 6.8721752,17.2861 6.6897988,17.324219 6.5,17.324219 c -0.1897988,0 -0.3721752,-0.03812 -0.5390625,-0.09375 C 5.764345,17.162089 5.5945263,17.052293 5.4492188,16.898438 5.3124586,16.736035 5.2007094,16.531081 5.1152344,16.283203 5.0383069,16.026778 5,15.71837 5,15.359375 L 5,10 Z" />
+         d="m 3,11.056641 0,4.46875 c 0,0.521398 0.068318,1.001578 0.2050781,1.4375 0.1453076,0.427374 0.3636817,0.798976 0.6542969,1.115234 0.2991627,0.307711 0.6739355,0.550971 1.1269531,0.730469 0.4261578,0.160815 0.9361562,0.248047 1.5136719,0.248047 0.5775157,0 1.0875141,-0.08723 1.5136719,-0.248047 C 8.4666895,18.629096 8.8414623,18.385836 9.140625,18.078125 9.4312402,17.761867 9.6496143,17.390265 9.7949219,16.962891 9.931682,16.526969 10,16.046789 10,15.525391 l 0,-4.46875 -2,0 0,4.302734 C 8,15.71837 7.9616931,16.026778 7.8847656,16.283203 7.7992906,16.531081 7.6875414,16.736035 7.5507812,16.898438 7.4054737,17.052293 7.235655,17.162089 7.0390625,17.230469 6.8721752,17.2861 6.6897988,17.324219 6.5,17.324219 c -0.1897988,0 -0.3721752,-0.03812 -0.5390625,-0.09375 C 5.764345,17.162089 5.5945263,17.052293 5.4492188,16.898438 5.3124586,16.736035 5.2007094,16.531081 5.1152344,16.283203 5.0383069,16.026778 5,15.71837 5,15.359375 l 0,-4.302734 z" />
     </g>
     <g
-       transform="matrix(-1,0,0,1,12.968221,0.3680156)"
+       transform="matrix(-1,0,0,1,-12.253709,-12.565582)"
        id="g4169"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.34567928px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   </g>


### PR DESCRIPTION
As proposed a new design for `nm-tech-*` in #934. Also fixed a incorrect icon from a previous PR