### PR TITLE
Adds microphone-symbolic to notifications

### DIFF
--- a/Numix/48/notifications/notification-microphone-sensitivity-high-symbolic.svg
+++ b/Numix/48/notifications/notification-microphone-sensitivity-high-symbolic.svg
@@ -1,0 +1,1 @@
+notification-microphone-sensitivity-high.svg

--- a/Numix/48/notifications/notification-microphone-sensitivity-low-symbolic.svg
+++ b/Numix/48/notifications/notification-microphone-sensitivity-low-symbolic.svg
@@ -1,0 +1,1 @@
+notification-microphone-sensitivity-low.svg

--- a/Numix/48/notifications/notification-microphone-sensitivity-medium-symbolic.svg
+++ b/Numix/48/notifications/notification-microphone-sensitivity-medium-symbolic.svg
@@ -1,0 +1,1 @@
+notification-microphone-sensitivity-medium.svg

--- a/Numix/48/notifications/notification-microphone-sensitivity-muted-symbolic.svg
+++ b/Numix/48/notifications/notification-microphone-sensitivity-muted-symbolic.svg
@@ -1,0 +1,1 @@
+notification-microphone-sensitivity-muted.svg


### PR DESCRIPTION
Figured out why the `symbolic` icon was shown after digging around in the source code for #1233 . The naming of the icons is super inconsistent (no idea why), so the microphone looks for `-symbolic` icons, and therefore uses the one from scalable. Adding them to `notifications` fixes it. 

Testing that can be done with `xte 'key XF86AudioMicMute'` even if no microphone is installed