### PR TITLE
Adds symlink for remmina-panel

### DIFF
--- a/Numix-Light/16/panel/remmina-panel.svg
+++ b/Numix-Light/16/panel/remmina-panel.svg
@@ -1,0 +1,1 @@
+disper-panel.svg

--- a/Numix-Light/16/panel/remmina-panel.svg
+++ b/Numix-Light/16/panel/remmina-panel.svg
@@ -1,1 +1,6 @@
-disper-panel.svg
+
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+ <path d="m 3.187 0.701 c -0.101 -0.003 -0.186 0.052 -0.186 0.121 l 0 2.419 c 0 0.038 0.027 0.075 0.073 0.097 l 4.627 2.322 -4.627 2.322 c -0.166 0.083 -0.026 0.259 0.168 0.211 l 9.642 -2.419 c 0.133 -0.033 0.158 -0.154 0.044 -0.211 l -9.642 -4.838 c -0.029 -0.014 -0.063 -0.023 -0.099 -0.024 z" style="visibility:visible;shape-rendering:auto;color-interpolation-filters:linearRGB;fill:#353535;opacity:1;image-rendering:auto;fill-opacity:1;text-rendering:auto;stroke:none;display:inline;color:#000;fill-rule:evenodd;color-rendering:auto;color-interpolation:sRGB"/>
+ <path d="m 12.813 15.299 c 0.101 0.003 0.186 -0.052 0.186 -0.121 l 0 -2.419 c 0 -0.038 -0.027 -0.075 -0.073 -0.097 l -4.627 -2.322 4.627 -2.322 c 0.166 -0.083 0.026 -0.259 -0.168 -0.211 l -9.642 2.419 c -0.133 0.033 -0.158 0.154 -0.044 0.211 l 9.642 4.838 c 0.029 0.014 0.063 0.023 0.099 0.024 z" style="visibility:visible;shape-rendering:auto;color-interpolation-filters:linearRGB;fill:#353535;opacity:1;image-rendering:auto;fill-opacity:1;text-rendering:auto;stroke:none;display:inline;color:#000;fill-rule:evenodd;color-rendering:auto;color-interpolation:sRGB"/>
+</svg>

--- a/Numix-Light/22/panel/remmina-panel.svg
+++ b/Numix-Light/22/panel/remmina-panel.svg
@@ -1,0 +1,1 @@
+disper-panel.svg

--- a/Numix-Light/22/panel/remmina-panel.svg
+++ b/Numix-Light/22/panel/remmina-panel.svg
@@ -1,1 +1,6 @@
-disper-panel.svg
+
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22">
+ <path d="m 5.224 2.241 c -0.122 -0.003 -0.223 0.063 -0.223 0.145 l 0 2.903 c 0 0.046 0.032 0.089 0.087 0.117 l 5.552 2.786 -5.552 2.786 c -0.199 0.1 -0.031 0.311 0.202 0.253 l 11.57 -2.903 c 0.16 -0.04 0.19 -0.184 0.053 -0.253 l -11.57 -5.806 c -0.035 -0.017 -0.076 -0.027 -0.119 -0.028 z" style="visibility:visible;shape-rendering:auto;color-interpolation-filters:linearRGB;fill:#353535;opacity:1;image-rendering:auto;fill-opacity:1;text-rendering:auto;stroke:none;display:inline;color:#000;fill-rule:evenodd;color-rendering:auto;color-interpolation:sRGB"/>
+ <path d="m 16.776 19.759 c 0.122 0.003 0.223 -0.063 0.223 -0.145 l 0 -2.903 c 0 -0.046 -0.032 -0.089 -0.087 -0.117 l -5.553 -2.786 5.553 -2.786 c 0.199 -0.1 0.031 -0.311 -0.202 -0.253 l -11.57 2.903 c -0.16 0.04 -0.19 0.184 -0.053 0.253 l 11.57 5.806 c 0.035 0.017 0.076 0.027 0.119 0.028 z" style="visibility:visible;shape-rendering:auto;color-interpolation-filters:linearRGB;fill:#353535;opacity:1;image-rendering:auto;fill-opacity:1;text-rendering:auto;stroke:none;display:inline;color:#000;fill-rule:evenodd;color-rendering:auto;color-interpolation:sRGB"/>
+</svg>

--- a/Numix-Light/24/panel/remmina-panel.svg
+++ b/Numix-Light/24/panel/remmina-panel.svg
@@ -1,0 +1,1 @@
+disper-panel.svg

--- a/Numix-Light/24/panel/remmina-panel.svg
+++ b/Numix-Light/24/panel/remmina-panel.svg
@@ -1,1 +1,6 @@
-disper-panel.svg
+
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+ <path style="visibility:visible;shape-rendering:auto;color-interpolation-filters:linearRGB;fill:#353535;opacity:1;image-rendering:auto;fill-opacity:1;text-rendering:auto;stroke:none;display:inline;color:#000;fill-rule:evenodd;color-rendering:auto;color-interpolation:sRGB" d="m 6.224 3.241 c -0.122 -0.003 -0.223 0.063 -0.223 0.145 l 0 2.903 c 0 0.046 0.032 0.089 0.087 0.117 l 5.552 2.786 -5.552 2.786 c -0.199 0.1 -0.031 0.311 0.202 0.253 l 11.57 -2.903 c 0.16 -0.04 0.19 -0.184 0.053 -0.253 l -11.57 -5.806 c -0.035 -0.017 -0.076 -0.027 -0.119 -0.028 z"/>
+ <path style="visibility:visible;shape-rendering:auto;color-interpolation-filters:linearRGB;fill:#353535;opacity:1;image-rendering:auto;fill-opacity:1;text-rendering:auto;stroke:none;display:inline;color:#000;fill-rule:evenodd;color-rendering:auto;color-interpolation:sRGB" d="m 17.776 20.759 c 0.122 0.003 0.223 -0.063 0.223 -0.145 l 0 -2.903 c 0 -0.046 -0.032 -0.089 -0.087 -0.117 l -5.553 -2.786 5.553 -2.786 c 0.199 -0.1 0.031 -0.311 -0.202 -0.253 l -11.57 2.903 c -0.16 0.04 -0.19 0.184 -0.053 0.253 l 11.57 5.806 c 0.035 0.017 0.076 0.027 0.119 0.028 z"/>
+</svg>

--- a/Numix/16/panel/remmina-panel.svg
+++ b/Numix/16/panel/remmina-panel.svg
@@ -1,0 +1,1 @@
+disper-panel.svg

--- a/Numix/16/panel/remmina-panel.svg
+++ b/Numix/16/panel/remmina-panel.svg
@@ -1,1 +1,6 @@
-disper-panel.svg
+
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+ <path style="visibility:visible;shape-rendering:auto;color-interpolation-filters:linearRGB;fill:#ececec;opacity:1;image-rendering:auto;fill-opacity:1;text-rendering:auto;stroke:none;display:inline;color:#000;fill-rule:evenodd;color-rendering:auto;color-interpolation:sRGB" d="m 3.187 0.701 c -0.101 -0.003 -0.186 0.052 -0.186 0.121 l 0 2.419 c 0 0.038 0.027 0.075 0.073 0.097 l 4.627 2.322 -4.627 2.322 c -0.166 0.083 -0.026 0.259 0.168 0.211 l 9.642 -2.419 c 0.133 -0.033 0.158 -0.154 0.044 -0.211 l -9.642 -4.838 c -0.029 -0.014 -0.063 -0.023 -0.099 -0.024 z"/>
+ <path style="visibility:visible;shape-rendering:auto;color-interpolation-filters:linearRGB;fill:#ececec;opacity:1;image-rendering:auto;fill-opacity:1;text-rendering:auto;stroke:none;display:inline;color:#000;fill-rule:evenodd;color-rendering:auto;color-interpolation:sRGB" d="m 12.813 15.299 c 0.101 0.003 0.186 -0.052 0.186 -0.121 l 0 -2.419 c 0 -0.038 -0.027 -0.075 -0.073 -0.097 l -4.627 -2.322 4.627 -2.322 c 0.166 -0.083 0.026 -0.259 -0.168 -0.211 l -9.642 2.419 c -0.133 0.033 -0.158 0.154 -0.044 0.211 l 9.642 4.838 c 0.029 0.014 0.063 0.023 0.099 0.024 z"/>
+</svg>

--- a/Numix/22/panel/remmina-panel.svg
+++ b/Numix/22/panel/remmina-panel.svg
@@ -1,0 +1,1 @@
+disper-panel.svg

--- a/Numix/22/panel/remmina-panel.svg
+++ b/Numix/22/panel/remmina-panel.svg
@@ -1,1 +1,6 @@
-disper-panel.svg
+
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg viewBox="0 0 22 22" xmlns="http://www.w3.org/2000/svg">
+ <path d="m 5.224 2.241 c -0.122 -0.003 -0.223 0.063 -0.223 0.145 l 0 2.903 c 0 0.046 0.032 0.089 0.087 0.117 l 5.552 2.786 -5.552 2.786 c -0.199 0.1 -0.031 0.311 0.202 0.253 l 11.57 -2.903 c 0.16 -0.04 0.19 -0.184 0.053 -0.253 l -11.57 -5.806 c -0.035 -0.017 -0.076 -0.027 -0.119 -0.028 z" style="visibility:visible;shape-rendering:auto;color-interpolation-filters:linearRGB;fill:#ececec;opacity:1;image-rendering:auto;fill-opacity:1;text-rendering:auto;stroke:none;display:inline;color:#000;fill-rule:evenodd;color-rendering:auto;color-interpolation:sRGB"/>
+ <path d="m 16.776 19.759 c 0.122 0.003 0.223 -0.063 0.223 -0.145 l 0 -2.903 c 0 -0.046 -0.032 -0.089 -0.087 -0.117 l -5.553 -2.786 5.553 -2.786 c 0.199 -0.1 0.031 -0.311 -0.202 -0.253 l -11.57 2.903 c -0.16 0.04 -0.19 0.184 -0.053 0.253 l 11.57 5.806 c 0.035 0.017 0.076 0.027 0.119 0.028 z" style="visibility:visible;shape-rendering:auto;color-interpolation-filters:linearRGB;fill:#ececec;opacity:1;image-rendering:auto;fill-opacity:1;text-rendering:auto;stroke:none;display:inline;color:#000;fill-rule:evenodd;color-rendering:auto;color-interpolation:sRGB"/>
+</svg>

--- a/Numix/24/panel/remmina-panel.svg
+++ b/Numix/24/panel/remmina-panel.svg
@@ -1,0 +1,1 @@
+disper-panel.svg

--- a/Numix/24/panel/remmina-panel.svg
+++ b/Numix/24/panel/remmina-panel.svg
@@ -1,1 +1,6 @@
-disper-panel.svg
+
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+ <path d="m 6.224 3.241 c -0.122 -0.003 -0.223 0.063 -0.223 0.145 l 0 2.903 c 0 0.046 0.032 0.089 0.087 0.117 l 5.552 2.786 -5.552 2.786 c -0.199 0.1 -0.031 0.311 0.202 0.253 l 11.57 -2.903 c 0.16 -0.04 0.19 -0.184 0.053 -0.253 l -11.57 -5.806 c -0.035 -0.017 -0.076 -0.027 -0.119 -0.028 z" style="visibility:visible;shape-rendering:auto;color-interpolation-filters:linearRGB;fill:#ececec;opacity:1;image-rendering:auto;fill-opacity:1;text-rendering:auto;stroke:none;display:inline;color:#000;fill-rule:evenodd;color-rendering:auto;color-interpolation:sRGB"/>
+ <path d="m 17.776 20.759 c 0.122 0.003 0.223 -0.063 0.223 -0.145 l 0 -2.903 c 0 -0.046 -0.032 -0.089 -0.087 -0.117 l -5.553 -2.786 5.553 -2.786 c 0.199 -0.1 0.031 -0.311 -0.202 -0.253 l -11.57 2.903 c -0.16 0.04 -0.19 0.184 -0.053 0.253 l 11.57 5.806 c 0.035 0.017 0.076 0.027 0.119 0.028 z" style="visibility:visible;shape-rendering:auto;color-interpolation-filters:linearRGB;fill:#ececec;opacity:1;image-rendering:auto;fill-opacity:1;text-rendering:auto;stroke:none;display:inline;color:#000;fill-rule:evenodd;color-rendering:auto;color-interpolation:sRGB"/>
+</svg>


### PR DESCRIPTION
Remmina now allows seperate theming of their tray icons: https://github.com/FreeRDP/Remmina/pull/894

A symlink to disper-panel should be spot-on

EDIT: Revisited the icon and added a unique icon (if someone has disper and remmina installed a symlink might be a bad idea). I've added something close to the "official" remmina icon http://www.remmina.org/wp/