### PR TITLE
Adds node-* icons

### DIFF
--- a/Numix/16/actions/format-segment-curve.svg
+++ b/Numix/16/actions/format-segment-curve.svg
@@ -1,0 +1,1 @@
+segment-curve.svg

--- a/Numix/16/actions/format-segment-line.svg
+++ b/Numix/16/actions/format-segment-line.svg
@@ -1,0 +1,1 @@
+segment-line.svg

--- a/Numix/16/actions/node-add.svg
+++ b/Numix/16/actions/node-add.svg
@@ -1,0 +1,12 @@
+
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+ <rect width="1" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" x="2.053" y="3.5" height="9"/>
+ <rect width="1" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" x="2" y="-12.5" transform="matrix(0 1 -1 0 0 0)" height="9"/>
+ <circle r="1" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:round;stroke-width:1;stroke-dashoffset:0" cx="2.5" cy="2.5"/>
+ <rect width="1" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" x="13" y="3.5" height="6.5"/>
+ <rect width="2" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" x="12.5" y="1.5" height="2"/>
+ <rect width="1" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" x="13" y="-10" transform="matrix(0 1 -1 0 0 0)" height="6.5"/>
+ <rect width="2" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" x="1.5" y="12.5" height="2"/>
+ <path style="fill:#859900" d="m 16 13 -2 0 l 0 -2 l -1 0 0 2 -2 0 0 1 2 0 l 0 2 l 1 0 0 -2 2 0 z"/>
+</svg>

--- a/Numix/16/actions/node-break.svg
+++ b/Numix/16/actions/node-break.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+ <rect transform="matrix(0 -1 1 0 0 0)" x="-14" height="2.5" y="3.5" width="1" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <path style="fill:#cb4b16" d="m 8 10 2.5 -3 -5 0 z"/>
+ <rect transform="matrix(0 -1 1 0 0 0)" height="5.5" x="-3" y="1" width="0.991" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <rect transform="matrix(0 -1 1 0 0 0)" x="-3" height="5.5" y="9.5" width="0.991" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <rect height="3" x="6.5" y="0.5" width="3" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0"/>
+ <rect height="2" x="1.5" y="12.5" width="2" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0"/>
+ <rect transform="matrix(0 -1 -1 0 0 0)" height="2.5" x="-14" y="-12.5" width="1" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <rect height="2" width="2" x="-14.5" transform="matrix(-1 0 0 1 0 0)" y="12.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0"/>
+</svg>

--- a/Numix/16/actions/node-cusp.svg
+++ b/Numix/16/actions/node-cusp.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1" d="m 0 1.5 c 2.649 0 7.405 11.475 7.405 11.475"/>
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1" d="m 9.456 13.07 c 4.415 -2.061 6.04 -7.099 6.04 -12.07"/>
+ <path style="stroke-dasharray:2 2;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" d="m 8.5 1 0 10"/>
+ <path style="stroke-dasharray:2 2;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" d="m 16 13.5 -6 0"/>
+ <rect x="-4.662" y="14.683" transform="matrix(0.70711 -0.70711 0.70711 0.70711 0 0)" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" width="2" height="2"/>
+</svg>

--- a/Numix/16/actions/node-delete-segment.svg
+++ b/Numix/16/actions/node-delete-segment.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+ <rect width="1" x="-14" height="2.5" y="3.5" transform="matrix(0 -1 1 0 0 0)" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <path d="m 8 10 2.5 -3 -5 0 z" style="fill:#cb4b16"/>
+ <rect width="2" x="1.5" height="2" y="12.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0"/>
+ <rect width="1" height="2.5" x="-14" y="-12.5" transform="matrix(0 -1 -1 0 0 0)" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <rect style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" transform="matrix(-1 0 0 1 0 0)" width="2" x="-14.5" y="12.5" height="2"/>
+ <rect width="1" height="9" x="-3" y="3.5" transform="matrix(0 -1 1 0 0 0)" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <rect width="2" x="1.5" height="2" y="1.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0"/>
+ <rect style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" transform="matrix(-1 0 0 1 0 0)" width="2" x="-14.5" y="1.5" height="2"/>
+</svg>

--- a/Numix/16/actions/node-delete.svg
+++ b/Numix/16/actions/node-delete.svg
@@ -1,0 +1,12 @@
+
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="3.5" x="2.053" width="1" height="9"/>
+ <rect transform="matrix(0 1 -1 0 0 0)" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="-12.5" x="2" width="1" height="9"/>
+ <circle style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:round;stroke-width:1;stroke-dashoffset:0" cy="2.5" cx="2.5" r="1"/>
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="3.5" x="13" width="1" height="6.5"/>
+ <rect style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" y="1.5" x="12.5" width="2" height="2"/>
+ <rect transform="matrix(0 1 -1 0 0 0)" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="-10" x="13" width="1" height="6.5"/>
+ <rect style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" y="12.5" x="1.5" width="2" height="2"/>
+ <path d="m 15.621 14.914 -1.414 -1.414 1.414 -1.414 -0.707 -0.707 -1.414 1.414 -1.414 -1.414 -0.707 0.707 1.414 1.414 -1.414 1.414 0.707 0.707 1.414 -1.414 1.414 1.414 z" style="fill:#dc322f;fill-opacity:1"/>
+</svg>

--- a/Numix/16/actions/node-join-segment.svg
+++ b/Numix/16/actions/node-join-segment.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+ <rect x="2" y="3.5" width="1" transform="matrix(0 1 1 0 0 0)" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" height="2.5"/>
+ <path d="m 8 10 2.5 -3 -5 0 z" style="fill:#cb4b16"/>
+ <rect width="2" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" height="2" transform="matrix(1 0 0 -1 0 0)" x="1.5" y="-3.5"/>
+ <rect x="2" y="-12.5" transform="matrix(0 1 -1 0 0 0)" width="1" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" height="2.5"/>
+ <rect width="2" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" height="2" transform="matrix(-1 0 0 -1 0 0)" x="-14.5" y="-3.5"/>
+ <rect x="13" y="3.5" transform="matrix(0 1 1 0 0 0)" width="1" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" height="9"/>
+ <rect width="2" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" height="2" transform="matrix(1 0 0 -1 0 0)" x="1.5" y="-14.5"/>
+ <rect width="2" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" height="2" transform="matrix(-1 0 0 -1 0 0)" x="-14.5" y="-14.5"/>
+</svg>

--- a/Numix/16/actions/node-join.svg
+++ b/Numix/16/actions/node-join.svg
@@ -1,0 +1,10 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+ <rect width="1" x="2" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="3.5" height="2.5" transform="matrix(0 1 1 0 0 0)"/>
+ <path style="fill:#cb4b16" d="m 8 10 2.5 -3 -5 0 z"/>
+ <rect width="0.991" x="13" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="1" height="5.5" transform="matrix(0 1 1 0 0 0)"/>
+ <rect width="0.991" x="13" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="9.5" height="5.5" transform="matrix(0 1 1 0 0 0)"/>
+ <rect height="3" transform="matrix(1 0 0 -1 0 0)" width="3" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" x="6.5" y="-15.5"/>
+ <rect height="2" transform="matrix(1 0 0 -1 0 0)" width="2" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" x="1.5" y="-3.5"/>
+ <rect width="1" x="2" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="-12.5" height="2.5" transform="matrix(0 1 -1 0 0 0)"/>
+ <rect height="2" transform="matrix(-1 0 0 -1 0 0)" width="2" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" x="-14.5" y="-3.5"/>
+</svg>

--- a/Numix/16/actions/node-segment-curve.svg
+++ b/Numix/16/actions/node-segment-curve.svg
@@ -1,0 +1,1 @@
+segment-curve.svg

--- a/Numix/16/actions/node-segment-line.svg
+++ b/Numix/16/actions/node-segment-line.svg
@@ -1,0 +1,1 @@
+segment-line.svg

--- a/Numix/16/actions/node-smooth.svg
+++ b/Numix/16/actions/node-smooth.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1" d="m 0.5 1 c 0 11.122 6.094 11.501 6.094 11.501"/>
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1" d="m 15.5 1 c 0 11.122 -6.094 11.501 -6.094 11.501"/>
+ <rect x="6.733" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" height="3" width="3" y="11.595"/>
+</svg>

--- a/Numix/16/actions/node-symmetric.svg
+++ b/Numix/16/actions/node-symmetric.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+ <path d="m 0.5 1 c 0 11.122 6.094 11.501 6.094 11.501" style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1"/>
+ <path d="m 15.5 1 c 0 11.122 -6.094 11.501 -6.094 11.501" style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1"/>
+ <rect width="3" height="3" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" y="11.5" x="6.5"/>
+ <path d="m 7 13.5 -5 0" style="stroke-dasharray:2 2;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0"/>
+ <path d="m 9 13.5 5 0" style="stroke-dasharray:2 2;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0"/>
+ <rect width="2" height="2" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" y="12.5" x="0.5"/>
+ <rect y="12.5" x="-15.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" transform="matrix(-1 0 0 1 0 0)" width="2" height="2"/>
+</svg>

--- a/Numix/16/actions/node-type-auto-smooth.svg
+++ b/Numix/16/actions/node-type-auto-smooth.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1" d="m 0.5 1 c 0 11.122 6.094 11.501 6.094 11.501"/>
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1" d="m 15.5 1 c 0 11.122 -6.094 11.501 -6.094 11.501"/>
+ <circle style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:round;stroke-width:1;stroke-dashoffset:0" cy="13" cx="8" r="1.5"/>
+</svg>

--- a/Numix/16/actions/node-type-cusp.svg
+++ b/Numix/16/actions/node-type-cusp.svg
@@ -1,0 +1,1 @@
+node-cusp.svg

--- a/Numix/16/actions/node-type-smooth.svg
+++ b/Numix/16/actions/node-type-smooth.svg
@@ -1,0 +1,1 @@
+node-smooth.svg

--- a/Numix/16/actions/node-type-symmetric.svg
+++ b/Numix/16/actions/node-type-symmetric.svg
@@ -1,0 +1,1 @@
+node-symmetric.svg

--- a/Numix/16/actions/segment-curve.svg
+++ b/Numix/16/actions/segment-curve.svg
@@ -1,6 +1,7 @@
+
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
- <path d="m 12 1 0 3 l 3 0 0 -3 z m 1 1 1 0 0 1 -1 0 z" style="fill:#888;opacity:1;fill-opacity:1;stroke:none"/>
- <path d="M -2.5 -12 A 9.5 9.5 0 0 1 -12 -2.5" transform="matrix(0,-1,-1,0,0,0)" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;fill-opacity:1;stroke:#dc322f;fill-rule:nonzero;stroke-linecap:butt;stroke-linejoin:round;stroke-width:1.5;stroke-dashoffset:0"/>
- <path d="m 1 12 0 3 l 3 0 0 -3 z m 1 1 1 0 0 1 -1 0 z" style="fill:#888;opacity:1;fill-opacity:1;stroke:none"/>
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+ <path style="fill:#313131;opacity:1;fill-opacity:1;stroke:none" d="m 12 1 0 3 l 3 0 0 -3 z m 1 1 1 0 0 1 -1 0 z"/>
+ <path transform="matrix(0 -1 -1 0 0 0)" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#dc322f;stroke-linecap:butt;stroke-linejoin:round;stroke-width:1.5;stroke-dashoffset:0" d="M -2.5 -12 A 9.5 9.5 0 0 1 -12 -2.5"/>
+ <path style="fill:#313131;opacity:1;fill-opacity:1;stroke:none" d="m 1 12 0 3 l 3 0 0 -3 z m 1 1 1 0 0 1 -1 0 z"/>
 </svg>

--- a/Numix/16/actions/segment-line.svg
+++ b/Numix/16/actions/segment-line.svg
@@ -1,6 +1,7 @@
+
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
- <rect width="13" height="1.5" x="-6.5" y="10.564" transform="matrix(0.70710678,-0.70710678,0.70710678,0.70710678,0,0)" style="fill:#dc322f;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
- <path d="m 12 1 0 3 l 3 0 0 -3 z m 1 1 1 0 0 1 -1 0 z" style="fill:#888;opacity:1;fill-opacity:1;stroke:none"/>
- <path d="m 1 12 0 3 l 3 0 0 -3 z m 1 1 1 0 0 1 -1 0 z" style="fill:#888;opacity:1;fill-opacity:1;stroke:none"/>
+ <rect style="fill:#dc322f;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" width="13" transform="matrix(0.70711 -0.70711 0.70711 0.70711 0 0)" x="-6.5" y="10.564" height="1.5"/>
+ <path style="fill:#313131;opacity:1;fill-opacity:1;stroke:none" d="m 12 1 0 3 l 3 0 0 -3 z m 1 1 1 0 0 1 -1 0 z"/>
+ <path style="fill:#313131;opacity:1;fill-opacity:1;stroke:none" d="m 1 12 0 3 l 3 0 0 -3 z m 1 1 1 0 0 1 -1 0 z"/>
 </svg>

--- a/Numix/22/actions/format-segment-curve.svg
+++ b/Numix/22/actions/format-segment-curve.svg
@@ -1,0 +1,1 @@
+segment-curve.svg

--- a/Numix/22/actions/format-segment-line.svg
+++ b/Numix/22/actions/format-segment-line.svg
@@ -1,0 +1,1 @@
+segment-line.svg

--- a/Numix/22/actions/node-add.svg
+++ b/Numix/22/actions/node-add.svg
@@ -1,0 +1,12 @@
+
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg viewBox="0 0 22 22" xmlns="http://www.w3.org/2000/svg">
+ <rect x="4" y="5.5" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" height="11" width="1"/>
+ <rect x="4" y="-16.5" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" height="11" width="1" transform="matrix(0 1 -1 0 0 0)"/>
+ <circle style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:round;stroke-width:1;stroke-dashoffset:0" cx="4" cy="4" r="1.5"/>
+ <rect x="17" y="5.5" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" height="6.5" width="1"/>
+ <rect x="16.5" y="2.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" height="3" width="3"/>
+ <rect x="17" y="-12" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" height="6.5" transform="matrix(0 1 -1 0 0 0)" width="1"/>
+ <rect x="2.5" y="16.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" height="3" width="3"/>
+ <path style="fill:#859900" d="m 22 16 -3 0 0 -3 -3 0 0 3 -3 0 0 3 3 0 0 3 3 0 0 -3 3 0 z"/>
+</svg>

--- a/Numix/22/actions/node-break.svg
+++ b/Numix/22/actions/node-break.svg
@@ -1,0 +1,10 @@
+<svg viewBox="0 0 22 22" xmlns="http://www.w3.org/2000/svg">
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" x="3" y="-9.5" transform="matrix(0 1 -1 0 0 0)" height="5.5" width="1"/>
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" x="18" y="-8" transform="matrix(0 1 -1 0 0 0)" height="3.25" width="1"/>
+ <rect style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" x="2.5" y="17.5" height="2" width="2"/>
+ <path d="M 11,13 14,9 8,9 Z" style="fill:#cb4b16"/>
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" x="18" y="-17.25" transform="matrix(0 1 -1 0 0 0)" height="3.25" width="1"/>
+ <rect style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" x="17.5" y="17.5" height="2" width="2"/>
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" x="3" y="-18" transform="matrix(0 1 -1 0 0 0)" height="5.5" width="1"/>
+ <rect x="9.5" y="-4.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" transform="matrix(1 0 0 -1 0 0)" height="3" width="3"/>
+</svg>

--- a/Numix/22/actions/node-cusp.svg
+++ b/Numix/22/actions/node-cusp.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 22 22" xmlns="http://www.w3.org/2000/svg">
+ <path d="m 2 3.5 c 3 0 8.5 11.461 8.5 11.461" style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1"/>
+ <path d="m 12.608 15.5 c 5 -2 6.892 -9.5 6.892 -12.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1"/>
+ <rect height="3" transform="matrix(0.70711 -0.70711 0.70711 0.70711 0 0)" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" x="-5.03" y="18.303" width="3"/>
+ <path d="m 11.506 3 0 11" style="stroke-dasharray:2 2;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0"/>
+ <path d="m 20 16.5 -7 0" style="stroke-dasharray:2 2;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0"/>
+</svg>

--- a/Numix/22/actions/node-delete-segment.svg
+++ b/Numix/22/actions/node-delete-segment.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+ <rect height="12" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" width="1" x="4" y="-18" transform="matrix(0 1 -1 0 0 0)"/>
+ <rect height="3.25" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" width="1" x="19" y="-9" transform="matrix(0 1 -1 0 0 0)"/>
+ <rect height="2" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" width="2" x="3.5" y="18.5"/>
+ <path style="fill:#cb4b16" d="m 12 14 3 -4 -6 0 z"/>
+ <rect height="3.25" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" width="1" x="19" y="-18.25" transform="matrix(0 1 -1 0 0 0)"/>
+ <rect height="2" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" width="2" x="18.5" y="18.5"/>
+ <rect height="2" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" width="2" x="3.5" y="3.5"/>
+ <rect height="2" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" width="2" x="18.5" y="3.5"/>
+</svg>

--- a/Numix/22/actions/node-delete.svg
+++ b/Numix/22/actions/node-delete.svg
@@ -1,0 +1,12 @@
+
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22">
+ <rect height="11" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="5.5" x="4" width="1"/>
+ <rect height="11" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="-16.5" width="1" x="4" transform="matrix(0 1 -1 0 0 0)"/>
+ <circle r="1.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:round;stroke-width:1;stroke-dashoffset:0" cy="4" cx="4"/>
+ <rect height="6.5" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="5.5" width="1" x="17"/>
+ <rect height="3" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" y="2.5" width="3" x="16.5"/>
+ <rect height="6.5" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="-12" x="17" width="1" transform="matrix(0 1 -1 0 0 0)"/>
+ <rect height="3" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" y="16.5" width="3" x="2.5"/>
+ <path style="fill:#dc322f;fill-opacity:1" d="m 21.743 19.621 -2.121 -2.121 2.121 -2.121 -2.121 -2.121 -2.121 2.121 -2.121 -2.121 -2.121 2.121 2.121 2.121 -2.121 2.121 2.121 2.121 2.121 -2.121 l 2.121 2.121 z"/>
+</svg>

--- a/Numix/22/actions/node-join-segment.svg
+++ b/Numix/22/actions/node-join-segment.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22">
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" x="-19" width="1" y="-17" height="12" transform="matrix(0 -1 -1 0 0 0)"/>
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" x="-4" height="3.25" y="-8" width="1" transform="matrix(0 -1 -1 0 0 0)"/>
+ <rect transform="matrix(1 0 0 -1 0 0)" height="2" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" width="2" x="2.5" y="-4.5"/>
+ <path d="M 11,13 14,9 8,9 Z" style="fill:#cb4b16"/>
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" x="-4" width="1" y="-17.25" height="3.25" transform="matrix(0 -1 -1 0 0 0)"/>
+ <rect transform="matrix(1 0 0 -1 0 0)" height="2" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" width="2" x="17.5" y="-4.5"/>
+ <rect transform="matrix(1 0 0 -1 0 0)" height="2" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" width="2" x="2.5" y="-19.5"/>
+ <rect transform="matrix(1 0 0 -1 0 0)" height="2" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" width="2" x="17.5" y="-19.5"/>
+</svg>

--- a/Numix/22/actions/node-join.svg
+++ b/Numix/22/actions/node-join.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22">
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" height="5.5" y="-9.5" transform="matrix(0 -1 -1 0 0 0)" x="-19" width="1"/>
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" height="3.25" transform="matrix(0 -1 -1 0 0 0)" y="-8" x="-4" width="1"/>
+ <rect style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" height="2" width="2" y="-4.5" x="2.5" transform="matrix(1 0 0 -1 0 0)"/>
+ <path style="fill:#cb4b16" d="M 11,13 14,9 8,9 Z"/>
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" height="3.25" y="-17.25" transform="matrix(0 -1 -1 0 0 0)" x="-4" width="1"/>
+ <rect style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" height="2" width="2" y="-4.5" x="17.5" transform="matrix(1 0 0 -1 0 0)"/>
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" height="5.5" transform="matrix(0 -1 -1 0 0 0)" y="-18" x="-19" width="1"/>
+ <rect style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" height="3" y="17.5" x="9.5" width="3"/>
+</svg>

--- a/Numix/22/actions/node-segment-curve.svg
+++ b/Numix/22/actions/node-segment-curve.svg
@@ -1,0 +1,1 @@
+segment-curve.svg

--- a/Numix/22/actions/node-segment-line.svg
+++ b/Numix/22/actions/node-segment-line.svg
@@ -1,0 +1,1 @@
+segment-line.svg

--- a/Numix/22/actions/node-smooth.svg
+++ b/Numix/22/actions/node-smooth.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22">
+ <path d="m 2.5 4 c 0 11 7 11.5 7 11.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1"/>
+ <path d="m 19.5 4 c 0 11 -7 11.5 -7 11.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1"/>
+ <rect height="3" width="3" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" x="9.5" y="14.5"/>
+</svg>

--- a/Numix/22/actions/node-symmetric.svg
+++ b/Numix/22/actions/node-symmetric.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22">
+ <path d="m 2.5 4 c 0 11 7 11.5 7 11.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1"/>
+ <path d="m 19.5 4 c 0 11 -7 11.5 -7 11.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1"/>
+ <rect x="9.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" height="3" width="3" y="14.5"/>
+ <path d="m 12 16.5 8 0" style="stroke-dasharray:2 2;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0"/>
+ <rect transform="matrix(-1 0 0 1 0 0)" y="15.5" x="-19.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" height="2" width="2"/>
+ <path d="m 10 16.5 -8 0" style="stroke-dasharray:2 2;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0"/>
+ <rect x="2.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" height="2" width="2" y="15.5"/>
+</svg>

--- a/Numix/22/actions/node-type-auto-smooth.svg
+++ b/Numix/22/actions/node-type-auto-smooth.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22">
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1" d="m 2.5 4 c 0 11 7 11.5 7 11.5"/>
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1" d="m 19.5 4 c 0 11 -7 11.5 -7 11.5"/>
+ <circle style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" cy="16" cx="11" r="1.5"/>
+</svg>

--- a/Numix/22/actions/node-type-cusp.svg
+++ b/Numix/22/actions/node-type-cusp.svg
@@ -1,0 +1,1 @@
+node-cusp.svg

--- a/Numix/22/actions/node-type-smooth.svg
+++ b/Numix/22/actions/node-type-smooth.svg
@@ -1,0 +1,1 @@
+node-smooth.svg

--- a/Numix/22/actions/node-type-symmetric.svg
+++ b/Numix/22/actions/node-type-symmetric.svg
@@ -1,0 +1,1 @@
+node-symmetric.svg

--- a/Numix/22/actions/segment-curve.svg
+++ b/Numix/22/actions/segment-curve.svg
@@ -1,6 +1,7 @@
+
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22">
- <path d="M -3.5 -17 A 13.5 13.5 0 0 1 -17 -3.5" transform="matrix(0,-1,-1,0,0,0)" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;fill-opacity:1;stroke:#dc322f;fill-rule:nonzero;stroke-linecap:square;stroke-linejoin:round;stroke-width:1.5;stroke-dashoffset:0"/>
- <path d="m 17 2 0 3 3 0 0 -3 z m 1 1 1 0 0 1 -1 0 z" style="fill:#888;opacity:1;fill-opacity:1;stroke:none"/>
- <path d="m 2 17 0 3 l 3 0 0 -3 z m 1 1 1 0 0 1 -1 0 z" style="fill:#888;opacity:1;fill-opacity:1;stroke:none"/>
+ <path transform="matrix(0 -1 -1 0 0 0)" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#dc322f;stroke-linecap:square;stroke-linejoin:round;stroke-width:1.5;stroke-dashoffset:0" d="M -3.5 -17 A 13.5 13.5 0 0 1 -17 -3.5"/>
+ <path style="fill:#313131;opacity:1;fill-opacity:1;stroke:none" d="m 17 2 0 3 3 0 0 -3 z m 1 1 1 0 0 1 -1 0 z"/>
+ <path style="fill:#313131;opacity:1;fill-opacity:1;stroke:none" d="m 2 17 0 3 l 3 0 0 -3 z m 1 1 1 0 0 1 -1 0 z"/>
 </svg>

--- a/Numix/22/actions/segment-line.svg
+++ b/Numix/22/actions/segment-line.svg
@@ -1,6 +1,7 @@
+
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22">
- <rect width="19" height="1.5" x="-9.5" y="14.806" transform="matrix(0.70710678,-0.70710678,0.70710678,0.70710678,0,0)" style="fill:#dc322f;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
- <path d="m 17 2 0 3 3 0 0 -3 z m 1 1 1 0 0 1 -1 0 z" style="fill:#888;opacity:1;fill-opacity:1;stroke:none"/>
- <path d="m 2 17 0 3 3 0 0 -3 z m 1 1 1 0 0 1 -1 0 z" style="fill:#888;opacity:1;fill-opacity:1;stroke:none"/>
+ <rect width="19" style="fill:#dc322f;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" height="1.5" transform="matrix(0.70711 -0.70711 0.70711 0.70711 0 0)" x="-9.5" y="14.806"/>
+ <path d="m 17 2 0 3 3 0 0 -3 z m 1 1 1 0 0 1 -1 0 z" style="fill:#313131;opacity:1;fill-opacity:1;stroke:none"/>
+ <path d="m 2 17 0 3 3 0 0 -3 z m 1 1 1 0 0 1 -1 0 z" style="fill:#313131;opacity:1;fill-opacity:1;stroke:none"/>
 </svg>

--- a/Numix/24/actions/format-segment-curve.svg
+++ b/Numix/24/actions/format-segment-curve.svg
@@ -1,0 +1,1 @@
+segment-curve.svg

--- a/Numix/24/actions/format-segment-line.svg
+++ b/Numix/24/actions/format-segment-line.svg
@@ -1,0 +1,1 @@
+segment-line.svg

--- a/Numix/24/actions/node-add.svg
+++ b/Numix/24/actions/node-add.svg
@@ -1,0 +1,12 @@
+
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+ <rect y="6.5" x="5" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" width="1" height="11"/>
+ <rect y="-17.5" x="5" transform="matrix(0 1 -1 0 0 0)" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" width="1" height="11"/>
+ <circle cy="5" cx="5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:round;stroke-width:1;stroke-dashoffset:0" r="1.5"/>
+ <rect y="6.5" x="18" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" width="1" height="6.5"/>
+ <rect y="3.5" x="17.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" width="3" height="3"/>
+ <rect y="-13" x="18" transform="matrix(0 1 -1 0 0 0)" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" width="1" height="6.5"/>
+ <rect y="17.5" x="3.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" width="3" height="3"/>
+ <path style="fill:#859900" d="m 23 17 -3 0 0 -3 -3 0 0 3 -3 0 0 3 3 0 0 3 3 0 0 -3 3 0 z"/>
+</svg>

--- a/Numix/24/actions/node-break.svg
+++ b/Numix/24/actions/node-break.svg
@@ -1,0 +1,10 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="-10.5" x="4" height="5.5" width="1" transform="matrix(0 1 -1 0 0 0)"/>
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="-9" x="19" height="3.25" transform="matrix(0 1 -1 0 0 0)" width="1"/>
+ <rect style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" y="18.5" x="3.5" height="2" width="2"/>
+ <path style="fill:#cb4b16" d="m 12 14 3 -4 -6 0 z"/>
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="-18.25" x="19" height="3.25" width="1" transform="matrix(0 1 -1 0 0 0)"/>
+ <rect style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" y="18.5" x="18.5" height="2" width="2"/>
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="-19" x="4" height="5.5" transform="matrix(0 1 -1 0 0 0)" width="1"/>
+ <rect transform="matrix(1 0 0 -1 0 0)" height="3" y="-5.5" x="10.5" width="3" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0"/>
+</svg>

--- a/Numix/24/actions/node-cusp.svg
+++ b/Numix/24/actions/node-cusp.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1" d="m 3 4.5 c 3 0 8.5 11.461 8.5 11.461"/>
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1" d="m 13.608 16.5 c 5 -2 6.892 -9.5 6.892 -12.5"/>
+ <rect width="3" y="19.717" x="-5.03" height="3" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" transform="matrix(0.70711 -0.70711 0.70711 0.70711 0 0)"/>
+ <path style="stroke-dasharray:2 2;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" d="m 12.506 4 0 11"/>
+ <path style="stroke-dasharray:2 2;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" d="m 21 17.5 -7 0"/>
+</svg>

--- a/Numix/24/actions/node-delete.svg
+++ b/Numix/24/actions/node-delete.svg
@@ -1,0 +1,12 @@
+
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" width="1" height="11" x="5" y="6.5"/>
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" width="1" height="11" x="5" transform="matrix(0 1 -1 0 0 0)" y="-17.5"/>
+ <circle r="1.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:round;stroke-width:1;stroke-dashoffset:0" cx="5" cy="5"/>
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" width="1" height="6.5" x="18" y="6.5"/>
+ <rect style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" width="3" height="3" x="17.5" y="3.5"/>
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" width="1" height="6.5" transform="matrix(0 1 -1 0 0 0)" x="18" y="-13"/>
+ <rect style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" width="3" height="3" x="3.5" y="17.5"/>
+ <path d="m 22.743 20.621 -2.121 -2.121 2.121 -2.121 -2.121 -2.121 -2.121 2.121 -2.121 -2.121 -2.121 2.121 2.121 2.121 -2.121 2.121 2.121 2.121 2.121 -2.121 l 2.121 2.121 z" style="fill:#dc322f;fill-opacity:1"/>
+</svg>

--- a/Numix/24/actions/node-join-segment.svg
+++ b/Numix/24/actions/node-join-segment.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+ <rect height="12" transform="matrix(0 -1 -1 0 0 0)" y="-18" x="-20" width="1" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <rect height="3.25" transform="matrix(0 -1 -1 0 0 0)" y="-9" x="-5" width="1" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <rect width="2" height="2" transform="matrix(1 0 0 -1 0 0)" y="-5.5" x="3.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0"/>
+ <path d="m 12 14 3 -4 -6 0 z" style="fill:#cb4b16"/>
+ <rect height="3.25" transform="matrix(0 -1 -1 0 0 0)" y="-18.25" x="-5" width="1" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <rect width="2" height="2" transform="matrix(1 0 0 -1 0 0)" y="-5.5" x="18.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0"/>
+ <rect width="2" height="2" transform="matrix(1 0 0 -1 0 0)" y="-20.5" x="3.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0"/>
+ <rect width="2" height="2" transform="matrix(1 0 0 -1 0 0)" y="-20.5" x="18.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0"/>
+</svg>

--- a/Numix/24/actions/node-join.svg
+++ b/Numix/24/actions/node-join.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+ <rect x="-20" y="-10.5" width="1" transform="matrix(0 -1 -1 0 0 0)" height="5.5" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <rect x="-5" y="-9" transform="matrix(0 -1 -1 0 0 0)" width="1" height="3.25" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <rect height="2" width="2" x="3.5" y="-5.5" transform="matrix(1 0 0 -1 0 0)" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0"/>
+ <path d="m 12 14 3 -4 -6 0 z" style="fill:#cb4b16"/>
+ <rect x="-5" y="-18.25" width="1" transform="matrix(0 -1 -1 0 0 0)" height="3.25" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <rect height="2" width="2" x="18.5" y="-5.5" transform="matrix(1 0 0 -1 0 0)" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0"/>
+ <rect x="-20" y="-19" transform="matrix(0 -1 -1 0 0 0)" width="1" height="5.5" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <rect x="10.5" y="18.5" width="3" height="3" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0"/>
+</svg>

--- a/Numix/24/actions/node-segment-curve.svg
+++ b/Numix/24/actions/node-segment-curve.svg
@@ -1,0 +1,1 @@
+segment-curve.svg

--- a/Numix/24/actions/node-segment-line.svg
+++ b/Numix/24/actions/node-segment-line.svg
@@ -1,0 +1,1 @@
+segment-line.svg

--- a/Numix/24/actions/node-smooth.svg
+++ b/Numix/24/actions/node-smooth.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+ <path d="m 3.5 5 c 0 11 7 11.5 7 11.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1"/>
+ <path d="m 20.5 5 c 0 11 -7 11.5 -7 11.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1"/>
+ <rect style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" x="10.5" y="15.5" height="3" width="3"/>
+</svg>

--- a/Numix/24/actions/node-symmetric.svg
+++ b/Numix/24/actions/node-symmetric.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1" d="m 3.5 5 c 0 11 7 11.5 7 11.5"/>
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1" d="m 20.5 5 c 0 11 -7 11.5 -7 11.5"/>
+ <rect width="3" x="10.5" y="15.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" height="3"/>
+ <path style="stroke-dasharray:2 2;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" d="m 13 17.5 8 0"/>
+ <rect style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" height="2" x="-20.5" y="16.5" width="2" transform="matrix(-1 0 0 1 0 0)"/>
+ <path style="stroke-dasharray:2 2;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" d="m 11 17.5 -8 0"/>
+ <rect width="2" x="3.5" y="16.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" height="2"/>
+</svg>

--- a/Numix/24/actions/node-type-auto-smooth.svg
+++ b/Numix/24/actions/node-type-auto-smooth.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+ <path d="m 3.5 5 c 0 11 7 11.5 7 11.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1"/>
+ <path d="m 20.5 5 c 0 11 -7 11.5 -7 11.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1"/>
+ <circle r="1.5" cy="17" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" cx="12"/>
+</svg>

--- a/Numix/24/actions/node-type-cusp.svg
+++ b/Numix/24/actions/node-type-cusp.svg
@@ -1,0 +1,1 @@
+node-cusp.svg

--- a/Numix/24/actions/node-type-smooth.svg
+++ b/Numix/24/actions/node-type-smooth.svg
@@ -1,0 +1,1 @@
+node-smooth.svg

--- a/Numix/24/actions/node-type-symmetric.svg
+++ b/Numix/24/actions/node-type-symmetric.svg
@@ -1,0 +1,1 @@
+node-symmetric.svg

--- a/Numix/24/actions/segment-curve.svg
+++ b/Numix/24/actions/segment-curve.svg
@@ -1,6 +1,7 @@
+
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
- <path d="M -4.5 -18 A 13.5 13.5 0 0 1 -18 -4.5" transform="matrix(0,-1,-1,0,0,0)" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;fill-opacity:1;stroke:#dc322f;fill-rule:nonzero;stroke-linecap:square;stroke-linejoin:round;stroke-width:1.5;stroke-dashoffset:0"/>
- <path d="m 18 3 0 3 3 0 0 -3 z m 1 1 1 0 0 1 -1 0 z" style="fill:#888;opacity:1;fill-opacity:1;stroke:none"/>
- <path d="m 3 18 0 3 3 0 0 -3 z m 1 1 1 0 0 1 -1 0 z" style="fill:#888;opacity:1;fill-opacity:1;stroke:none"/>
+ <path d="M -4.5 -18 A 13.5 13.5 0 0 1 -18 -4.5" transform="matrix(0 -1 -1 0 0 0)" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#dc322f;stroke-linecap:square;stroke-linejoin:round;stroke-width:1.5;stroke-dashoffset:0"/>
+ <path d="m 18 3 0 3 3 0 0 -3 z m 1 1 1 0 0 1 -1 0 z" style="fill:#313131;opacity:1;fill-opacity:1;stroke:none"/>
+ <path d="m 3 18 0 3 3 0 0 -3 z m 1 1 1 0 0 1 -1 0 z" style="fill:#313131;opacity:1;fill-opacity:1;stroke:none"/>
 </svg>

--- a/Numix/24/actions/segment-line.svg
+++ b/Numix/24/actions/segment-line.svg
@@ -1,6 +1,7 @@
+
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
- <rect width="19" height="1.5" x="-9.5" y="16.221" transform="matrix(0.70710678,-0.70710678,0.70710678,0.70710678,0,0)" style="fill:#dc322f;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
- <path d="m 18 3 0 3 3 0 0 -3 z m 1 1 1 0 0 1 -1 0 z" style="fill:#888;opacity:1;fill-opacity:1;stroke:none"/>
- <path d="m 3 18 0 3 3 0 0 -3 z m 1 1 1 0 0 1 -1 0 z" style="fill:#888;opacity:1;fill-opacity:1;stroke:none"/>
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+ <rect x="-9.5" transform="matrix(0.70711 -0.70711 0.70711 0.70711 0 0)" style="fill:#dc322f;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" width="19" height="1.5" y="16.221"/>
+ <path style="fill:#313131;opacity:1;fill-opacity:1;stroke:none" d="m 18 3 0 3 3 0 0 -3 z m 1 1 1 0 0 1 -1 0 z"/>
+ <path style="fill:#313131;opacity:1;fill-opacity:1;stroke:none" d="m 3 18 0 3 3 0 0 -3 z m 1 1 1 0 0 1 -1 0 z"/>
 </svg>

--- a/Numix/32/actions/format-segment-curve.svg
+++ b/Numix/32/actions/format-segment-curve.svg
@@ -1,0 +1,1 @@
+segment-curve.svg

--- a/Numix/32/actions/format-segment-line.svg
+++ b/Numix/32/actions/format-segment-line.svg
@@ -1,0 +1,1 @@
+segment-line.svg

--- a/Numix/32/actions/node-add.svg
+++ b/Numix/32/actions/node-add.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+ <rect x="6" height="15.5" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" width="1" y="8"/>
+ <rect x="6" height="15.5" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" width="1" y="-24" transform="matrix(0 1 -1 0 0 0)"/>
+ <circle cy="6" cx="6" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:round;stroke-width:2;stroke-dashoffset:0" r="2"/>
+ <rect x="-26" height="9.5" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" width="1" y="-18" transform="matrix(-1 0 0 -1 0 0)"/>
+ <rect x="24" height="4" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" width="4" y="4"/>
+ <rect x="25" height="9.5" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" width="1" transform="matrix(0 1 -1 0 0 0)" y="-18"/>
+ <rect x="4" height="4" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" width="4" y="24"/>
+ <path style="fill:#859900" d="m 31 23 -4 0 0 -4 -4 0 0 4 -4 0 0 4 4 0 0 4 4 0 0 -4 4 0 z"/>
+</svg>

--- a/Numix/32/actions/node-break.svg
+++ b/Numix/32/actions/node-break.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="8.5" x="-26" transform="matrix(0 -1 1 0 0 0)" width="1" height="4.5"/>
+ <path style="fill:#cb4b16" d="m 16 18 4 -4 -8 0 z"/>
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="4" transform="matrix(0 -1 1 0 0 0)" x="-7.02" width="1" height="10"/>
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="18" x="-7.01" transform="matrix(0 -1 1 0 0 0)" width="1" height="10"/>
+ <rect style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" y="4" x="14" width="4" height="4"/>
+ <rect style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" y="24" x="5" width="3" height="3"/>
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="-23.5" transform="matrix(0 -1 -1 0 0 0)" x="-26" width="1" height="4.5"/>
+ <rect width="3" height="3" y="24" x="-27" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" transform="matrix(-1 0 0 1 0 0)"/>
+</svg>

--- a/Numix/32/actions/node-cusp.svg
+++ b/Numix/32/actions/node-cusp.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+ <path d="m 2 5.5 c 4.7 0 13.14 17.05 13.14 17.05" style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1"/>
+ <path d="m 18.776 22.69 c 7.833 -3.061 10.724 -10.302 10.724 -17.69" style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1"/>
+ <path d="m 16.5 5 0 17" style="stroke-dasharray:2 2;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0"/>
+ <path d="m 30 23.5 -11 0" style="stroke-dasharray:2 2;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0"/>
+ <rect width="4" height="4" x="-6.95" y="26.28" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" transform="matrix(0.70711 -0.70711 0.70711 0.70711 0 0)"/>
+</svg>

--- a/Numix/32/actions/node-delete-segment.svg
+++ b/Numix/32/actions/node-delete-segment.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+ <rect width="1" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" x="-26" height="4.5" y="8.5" transform="matrix(0 -1 1 0 0 0)"/>
+ <path d="m 16 18 4 -4 -8 0 z" style="fill:#cb4b16"/>
+ <rect width="3" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" height="3" x="5" y="24"/>
+ <rect width="1" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" height="4.5" x="-26" y="-23.5" transform="matrix(0 -1 -1 0 0 0)"/>
+ <rect height="3" width="3" x="-27" y="24" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" transform="matrix(-1 0 0 1 0 0)"/>
+ <rect width="1" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" height="15" x="-7" y="8.5" transform="matrix(0 -1 1 0 0 0)"/>
+ <rect width="3" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" height="3" x="5" y="5"/>
+ <rect height="3" width="3" x="-27" y="5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" transform="matrix(-1 0 0 1 0 0)"/>
+</svg>

--- a/Numix/32/actions/node-delete.svg
+++ b/Numix/32/actions/node-delete.svg
@@ -1,0 +1,10 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+ <rect y="8" x="6" height="15.5" width="1" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <rect y="-24" x="6" height="15.5" width="1" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" transform="matrix(0 1 -1 0 0 0)"/>
+ <circle style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:round;stroke-width:2;stroke-dashoffset:0" r="2" cy="6" cx="6"/>
+ <rect y="-18" x="-26" height="9.5" width="1" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" transform="matrix(-1 0 0 -1 0 0)"/>
+ <rect y="4" x="24" height="4" width="4" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0"/>
+ <rect y="-18" x="25" height="9.5" width="1" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" transform="matrix(0 1 -1 0 0 0)"/>
+ <rect y="24" x="4" height="4" width="4" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0"/>
+ <path d="m 30.657 27.828 -2.828 -2.828 2.828 -2.828 -2.828 -2.828 -2.828 2.828 -2.828 -2.828 -2.828 2.828 2.828 2.828 -2.828 2.828 2.828 2.828 2.828 -2.828 l 2.828 2.828 z" style="fill:#dc322f;fill-opacity:1"/>
+</svg>

--- a/Numix/32/actions/node-join-segment.svg
+++ b/Numix/32/actions/node-join-segment.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+ <rect transform="matrix(0 1 1 0 0 0)" height="4.5" x="6" y="8.5" width="1" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <path d="m 16 18 4 -4 -8 0 z" style="fill:#cb4b16"/>
+ <rect height="3" y="-8" transform="matrix(1 0 0 -1 0 0)" width="3" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" x="5"/>
+ <rect transform="matrix(0 1 -1 0 0 0)" height="4.5" x="6" y="-23.5" width="1" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <rect height="3" y="-8" transform="matrix(-1 0 0 -1 0 0)" width="3" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" x="-27"/>
+ <rect transform="matrix(0 1 1 0 0 0)" height="15" x="25" y="8.5" width="1" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <rect height="3" y="-27" transform="matrix(1 0 0 -1 0 0)" width="3" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" x="5"/>
+ <rect height="3" y="-27" transform="matrix(-1 0 0 -1 0 0)" width="3" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" x="-27"/>
+</svg>

--- a/Numix/32/actions/node-join.svg
+++ b/Numix/32/actions/node-join.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+ <rect height="4.5" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="8.5" x="6" transform="matrix(0 1 1 0 0 0)" width="1"/>
+ <path style="fill:#cb4b16" d="m 16 18 4 -4 -8 0 z"/>
+ <rect height="10" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="4" x="24.982" transform="matrix(0 1 1 0 0 0)" width="1"/>
+ <rect height="10" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="18" x="24.991" transform="matrix(0 1 1 0 0 0)" width="1"/>
+ <rect transform="matrix(1 0 0 -1 0 0)" width="4" y="-28" height="4" x="14" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0"/>
+ <rect transform="matrix(1 0 0 -1 0 0)" width="3" y="-8" height="3" x="5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0"/>
+ <rect height="4.5" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="-23.5" x="6" transform="matrix(0 1 -1 0 0 0)" width="1"/>
+ <rect transform="matrix(-1 0 0 -1 0 0)" width="3" y="-8" height="3" x="-27" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0"/>
+</svg>

--- a/Numix/32/actions/node-segment-curve.svg
+++ b/Numix/32/actions/node-segment-curve.svg
@@ -1,0 +1,1 @@
+segment-curve.svg

--- a/Numix/32/actions/node-segment-line.svg
+++ b/Numix/32/actions/node-segment-line.svg
@@ -1,0 +1,1 @@
+segment-line.svg

--- a/Numix/32/actions/node-smooth.svg
+++ b/Numix/32/actions/node-smooth.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1" d="m 2.5 6 c 0 19.342 10.969 20 10.969 20"/>
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1" d="m 29.5 6 c 0 19.342 -10.969 20 -10.969 20"/>
+ <rect height="4" width="4" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" x="14" y="24"/>
+</svg>

--- a/Numix/32/actions/node-symmetric.svg
+++ b/Numix/32/actions/node-symmetric.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+ <path style="stroke-dasharray:2 2;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" d="m 14 26.5 -9 0"/>
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1" d="m 2.5 6 c 0 19.342 10.969 20 10.969 20"/>
+ <path style="stroke-dasharray:2 2;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" d="m 18 26.5 9 0"/>
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1" d="m 29.5 6 c 0 19.342 -10.969 20 -10.969 20"/>
+ <rect width="4" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" x="14" y="24" height="4"/>
+ <rect width="2" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" x="3.5" y="25.5" height="2"/>
+ <rect width="2" height="2" x="-28.5" y="25.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" transform="matrix(-1 0 0 1 0 0)"/>
+</svg>

--- a/Numix/32/actions/node-type-auto-smooth.svg
+++ b/Numix/32/actions/node-type-auto-smooth.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+ <path d="m 2.5 6 c 0 19.342 10.969 20 10.969 20" style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1"/>
+ <path d="m 29.5 6 c 0 19.342 -10.969 20 -10.969 20" style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1"/>
+ <circle cx="16" cy="26" r="2" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:round;stroke-width:2;stroke-dashoffset:0"/>
+</svg>

--- a/Numix/32/actions/node-type-cusp.svg
+++ b/Numix/32/actions/node-type-cusp.svg
@@ -1,0 +1,1 @@
+node-cusp.svg

--- a/Numix/32/actions/node-type-smooth.svg
+++ b/Numix/32/actions/node-type-smooth.svg
@@ -1,0 +1,1 @@
+node-smooth.svg

--- a/Numix/32/actions/node-type-symmetric.svg
+++ b/Numix/32/actions/node-type-symmetric.svg
@@ -1,0 +1,1 @@
+node-symmetric.svg

--- a/Numix/32/actions/segment-curve.svg
+++ b/Numix/32/actions/segment-curve.svg
@@ -1,6 +1,7 @@
+
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
- <path d="m 23 3 0 6 6 0 0 -6 z m 2 2 2 0 0 2 -2 0 z" style="fill:#888;opacity:1;fill-opacity:1;stroke:none"/>
- <path d="M -6 -23 A 17 17 0 0 1 -23 -6" transform="matrix(0,-1,-1,0,0,0)" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;fill-opacity:1;stroke:#dc322f;fill-rule:nonzero;stroke-linecap:butt;stroke-linejoin:round;stroke-width:2;stroke-dashoffset:0"/>
- <path d="m 3 23 0 6 6 0 0 -6 z m 2 2 2 0 0 2 -2 0 z" style="fill:#888;opacity:1;fill-opacity:1;stroke:none"/>
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+ <path d="m 23 3 0 6 6 0 0 -6 z m 2 2 2 0 0 2 -2 0 z" style="fill:#313131;opacity:1;fill-opacity:1;stroke:none"/>
+ <path transform="matrix(0 -1 -1 0 0 0)" d="M -6 -23 A 17 17 0 0 1 -23 -6" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#dc322f;stroke-linecap:butt;stroke-linejoin:round;stroke-width:2;stroke-dashoffset:0"/>
+ <path d="m 3 23 0 6 6 0 0 -6 z m 2 2 2 0 0 2 -2 0 z" style="fill:#313131;opacity:1;fill-opacity:1;stroke:none"/>
 </svg>

--- a/Numix/32/actions/segment-line.svg
+++ b/Numix/32/actions/segment-line.svg
@@ -1,6 +1,7 @@
+
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
- <rect width="24" height="2" x="-12" y="21.627" transform="matrix(0.70710678,-0.70710678,0.70710678,0.70710678,0,0)" style="fill:#dc322f;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
- <path d="m 23 3 0 6 6 0 0 -6 z m 2 2 2 0 0 2 -2 0 z" style="fill:#888;opacity:1;fill-opacity:1;stroke:none"/>
- <path d="m 3 23 0 6 6 0 0 -6 z m 2 2 2 0 0 2 -2 0 z" style="fill:#888;opacity:1;fill-opacity:1;stroke:none"/>
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+ <rect style="fill:#dc322f;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" width="24" height="2" transform="matrix(0.70711 -0.70711 0.70711 0.70711 0 0)" y="21.627" x="-12"/>
+ <path style="fill:#313131;opacity:1;fill-opacity:1;stroke:none" d="m 23 3 0 6 6 0 0 -6 z m 2 2 2 0 0 2 -2 0 z"/>
+ <path style="fill:#313131;opacity:1;fill-opacity:1;stroke:none" d="m 3 23 0 6 6 0 0 -6 z m 2 2 2 0 0 2 -2 0 z"/>
 </svg>

--- a/Numix/48/actions/format-segment-curve.svg
+++ b/Numix/48/actions/format-segment-curve.svg
@@ -1,0 +1,1 @@
+segment-curve.svg

--- a/Numix/48/actions/format-segment-line.svg
+++ b/Numix/48/actions/format-segment-line.svg
@@ -1,0 +1,1 @@
+segment-line.svg

--- a/Numix/48/actions/node-add.svg
+++ b/Numix/48/actions/node-add.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+ <rect y="12.5" width="2" x="9" height="23" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <rect width="2" y="-35.5" x="9" height="23" transform="matrix(0 1 -1 0 0 0)" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <circle r="3" cy="9" cx="9" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:round;stroke-width:2;stroke-dashoffset:0"/>
+ <rect width="2" y="12.5" x="37" height="14.5" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <rect y="6" width="6" x="36" height="6" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0"/>
+ <rect y="-27" width="2" x="37" height="14.5" transform="matrix(0 1 -1 0 0 0)" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <rect y="36" width="6" x="6" height="6" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0"/>
+ <path d="m 47 35 -6 0 0 -6 -6 0 0 6 -6 0 0 6 6 0 0 6 6 0 0 -6 6 0 z" style="fill:#859900"/>
+</svg>

--- a/Numix/48/actions/node-break.svg
+++ b/Numix/48/actions/node-break.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+ <rect width="2" transform="matrix(0 1 -1 0 0 0)" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" x="9" y="-21" height="10"/>
+ <rect transform="matrix(0 1 -1 0 0 0)" width="2" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" x="9" y="-37" height="10"/>
+ <rect width="6" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" x="21" y="7" height="6"/>
+ <rect transform="matrix(0 1 -1 0 0 0)" width="2" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" x="37" y="-20" height="7.5"/>
+ <rect width="4" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" x="8" y="36" height="4"/>
+ <path d="m 24 28 5 -6 -10 0 z" style="fill:#cb4b16"/>
+ <rect width="2" transform="matrix(0 1 -1 0 0 0)" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" x="37" y="-35.5" height="7.5"/>
+ <rect width="4" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" x="36" y="36" height="4"/>
+</svg>

--- a/Numix/48/actions/node-cusp.svg
+++ b/Numix/48/actions/node-cusp.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2" d="m 6 11 c 6 0 17 22.5 17 22.5"/>
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2" d="m 27 33.5 c 10 -4 14 -17.5 14 -23.5"/>
+ <rect x="-10.07" transform="matrix(0.70711 -0.70711 0.70711 0.70711 0 0)" y="40.13" width="6" height="6" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0"/>
+ <path style="stroke-dasharray:2 2;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" d="m 25.5 10 0 21.5"/>
+ <path style="stroke-dasharray:2 2;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" d="m 42 35.5 -14 0"/>
+</svg>

--- a/Numix/48/actions/node-delete-segment.svg
+++ b/Numix/48/actions/node-delete-segment.svg
@@ -1,0 +1,10 @@
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+ <rect x="9" transform="matrix(0 1 -1 0 0 0)" height="24" width="2" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="-36"/>
+ <rect x="37" transform="matrix(0 1 -1 0 0 0)" height="8.5" width="2" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="-20"/>
+ <rect x="8" height="4" width="4" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" y="36"/>
+ <path d="m 24 28 5 -6 -10 0 z" style="fill:#cb4b16"/>
+ <rect x="37" transform="matrix(0 1 -1 0 0 0)" height="8.5" width="2" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="-36.5"/>
+ <rect x="36" height="4" width="4" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" y="36"/>
+ <rect x="8" height="4" width="4" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" y="8"/>
+ <rect x="36" height="4" width="4" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" y="8"/>
+</svg>

--- a/Numix/48/actions/node-delete.svg
+++ b/Numix/48/actions/node-delete.svg
@@ -1,0 +1,10 @@
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+ <rect height="23" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="12.5" x="9" width="2"/>
+ <rect height="23" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="-35.5" x="9" transform="matrix(0 1 -1 0 0 0)" width="2"/>
+ <circle style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:round;stroke-width:2;stroke-dashoffset:0" r="3" cy="9" cx="9"/>
+ <rect height="14.5" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="12.5" x="37" width="2"/>
+ <rect height="6" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" y="6" x="36" width="6"/>
+ <rect height="14.5" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="-27" transform="matrix(0 1 -1 0 0 0)" x="37" width="2"/>
+ <rect height="6" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" y="36" x="6" width="6"/>
+ <path style="fill:#dc322f;fill-opacity:1" d="m 46.49 42.24 -4.243 -4.243 4.243 -4.243 -4.243 -4.243 -4.243 4.243 l -4.243 -4.243 -4.243 4.243 4.243 4.243 -4.243 4.243 4.243 4.243 l 4.243 -4.243 l 4.243 4.243 z"/>
+</svg>

--- a/Numix/48/actions/node-join-segment.svg
+++ b/Numix/48/actions/node-join-segment.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+ <rect width="2" transform="matrix(0 -1 -1 0 0 0)" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" height="24" x="-39" y="-36"/>
+ <rect width="2" transform="matrix(0 -1 -1 0 0 0)" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" height="8.5" x="-11" y="-20"/>
+ <rect width="4" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" height="4" x="8" y="36"/>
+ <path d="m 24 28 5 -6 -10 0 z" style="fill:#cb4b16"/>
+ <rect width="2" transform="matrix(0 -1 -1 0 0 0)" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" height="8.5" x="-11" y="-36.5"/>
+ <rect width="4" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" height="4" x="36" y="36"/>
+ <rect width="4" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" height="4" x="8" y="8"/>
+ <rect width="4" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" height="4" x="36" y="8"/>
+</svg>

--- a/Numix/48/actions/node-join.svg
+++ b/Numix/48/actions/node-join.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" transform="matrix(0 -1 -1 0 0 0)" y="-21" width="2" x="-40" height="10"/>
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" transform="matrix(0 -1 -1 0 0 0)" y="-37" x="-40" width="2" height="10"/>
+ <rect width="6" height="6" transform="matrix(1 0 0 -1 0 0)" y="-42" x="21" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0"/>
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" transform="matrix(0 -1 -1 0 0 0)" y="-20" x="-12" width="2" height="8.5"/>
+ <rect width="4" height="4" transform="matrix(1 0 0 -1 0 0)" y="-13" x="8" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0"/>
+ <path style="fill:#cb4b16" d="m 24 28 5 -6 -10 0 z"/>
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" transform="matrix(0 -1 -1 0 0 0)" y="-36.5" width="2" x="-12" height="8.5"/>
+ <rect width="4" height="4" transform="matrix(1 0 0 -1 0 0)" y="-13" x="36" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0"/>
+</svg>

--- a/Numix/48/actions/node-segment-curve.svg
+++ b/Numix/48/actions/node-segment-curve.svg
@@ -1,0 +1,1 @@
+segment-curve.svg

--- a/Numix/48/actions/node-segment-line.svg
+++ b/Numix/48/actions/node-segment-line.svg
@@ -1,0 +1,1 @@
+segment-line.svg

--- a/Numix/48/actions/node-smooth.svg
+++ b/Numix/48/actions/node-smooth.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2" d="m 8 10 c 0 22 13 22.5 13 22.5"/>
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2" d="m 40 10 c 0 22 -13 22.5 -13 22.5"/>
+ <rect y="31" x="21" height="6" width="6" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0"/>
+</svg>

--- a/Numix/48/actions/node-symmetric.svg
+++ b/Numix/48/actions/node-symmetric.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+ <path d="m 8 10 c 0 22 13 22.5 13 22.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2"/>
+ <path d="m 40 10 c 0 22 -13 22.5 -13 22.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2"/>
+ <rect height="6" width="6" x="21" y="31" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0"/>
+ <path d="m 21 34.5 -11 0" style="stroke-dasharray:2 2;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0"/>
+ <rect height="2" width="2" x="9.5" y="33.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0"/>
+ <path d="m 27 34.5 11 0" style="stroke-dasharray:2 2;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0"/>
+ <rect width="2" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" height="2" transform="matrix(-1 0 0 1 0 0)" x="-38.5" y="33.5"/>
+</svg>

--- a/Numix/48/actions/node-type-auto-smooth.svg
+++ b/Numix/48/actions/node-type-auto-smooth.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+ <path d="m 8 10 c 0 22 13 22.5 13 22.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2"/>
+ <path d="m 40 10 c 0 22 -13 22.5 -13 22.5" style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2"/>
+ <circle r="3" cx="24" cy="34" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0"/>
+</svg>

--- a/Numix/48/actions/node-type-cusp.svg
+++ b/Numix/48/actions/node-type-cusp.svg
@@ -1,0 +1,1 @@
+node-cusp.svg

--- a/Numix/48/actions/node-type-smooth.svg
+++ b/Numix/48/actions/node-type-smooth.svg
@@ -1,0 +1,1 @@
+node-smooth.svg

--- a/Numix/48/actions/node-type-symmetric.svg
+++ b/Numix/48/actions/node-type-symmetric.svg
@@ -1,0 +1,1 @@
+node-symmetric.svg

--- a/Numix/48/actions/segment-curve.svg
+++ b/Numix/48/actions/segment-curve.svg
@@ -1,6 +1,7 @@
+
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
- <path d="m 33 9 0 6 6 0 0 -6 z m 2 2 2 0 0 2 -2 0 z" style="fill:#888;opacity:1;fill-opacity:1;stroke:none"/>
- <path d="m -12 -33 a 21 21 0 0 1 -21 21" transform="matrix(0,-1,-1,0,0,0)" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;fill-opacity:1;stroke:#dc322f;fill-rule:nonzero;stroke-linecap:butt;stroke-linejoin:round;stroke-width:2;stroke-dashoffset:0"/>
- <path d="m 9 33 0 6 6 0 0 -6 z m 2 2 2 0 0 2 -2 0 z" style="fill:#888;opacity:1;fill-opacity:1;stroke:none"/>
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+ <path style="fill:#313131;opacity:1;fill-opacity:1;stroke:none" d="m 33 9 0 6 6 0 0 -6 z m 2 2 2 0 0 2 -2 0 z"/>
+ <path transform="matrix(0 -1 -1 0 0 0)" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#dc322f;stroke-linecap:butt;stroke-linejoin:round;stroke-width:2;stroke-dashoffset:0" d="m -12 -33 a 21 21 0 0 1 -21 21"/>
+ <path style="fill:#313131;opacity:1;fill-opacity:1;stroke:none" d="m 9 33 0 6 6 0 0 -6 z m 2 2 2 0 0 2 -2 0 z"/>
 </svg>

--- a/Numix/48/actions/segment-line.svg
+++ b/Numix/48/actions/segment-line.svg
@@ -1,6 +1,7 @@
+
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
- <rect width="2" height="30" x="32.941" y="-15" transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,0,0)" style="fill:#dc322f;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
- <path d="m 33 9 0 6 6 0 0 -6 z m 2 2 2 0 0 2 -2 0 z" style="fill:#888;opacity:1;fill-opacity:1;stroke:none"/>
- <path d="m 9 33 0 6 6 0 0 -6 z m 2 2 2 0 0 2 -2 0 z" style="fill:#888;opacity:1;fill-opacity:1;stroke:none"/>
+ <rect width="2" style="fill:#dc322f;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" transform="matrix(0.70711 0.70711 -0.70711 0.70711 0 0)" height="30" x="32.941" y="-15"/>
+ <path d="m 33 9 0 6 6 0 0 -6 z m 2 2 2 0 0 2 -2 0 z" style="fill:#313131;opacity:1;fill-opacity:1;stroke:none"/>
+ <path d="m 9 33 0 6 6 0 0 -6 z m 2 2 2 0 0 2 -2 0 z" style="fill:#313131;opacity:1;fill-opacity:1;stroke:none"/>
 </svg>

--- a/Numix/64/actions/format-segment-curve.svg
+++ b/Numix/64/actions/format-segment-curve.svg
@@ -1,0 +1,1 @@
+segment-curve.svg

--- a/Numix/64/actions/format-segment-line.svg
+++ b/Numix/64/actions/format-segment-line.svg
@@ -1,0 +1,1 @@
+segment-line.svg

--- a/Numix/64/actions/node-add.svg
+++ b/Numix/64/actions/node-add.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+ <rect y="18" x="14" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" height="28" width="2"/>
+ <rect y="18" x="-16" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" transform="matrix(0 -1 1 0 0 0)" height="28" width="2"/>
+ <circle style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:round;stroke-width:2;stroke-dashoffset:0" cy="14" r="4" cx="14"/>
+ <rect y="18" x="48" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" height="16" width="2"/>
+ <rect y="10" x="46" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" height="8" width="8"/>
+ <path style="fill:#859900" d="m 61 45 -8 0 0 -8 -8 0 0 8 -8 0 0 8 8 0 0 8 8 0 0 -8 8 0 z"/>
+ <rect y="18" x="-50" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" transform="matrix(0 -1 1 0 0 0)" height="16" width="2"/>
+ <rect y="46" x="10" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" height="8" width="8"/>
+</svg>

--- a/Numix/64/actions/node-break.svg
+++ b/Numix/64/actions/node-break.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+ <rect y="16" x="-52" width="2" height="11" transform="matrix(0 -1 1 0 0 0)" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <rect y="37" x="-52" width="2" height="11" transform="matrix(0 -1 1 0 0 0)" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <rect y="48" x="48" width="6" height="6" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0"/>
+ <rect y="48" x="10" width="6" height="6" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0"/>
+ <path style="fill:#cb4b16" d="m 32 37 7 -8 -14 0 z"/>
+ <rect y="14" x="-16" width="2" height="14" transform="matrix(0 -1 1 0 0 0)" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <rect y="36" x="-16" width="2" height="14" transform="matrix(0 -1 1 0 0 0)" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <rect y="11" x="28" width="8" height="8" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0"/>
+</svg>

--- a/Numix/64/actions/node-cusp.svg
+++ b/Numix/64/actions/node-cusp.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2" d="m 8 15 c 8.06 0 22.523 30.04 22.523 30.04"/>
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2" d="m 36.759 45.3 c 13.429 -5.386 18.241 -18.297 18.241 -31.3"/>
+ <path style="stroke-dasharray:2 2;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" d="m 33.5 14 0 28.5"/>
+ <path style="stroke-dasharray:2 2;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" d="m 56 47.5 -18 0"/>
+ <rect transform="matrix(0.70711 0.70711 -0.70711 0.70711 0 0)" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" width="8" height="8" x="53.28" y="5.9"/>
+</svg>

--- a/Numix/64/actions/node-delete-segment.svg
+++ b/Numix/64/actions/node-delete-segment.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+ <rect transform="matrix(0 -1 1 0 0 0)" height="11" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="16" x="-51" width="2"/>
+ <rect transform="matrix(0 -1 1 0 0 0)" height="11" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="37" x="-51" width="2"/>
+ <rect height="6" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" y="47" x="48" width="6"/>
+ <rect height="6" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" y="47" x="10" width="6"/>
+ <path d="m 32 37 7 -8 -14 0 z" style="fill:#cb4b16"/>
+ <rect transform="matrix(0 -1 1 0 0 0)" height="31" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" y="16" x="-15" width="2"/>
+ <rect height="6" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" y="11" x="48" width="6"/>
+ <rect height="6" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" y="11" x="10" width="6"/>
+</svg>

--- a/Numix/64/actions/node-delete.svg
+++ b/Numix/64/actions/node-delete.svg
@@ -1,0 +1,10 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+ <rect y="18" height="28" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" x="14" width="2"/>
+ <rect y="18" height="28" transform="matrix(0 -1 1 0 0 0)" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" width="2" x="-16"/>
+ <circle cy="14" r="4" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:round;stroke-width:2;stroke-dashoffset:0" cx="14"/>
+ <rect y="18" height="16" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" width="2" x="48"/>
+ <rect y="10" height="8" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" width="8" x="46"/>
+ <path d="m 60.31 54.657 -5.657 -5.657 5.657 -5.657 -5.657 -5.657 -5.657 5.657 -5.657 -5.657 -5.657 5.657 5.657 5.657 -5.657 5.657 5.657 5.657 5.657 -5.657 l 5.657 5.657 z" style="fill:#dc322f;fill-opacity:1"/>
+ <rect y="18" height="16" transform="matrix(0 -1 1 0 0 0)" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" x="-50" width="2"/>
+ <rect y="46" height="8" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" width="8" x="10"/>
+</svg>

--- a/Numix/64/actions/node-join-segment.svg
+++ b/Numix/64/actions/node-join-segment.svg
@@ -1,0 +1,10 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+ <rect width="2" transform="matrix(0 1 1 0 0 0)" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" height="11" x="13" y="16"/>
+ <rect width="2" transform="matrix(0 1 1 0 0 0)" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" height="11" x="13" y="37"/>
+ <rect height="6" x="48" y="-17" width="6" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" transform="matrix(1 0 0 -1 0 0)"/>
+ <rect height="6" x="10" y="-17" width="6" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" transform="matrix(1 0 0 -1 0 0)"/>
+ <path d="m 32 37 7 -8 -14 0 z" style="fill:#cb4b16"/>
+ <rect width="2" transform="matrix(0 1 1 0 0 0)" style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" height="31" x="49" y="16"/>
+ <rect height="6" x="48" y="-53" width="6" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" transform="matrix(1 0 0 -1 0 0)"/>
+ <rect height="6" x="10" y="-53" width="6" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" transform="matrix(1 0 0 -1 0 0)"/>
+</svg>

--- a/Numix/64/actions/node-join.svg
+++ b/Numix/64/actions/node-join.svg
@@ -1,0 +1,10 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" transform="matrix(0 1 1 0 0 0)" x="13" y="16" height="11" width="2"/>
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" transform="matrix(0 1 1 0 0 0)" x="13" height="11" y="37" width="2"/>
+ <rect height="6" x="48" y="-17" width="6" transform="matrix(1 0 0 -1 0 0)" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0"/>
+ <rect height="6" x="10" y="-17" width="6" transform="matrix(1 0 0 -1 0 0)" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0"/>
+ <path style="fill:#cb4b16" d="m 32 37 7 -8 -14 0 z"/>
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" transform="matrix(0 1 1 0 0 0)" x="49" height="14" y="14" width="2"/>
+ <rect style="fill:#3daee9;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero" transform="matrix(0 1 1 0 0 0)" x="49" y="36" height="14" width="2"/>
+ <rect height="8" x="28" y="-54" width="8" transform="matrix(1 0 0 -1 0 0)" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0"/>
+</svg>

--- a/Numix/64/actions/node-segment-curve.svg
+++ b/Numix/64/actions/node-segment-curve.svg
@@ -1,0 +1,1 @@
+segment-curve.svg

--- a/Numix/64/actions/node-segment-line.svg
+++ b/Numix/64/actions/node-segment-line.svg
@@ -1,0 +1,1 @@
+segment-line.svg

--- a/Numix/64/actions/node-smooth.svg
+++ b/Numix/64/actions/node-smooth.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2" d="m 9 13.162 c 0 31.461 18.688 32.18 18.688 32.18"/>
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2" d="m 55 13.162 c 0 31.461 -18.688 32.18 -18.688 32.18"/>
+ <rect height="8" width="8" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" y="41.838" x="28"/>
+</svg>

--- a/Numix/64/actions/node-symmetric.svg
+++ b/Numix/64/actions/node-symmetric.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2" d="m 9 13.162 c 0 31.461 18.688 32.18 18.688 32.18"/>
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2" d="m 55 13.162 c 0 31.461 -18.688 32.18 -18.688 32.18"/>
+ <rect height="8" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" width="8" x="28" y="41.838"/>
+ <path style="stroke-dasharray:2 2;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" d="m 28 47.5 -13 0"/>
+ <rect height="2" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" width="2" x="13.5" y="46.5"/>
+ <path style="stroke-dasharray:2 2;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" d="m 36 47.5 13 0"/>
+ <rect style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1;stroke-dashoffset:0" width="2" transform="matrix(-1 0 0 1 0 0)" height="2" x="-50.5" y="46.5"/>
+</svg>

--- a/Numix/64/actions/node-type-auto-smooth.svg
+++ b/Numix/64/actions/node-type-auto-smooth.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2" d="m 9 13.162 c 0 31.461 18.688 32.18 18.688 32.18"/>
+ <path style="stroke-dasharray:none;stroke-opacity:1;fill:none;stroke-miterlimit:4;stroke:#3daee9;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2" d="m 55 13.162 c 0 31.461 -18.688 32.18 -18.688 32.18"/>
+ <circle cx="32" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#313131;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:2;stroke-dashoffset:0" cy="46" r="4"/>
+</svg>

--- a/Numix/64/actions/node-type-cusp.svg
+++ b/Numix/64/actions/node-type-cusp.svg
@@ -1,0 +1,1 @@
+node-cusp.svg

--- a/Numix/64/actions/node-type-smooth.svg
+++ b/Numix/64/actions/node-type-smooth.svg
@@ -1,0 +1,1 @@
+node-smooth.svg

--- a/Numix/64/actions/node-type-symmetric.svg
+++ b/Numix/64/actions/node-type-symmetric.svg
@@ -1,0 +1,1 @@
+node-symmetric.svg

--- a/Numix/64/actions/segment-curve.svg
+++ b/Numix/64/actions/segment-curve.svg
@@ -1,6 +1,7 @@
+
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
- <path d="m 46 9 0 9 9 0 0 -9 z m 3 3 3 0 0 3 -3 0 z" style="fill:#888;opacity:1;fill-opacity:1;stroke:none"/>
- <path d="m -13.5 -46 a 32.5 32.5 0 0 1 -32.5 32.5" transform="matrix(0,-1,-1,0,0,0)" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;fill-opacity:1;stroke:#dc322f;fill-rule:nonzero;stroke-linecap:butt;stroke-linejoin:round;stroke-width:3;stroke-dashoffset:0"/>
- <path d="m 9 46 0 9 9 0 0 -9 z m 3 3 3 0 0 3 -3 0 z" style="fill:#888;opacity:1;fill-opacity:1;stroke:none"/>
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+ <path d="m 46 9 0 9 9 0 0 -9 z m 3 3 3 0 0 3 -3 0 z" style="fill:#313131;opacity:1;fill-opacity:1;stroke:none"/>
+ <path d="m -13.5 -46 a 32.5 32.5 0 0 1 -32.5 32.5" transform="matrix(0 -1 -1 0 0 0)" style="stroke-dasharray:none;stroke-opacity:1;fill:none;opacity:1;stroke-miterlimit:4;stroke:#dc322f;stroke-linecap:butt;stroke-linejoin:round;stroke-width:3;stroke-dashoffset:0"/>
+ <path d="m 9 46 0 9 9 0 0 -9 z m 3 3 3 0 0 3 -3 0 z" style="fill:#313131;opacity:1;fill-opacity:1;stroke:none"/>
 </svg>

--- a/Numix/64/actions/segment-line.svg
+++ b/Numix/64/actions/segment-line.svg
@@ -1,6 +1,7 @@
+
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
- <rect width="47" height="3" x="-23.5" y="43.755" transform="matrix(0.70710678,-0.70710678,0.70710678,0.70710678,0,0)" style="fill:#dc322f;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
- <path d="m 46 9 0 9 9 0 0 -9 z m 3 3 3 0 0 3 -3 0 z" style="fill:#888;opacity:1;fill-opacity:1;stroke:none"/>
- <path d="m 9 46 0 9 9 0 0 -9 z m 3 3 3 0 0 3 -3 0 z" style="fill:#888;opacity:1;fill-opacity:1;stroke:none"/>
+ <rect transform="matrix(0.70711 -0.70711 0.70711 0.70711 0 0)" height="3" x="-23.5" y="43.755" width="47" style="fill:#dc322f;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <path d="m 46 9 0 9 9 0 0 -9 z m 3 3 3 0 0 3 -3 0 z" style="fill:#313131;opacity:1;fill-opacity:1;stroke:none"/>
+ <path d="m 9 46 0 9 9 0 0 -9 z m 3 3 3 0 0 3 -3 0 z" style="fill:#313131;opacity:1;fill-opacity:1;stroke:none"/>
 </svg>


### PR DESCRIPTION
From #437.  I also added a few symlinks so that they show up in inkscape
![node-add](https://cloud.githubusercontent.com/assets/6475757/18362454/151d77a6-7606-11e6-825a-49e5320f1aa3.png)
![node-break](https://cloud.githubusercontent.com/assets/6475757/18362456/151eb08a-7606-11e6-97ef-3a4188a6005e.png)
![node-cusp](https://cloud.githubusercontent.com/assets/6475757/18362457/15206b8c-7606-11e6-9d48-d4c64e9f18b4.png)
![node-delete](https://cloud.githubusercontent.com/assets/6475757/18362458/152460ac-7606-11e6-859b-f6886d01140c.png)
![node-delete-segment](https://cloud.githubusercontent.com/assets/6475757/18362455/151e91c2-7606-11e6-8e11-b5e8d593f6fb.png)
![node-join](https://cloud.githubusercontent.com/assets/6475757/18362462/1541b404-7606-11e6-8e77-77aa2c793a7a.png)
![node-join-segment](https://cloud.githubusercontent.com/assets/6475757/18362460/153ee9c2-7606-11e6-8179-3b1c0083909b.png)
![node-smooth](https://cloud.githubusercontent.com/assets/6475757/18362464/154312b8-7606-11e6-8b61-fbde0d4b8a52.png)
![node-symmetric](https://cloud.githubusercontent.com/assets/6475757/18362461/1540ed26-7606-11e6-8be1-42d11df27019.png)
![node-type-auto-smooth](https://cloud.githubusercontent.com/assets/6475757/18362463/154217be-7606-11e6-82d5-7eef618af085.png)









