### PR TITLE
subtitle mimetype restyled

### DIFF
--- a/Numix/16/mimetypes/application-x-subrip.svg
+++ b/Numix/16/mimetypes/application-x-subrip.svg
@@ -13,7 +13,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="application-x-subrip.svg">
+   sodipodi:docname="application-x-subrip_16.svg">
   <metadata
      id="metadata14">
     <rdf:RDF>
@@ -54,6 +54,19 @@
            id="path19" />
       </g>
     </clipPath>
+    <clipPath
+       id="clipPath-165128749-9">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17-5">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19-9" />
+      </g>
+    </clipPath>
   </defs>
   <sodipodi:namedview
      pagecolor="#ffffff"
@@ -65,12 +78,12 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
-     inkscape:window-height="1016"
+     inkscape:window-height="1013"
      id="namedview10"
      showgrid="true"
-     inkscape:zoom="32"
-     inkscape:cx="7.1048387"
-     inkscape:cy="6.6006295"
+     inkscape:zoom="64"
+     inkscape:cx="7.028337"
+     inkscape:cy="6.7240487"
      inkscape:window-x="0"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
@@ -90,37 +103,32 @@
      d="m 9.5,0 4.496,4.5 -3.804307,0 C 9.8557274,4.5 9.5,4.143957 9.5,3.807692 L 9.5,0 Z"
      id="path8"
      inkscape:connector-curvature="0" />
-  <g
-     transform="matrix(0.24992093,0,0,0.2427961,2.0035962,3.0862207)"
-     id="g49"
-     style="fill:#ffffff">
-    <g
-       clip-path="url(#clipPath-165128749)"
-       id="g51"
-       style="fill:#ffffff">
-      <!-- color: #474747 -->
-      <g
-         id="g53"
-         style="fill:#ffffff">
-        <path
-           d="m 19.191685,12.000931 c -3.926,0 -7.202279,3.877819 -7.202278,7.803819 l 10e-7,3.90191 c 1e-6,3.926 4.07653,8.887683 8.00253,8.887683 l 8.002531,0 c 3.925956,0 8.00253,-4.961682 8.002531,-8.887683 l 0,-3.90191 c 0,-3.926 -3.276278,-7.803819 -7.202278,-7.803819"
-           id="path55"
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           sodipodi:nodetypes="cssssssc" />
-        <path
-           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           inkscape:connector-curvature="0"
-           d="m 31.995735,28.47566 -12.003797,0 -4.001265,12.356047"
-           id="path57"
-           sodipodi:nodetypes="ccc" />
-      </g>
-    </g>
-  </g>
   <path
      style="fill:#000000;fill-opacity:0.19599998"
      d="M 10.5,4.5 14,8 14,4.5 Z"
      id="path6-4"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cccc" />
+  <g
+     transform="matrix(0.24992093,0,0,0.25250794,2.0035963,2.9696694)"
+     id="g49"
+     style="fill:#f9f9f9">
+    <g
+       clip-path="url(#clipPath-165128749-9)"
+       id="g51"
+       style="fill:#f9f9f9">
+      <!-- color: #474747 -->
+      <g
+         id="g53"
+         style="fill:#f9f9f9">
+        <path
+           style="fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 32,24 c -8.666667,1e-6 -13,4.166667 -13,8.333334 0,4.166666 2.936105,8.333333 8.734375,8.333333 L 23.333333,47.75 l 0,1.25 L 25.5,49 36.401042,40.666667 C 43.087358,40.392844 45,36.760417 45,32.333334 45,28.166667 40.666667,23.999999 32,24 Z"
+           id="path55"
+           transform="matrix(0.92336896,0,0,0.95046518,-5.5546033,-10.810233)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sscccccss" />
+      </g>
+    </g>
+  </g>
 </svg>

--- a/Numix/22/mimetypes/application-x-subrip.svg
+++ b/Numix/22/mimetypes/application-x-subrip.svg
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -54,6 +54,19 @@
            id="path19" />
       </g>
     </clipPath>
+    <clipPath
+       id="clipPath-165128749-6">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17-8">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19-4" />
+      </g>
+    </clipPath>
   </defs>
   <sodipodi:namedview
      pagecolor="#ffffff"
@@ -65,12 +78,12 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
-     inkscape:window-height="1016"
+     inkscape:window-height="1013"
      id="namedview10"
      showgrid="true"
-     inkscape:zoom="32"
-     inkscape:cx="16.881978"
-     inkscape:cy="11.273536"
+     inkscape:zoom="16"
+     inkscape:cx="22.245596"
+     inkscape:cy="8.6523187"
      inkscape:window-x="0"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
@@ -90,37 +103,32 @@
      d="m 13,0 6,6 -5.076923,0 C 13.474725,6 13,5.5252752 13,5.0769232 L 13,0 Z"
      id="path8"
      inkscape:connector-curvature="0" />
-  <g
-     transform="matrix(0.41653489,0,0,0.36419415,1.0059937,3.6293312)"
-     id="g49"
-     style="fill:#ffffff">
-    <g
-       clip-path="url(#clipPath-165128749)"
-       id="g51"
-       style="fill:#ffffff">
-      <!-- color: #474747 -->
-      <g
-         id="g53"
-         style="fill:#ffffff">
-        <path
-           d="m 19.191685,12.000931 c -3.926,0 -7.202279,3.877819 -7.202278,7.803819 l 10e-7,3.90191 c 1e-6,3.926 3.276277,7.303574 7.202277,7.303574 l 9.603037,0 c 3.925956,0 7.202277,-3.377573 7.202278,-7.303574 l 0,-3.90191 c 0,-3.926 -3.276278,-7.803819 -7.202278,-7.803819"
-           id="path55"
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           sodipodi:nodetypes="cssssssc" />
-        <path
-           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           inkscape:connector-curvature="0"
-           d="m 33.59624,25.729872 -12.003796,0 -4.801519,13.728941"
-           id="path57"
-           sodipodi:nodetypes="ccc" />
-      </g>
-    </g>
-  </g>
   <path
      style="fill:#000000;fill-opacity:0.19599998"
      d="M 14,6.0000005 19,11 19,6.0000005 Z"
      id="path6-0"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cccc" />
+  <g
+     transform="matrix(0.41653489,0,0,0.42084656,1.0059937,2.9494493)"
+     id="g49"
+     style="fill:#f9f9f9">
+    <g
+       clip-path="url(#clipPath-165128749-6)"
+       id="g51"
+       style="fill:#f9f9f9">
+      <!-- color: #474747 -->
+      <g
+         id="g53"
+         style="fill:#f9f9f9">
+        <path
+           style="fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 32,24 c -7.8,0 -13,5.000001 -13,10 0,3.562531 2.435063,6.996041 7.15,8.75 L 24.2,49 33.3,44 C 39.986316,43.726177 45,38.857013 45,34 45,29.000001 39.8,24 32,24 Z"
+           id="path55"
+           transform="matrix(0.92336896,0,0,0.95046518,-5.5546033,-10.810233)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sscccss" />
+      </g>
+    </g>
+  </g>
 </svg>

--- a/Numix/24/mimetypes/application-x-subrip.svg
+++ b/Numix/24/mimetypes/application-x-subrip.svg
@@ -13,7 +13,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="application-x-subrip.svg">
+   sodipodi:docname="application-x-subrip_24.svg">
   <metadata
      id="metadata14">
     <rdf:RDF>
@@ -54,6 +54,19 @@
            id="path19" />
       </g>
     </clipPath>
+    <clipPath
+       id="clipPath-165128749-6">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17-8">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19-4" />
+      </g>
+    </clipPath>
   </defs>
   <sodipodi:namedview
      pagecolor="#ffffff"
@@ -65,12 +78,12 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
-     inkscape:window-height="1016"
+     inkscape:window-height="1013"
      id="namedview10"
      showgrid="true"
      inkscape:zoom="45.254834"
-     inkscape:cx="13.212597"
-     inkscape:cy="15.199737"
+     inkscape:cx="9.268267"
+     inkscape:cy="9.8964361"
      inkscape:window-x="0"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
@@ -90,37 +103,32 @@
      d="m 14,1 6,6 -5.076923,0 C 14.474725,7 14,6.5252752 14,6.0769232 L 14,1 Z"
      id="path8"
      inkscape:connector-curvature="0" />
-  <g
-     transform="matrix(0.41653489,0,0,0.36419415,2.0059937,4.6293312)"
-     id="g49"
-     style="fill:#ffffff">
-    <g
-       clip-path="url(#clipPath-165128749)"
-       id="g51"
-       style="fill:#ffffff">
-      <!-- color: #474747 -->
-      <g
-         id="g53"
-         style="fill:#ffffff">
-        <path
-           d="m 19.191685,12.000931 c -3.926,0 -7.202279,3.877819 -7.202278,7.803819 l 10e-7,3.90191 c 1e-6,3.926 3.276277,7.303574 7.202277,7.303574 l 9.603037,0 c 3.925956,0 7.202277,-3.377573 7.202278,-7.303574 l 0,-3.90191 c 0,-3.926 -3.276278,-7.803819 -7.202278,-7.803819"
-           id="path55"
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           sodipodi:nodetypes="cssssssc" />
-        <path
-           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           inkscape:connector-curvature="0"
-           d="m 33.59624,25.729872 -12.003796,0 -4.801519,13.728941"
-           id="path57"
-           sodipodi:nodetypes="ccc" />
-      </g>
-    </g>
-  </g>
   <path
      style="fill:#000000;fill-opacity:0.19599998"
      d="M 15,7.0000005 20,12 20,7.0000005 Z"
      id="path6-0"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cccc" />
+  <g
+     transform="matrix(0.41653489,0,0,0.42084656,2.0059937,3.9494493)"
+     id="g49"
+     style="fill:#f9f9f9">
+    <g
+       clip-path="url(#clipPath-165128749-6)"
+       id="g51"
+       style="fill:#f9f9f9">
+      <!-- color: #474747 -->
+      <g
+         id="g53"
+         style="fill:#f9f9f9">
+        <path
+           style="fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 32,24 c -7.8,0 -13,5.000001 -13,10 0,3.562531 2.435063,6.996041 7.15,8.75 L 24.2,49 33.3,44 C 39.986316,43.726177 45,38.857013 45,34 45,29.000001 39.8,24 32,24 Z"
+           id="path55"
+           transform="matrix(0.92336896,0,0,0.95046518,-5.5546033,-10.810233)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sscccss" />
+      </g>
+    </g>
+  </g>
 </svg>

--- a/Numix/32/mimetypes/application-x-subrip.svg
+++ b/Numix/32/mimetypes/application-x-subrip.svg
@@ -13,7 +13,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="application-x-subrip.svg">
+   sodipodi:docname="application-x-subrip_32.svg">
   <metadata
      id="metadata14">
     <rdf:RDF>
@@ -54,6 +54,19 @@
            id="path19" />
       </g>
     </clipPath>
+    <clipPath
+       id="clipPath-165128749-1">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17-0">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19-9" />
+      </g>
+    </clipPath>
   </defs>
   <sodipodi:namedview
      pagecolor="#ffffff"
@@ -65,12 +78,12 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
-     inkscape:window-height="1016"
+     inkscape:window-height="1013"
      id="namedview10"
      showgrid="true"
-     inkscape:zoom="22.627417"
-     inkscape:cx="16.804755"
-     inkscape:cy="16.42353"
+     inkscape:zoom="16"
+     inkscape:cx="29.165508"
+     inkscape:cy="12.140018"
      inkscape:window-x="0"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
@@ -90,37 +103,32 @@
      d="m 19,0 8.992,9 -7.608615,0 C 19.711455,9 19,8.287913 19,7.6153849 L 19,0 Z"
      id="path8"
      inkscape:connector-curvature="0" />
-  <g
-     transform="matrix(0.58314884,0,0,0.52605821,2.0083911,5.6868117)"
-     id="g49"
-     style="fill:#ffffff">
-    <g
-       clip-path="url(#clipPath-165128749)"
-       id="g51"
-       style="fill:#ffffff">
-      <!-- color: #474747 -->
-      <g
-         id="g53"
-         style="fill:#ffffff">
-        <path
-           d="m 19.191685,12.000931 c -3.926,0 -7.202279,3.877819 -7.202278,7.803819 l 10e-7,3.90191 c 1e-6,3.926 3.276277,7.303574 7.202277,7.303574 l 9.603037,0 c 3.925956,0 7.202277,-3.377573 7.202278,-7.303574 l 0,-3.90191 c 0,-3.926 -3.276278,-7.803819 -7.202278,-7.803819"
-           id="path55"
-           inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           sodipodi:nodetypes="cssssssc" />
-        <path
-           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           inkscape:connector-curvature="0"
-           d="m 33.59624,27.60857 -13.032692,0 -5.144485,9.104455"
-           id="path57"
-           sodipodi:nodetypes="ccc" />
-      </g>
-    </g>
-  </g>
   <path
      style="fill:#000000;fill-opacity:0.19599998"
      d="m 21,9 7,7 0,-7 z"
      id="path6-4"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cccc" />
+  <g
+     transform="matrix(0.58314884,0,0,0.54710053,2.0083913,6.434284)"
+     id="g49"
+     style="fill:#f9f9f9">
+    <g
+       clip-path="url(#clipPath-165128749-1)"
+       id="g51"
+       style="fill:#f9f9f9">
+      <!-- color: #474747 -->
+      <g
+         id="g53"
+         style="fill:#f9f9f9">
+        <path
+           style="fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 32,24 c -7.428572,0 -13,4.615386 -13,9.615385 0,3.562531 2.754672,8.286369 7.428571,9.615384 L 24.571428,49 33.857143,43.230769 C 40.543459,42.956946 45,38.472398 45,33.615385 45,28.615386 39.428571,24 32,24 Z"
+           id="path55"
+           transform="matrix(0.92336896,0,0,0.95046518,-5.5546033,-10.810233)"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sscccss" />
+      </g>
+    </g>
+  </g>
 </svg>

--- a/Numix/48/mimetypes/application-x-subrip.svg
+++ b/Numix/48/mimetypes/application-x-subrip.svg
@@ -13,7 +13,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="application-x-subrip.svg">
+   sodipodi:docname="application-x-subrip_48.svg">
   <metadata
      id="metadata14">
     <rdf:RDF>
@@ -54,6 +54,19 @@
            id="path19" />
       </g>
     </clipPath>
+    <clipPath
+       id="clipPath-165128749-9">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17-3">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19-1" />
+      </g>
+    </clipPath>
   </defs>
   <sodipodi:namedview
      pagecolor="#ffffff"
@@ -65,12 +78,12 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
-     inkscape:window-height="1016"
+     inkscape:window-height="1013"
      id="namedview10"
-     showgrid="true"
-     inkscape:zoom="11.313709"
-     inkscape:cx="13.72126"
-     inkscape:cy="22.870994"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="-168.91605"
+     inkscape:cy="13.94584"
      inkscape:window-x="0"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
@@ -93,29 +106,24 @@
      d="m 29,1 13,13 -11,0 c -0.971429,0 -2,-1.028571 -2,-2 L 29,1 z"
      id="path8" />
   <g
-     transform="matrix(0.83306979,0,0,0.7688543,4.0119871,8.7730325)"
+     transform="matrix(0.83306977,0,0,0.79960846,4.0119875,9.4039538)"
      id="g49"
-     style="fill:#ffffff">
+     style="fill:#f9f9f9">
     <g
-       clip-path="url(#clipPath-165128749)"
+       clip-path="url(#clipPath-165128749-9)"
        id="g51"
-       style="fill:#ffffff">
+       style="fill:#f9f9f9">
       <!-- color: #474747 -->
       <g
          id="g53"
-         style="fill:#ffffff">
+         style="fill:#f9f9f9">
         <path
-           d="m 19.191685,12.000931 c -3.926,0 -7.202279,3.877819 -7.202278,7.803819 l 10e-7,3.90191 c 1e-6,3.926 3.276277,7.803819 7.202277,7.803819 l 9.603037,0 c 3.925956,0 7.202277,-3.877818 7.202278,-7.803819 l 0,-3.90191 c 0,-3.926 -3.276278,-7.803819 -7.202278,-7.803819"
+           style="fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="M 32.65,24 C 24.2,24 19,28.868422 19,33.868421 c 0,3.562531 2.435063,7.456567 7.15,9.210526 L 24.2,49 33.95,43.736842 C 40.636316,43.463019 45,38.725434 45,33.868421 45,28.868422 39.8,24 32.65,24 Z"
            id="path55"
+           transform="matrix(0.92336896,0,0,0.95046518,-5.5546033,-10.810233)"
            inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           sodipodi:nodetypes="cssssssc" />
-        <path
-           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           inkscape:connector-curvature="0"
-           d="m 33.59624,27.60857 -14.404555,0 -3.601139,9.104455"
-           id="path57"
-           sodipodi:nodetypes="ccc" />
+           sodipodi:nodetypes="sscccss" />
       </g>
     </g>
   </g>

--- a/Numix/64/mimetypes/application-x-subrip.svg
+++ b/Numix/64/mimetypes/application-x-subrip.svg
@@ -65,12 +65,12 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
-     inkscape:window-height="1016"
+     inkscape:window-height="1013"
      id="namedview10"
      showgrid="true"
-     inkscape:zoom="11.313709"
-     inkscape:cx="32.71283"
-     inkscape:cy="29.616764"
+     inkscape:zoom="11.313708"
+     inkscape:cx="47.143701"
+     inkscape:cy="31.942096"
      inkscape:window-x="0"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
@@ -91,29 +91,24 @@
      id="path8"
      inkscape:connector-curvature="0" />
   <g
-     transform="matrix(1.0829907,0,0,1.0521164,6.0155837,11.373623)"
+     transform="matrix(1.0829907,0,0,1.0521164,6.0155837,12.373623)"
      id="g49"
-     style="fill:#ffffff">
+     style="fill:#f9f9f9">
     <g
        clip-path="url(#clipPath-165128749)"
        id="g51"
-       style="fill:#ffffff">
+       style="fill:#f9f9f9">
       <!-- color: #474747 -->
       <g
          id="g53"
-         style="fill:#ffffff">
+         style="fill:#f9f9f9">
         <path
-           d="m 19.191685,12.000931 c -3.926,0 -7.202279,3.877819 -7.202278,7.803819 l 10e-7,3.90191 c 1e-6,3.926 3.276277,7.303575 7.202277,7.303575 l 9.603037,0 c 3.925956,0 7.202277,-3.377574 7.202278,-7.303575 l 0,-3.90191 c 0,-3.926 -3.276278,-7.803819 -7.202278,-7.803819"
+           style="fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 33,24 c -9,0 -14,5.000001 -14,10 0,3.562531 2.285063,7.246041 7,9 l -2,6 10,-5 C 40.686316,43.726177 45,38.857013 45,34 45,29.000001 39.999999,24 33,24 Z"
            id="path55"
+           transform="matrix(0.92336896,0,0,0.95046518,-5.5546033,-10.810233)"
            inkscape:connector-curvature="0"
-           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           sodipodi:nodetypes="cssssssc" />
-        <path
-           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           inkscape:connector-curvature="0"
-           d="m 33.226893,27.208374 -13.850534,0 -3.693476,9.504651"
-           id="path57"
-           sodipodi:nodetypes="ccc" />
+           sodipodi:nodetypes="sscccss" />
       </g>
     </g>
   </g>


### PR DESCRIPTION
- Changed color from ``#ffffff`` to ``#f9f9f9``
- Unified the two paths that composed the symbol
- Restyled the symbol to something not too squared

Actual:
![image](https://cloud.githubusercontent.com/assets/11244067/11920701/8a922f22-a75d-11e5-883d-2ca1114c8cee.png)![image](https://cloud.githubusercontent.com/assets/11244067/11920702/917c1bc2-a75d-11e5-88c7-cb1c1df38f2a.png)![image](https://cloud.githubusercontent.com/assets/11244067/11920703/96569bae-a75d-11e5-862d-65451ad6478f.png)![image](https://cloud.githubusercontent.com/assets/11244067/11920706/9b762cbc-a75d-11e5-90ee-406faf77f25e.png)![image](https://cloud.githubusercontent.com/assets/11244067/11920707/a08ffdf4-a75d-11e5-9b24-660f8d802e5a.png)![image](https://cloud.githubusercontent.com/assets/11244067/11920719/a4c4ff14-a75d-11e5-997a-727e6fce6c22.png)

New:
![image](https://cloud.githubusercontent.com/assets/11244067/11920674/243f6136-a75d-11e5-85d1-75133eda908b.png)![image](https://cloud.githubusercontent.com/assets/11244067/11920676/29bc4b06-a75d-11e5-8779-15f285b77ab0.png)![image](https://cloud.githubusercontent.com/assets/11244067/11920679/301a6d98-a75d-11e5-8a2c-e90d32c43ed4.png)![image](https://cloud.githubusercontent.com/assets/11244067/11920680/353dfb96-a75d-11e5-9c1e-6dcc5e2d53bf.png)![image](https://cloud.githubusercontent.com/assets/11244067/11920681/39989d7c-a75d-11e5-86b0-f2244841030b.png)![image](https://cloud.githubusercontent.com/assets/11244067/11920682/3e29e80a-a75d-11e5-8442-b38736bc3cf7.png)