### PR TITLE
Some symlinks for KDE 5 / dolphin VCS emblems

### DIFF
--- a/Numix/16/emblems/emblem-dropbox-selsync.svg
+++ b/Numix/16/emblems/emblem-dropbox-selsync.svg
@@ -1,4 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
- <path d="m 43.605 24 c 0 10.828 -8.777 19.605 -19.605 19.605 c -10.828 0 -19.605 -8.777 -19.605 -19.605 c 0 -10.828 8.777 -19.605 19.605 -19.605 c 10.828 0 19.605 8.777 19.605 19.605 Z" transform="scale(.33333)" style="fill:#dc322f;fill-opacity:1;stroke:#777;stroke-width:0.792"/>
- <path d="m 4 7 0 2 8 0 0 -2 z" style="fill:#fff;fill-opacity:1"/>
-</svg>
+emblem-remove.svg

--- a/Numix/16/emblems/emblem-remove.svg
+++ b/Numix/16/emblems/emblem-remove.svg
@@ -1,1 +1,4 @@
-emblem-dropbox-selsync.svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+ <path d="m 43.605 24 c 0 10.828 -8.777 19.605 -19.605 19.605 c -10.828 0 -19.605 -8.777 -19.605 -19.605 c 0 -10.828 8.777 -19.605 19.605 -19.605 c 10.828 0 19.605 8.777 19.605 19.605 Z" transform="scale(.33333)" style="fill:#dc322f;fill-opacity:1;stroke:#777;stroke-width:0.792"/>
+ <path d="m 4 7 0 2 8 0 0 -2 z" style="fill:#fff;fill-opacity:1"/>
+</svg>

--- a/Numix/16/emblems/vcs-added.svg
+++ b/Numix/16/emblems/vcs-added.svg
@@ -1,0 +1,1 @@
+emblem-added.svg

--- a/Numix/16/emblems/vcs-conflicting.svg
+++ b/Numix/16/emblems/vcs-conflicting.svg
@@ -1,0 +1,1 @@
+emblem-important.svg

--- a/Numix/16/emblems/vcs-locally-modified-unstaged.svg
+++ b/Numix/16/emblems/vcs-locally-modified-unstaged.svg
@@ -1,0 +1,1 @@
+emblem-development.svg

--- a/Numix/16/emblems/vcs-locally-modified.svg
+++ b/Numix/16/emblems/vcs-locally-modified.svg
@@ -1,0 +1,1 @@
+emblem-development.svg

--- a/Numix/16/emblems/vcs-normal.svg
+++ b/Numix/16/emblems/vcs-normal.svg
@@ -1,0 +1,1 @@
+emblem-ubuntuone-synchronized.svg

--- a/Numix/16/emblems/vcs-removed.svg
+++ b/Numix/16/emblems/vcs-removed.svg
@@ -1,0 +1,1 @@
+emblem-remove.svg

--- a/Numix/16/emblems/vcs-update-required.svg
+++ b/Numix/16/emblems/vcs-update-required.svg
@@ -1,0 +1,1 @@
+emblem-insync-des-error.svg

--- a/Numix/16/emblems/vcs-update-required.svg
+++ b/Numix/16/emblems/vcs-update-required.svg
@@ -1,1 +1,1 @@
-emblem-insync-des-error.svg
+emblem-ubuntuone-updating.svg

--- a/Numix/22/emblems/emblem-dropbox-selsync.svg
+++ b/Numix/22/emblems/emblem-dropbox-selsync.svg
@@ -1,4 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22">
- <path d="m 43.602 24 c 0 10.824 -8.778 19.602 -19.602 19.602 c -10.824 0 -19.602 -8.778 -19.602 -19.602 c 0 -10.824 8.778 -19.602 19.602 -19.602 c 10.824 0 19.602 8.778 19.602 19.602 Z" transform="scale(.45833)" style="fill:#dc322f;fill-opacity:1;stroke:#777;stroke-width:0.792"/>
- <path d="m 17 9 -12 0 0 4 12 0" style="fill:#fff;fill-opacity:1"/>
-</svg>
+emblem-remove.svg

--- a/Numix/22/emblems/emblem-remove.svg
+++ b/Numix/22/emblems/emblem-remove.svg
@@ -1,1 +1,4 @@
-emblem-dropbox-selsync.svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22">
+ <path d="m 43.602 24 c 0 10.824 -8.778 19.602 -19.602 19.602 c -10.824 0 -19.602 -8.778 -19.602 -19.602 c 0 -10.824 8.778 -19.602 19.602 -19.602 c 10.824 0 19.602 8.778 19.602 19.602 Z" transform="scale(.45833)" style="fill:#dc322f;fill-opacity:1;stroke:#777;stroke-width:0.792"/>
+ <path d="m 17 9 -12 0 0 4 12 0" style="fill:#fff;fill-opacity:1"/>
+</svg>

--- a/Numix/22/emblems/vcs-added.svg
+++ b/Numix/22/emblems/vcs-added.svg
@@ -1,0 +1,1 @@
+emblem-added.svg

--- a/Numix/22/emblems/vcs-conflicting.svg
+++ b/Numix/22/emblems/vcs-conflicting.svg
@@ -1,0 +1,1 @@
+emblem-important.svg

--- a/Numix/22/emblems/vcs-locally-modified-unstaged.svg
+++ b/Numix/22/emblems/vcs-locally-modified-unstaged.svg
@@ -1,0 +1,1 @@
+emblem-development.svg

--- a/Numix/22/emblems/vcs-locally-modified.svg
+++ b/Numix/22/emblems/vcs-locally-modified.svg
@@ -1,0 +1,1 @@
+emblem-development.svg

--- a/Numix/22/emblems/vcs-normal.svg
+++ b/Numix/22/emblems/vcs-normal.svg
@@ -1,0 +1,1 @@
+emblem-ubuntuone-synchronized.svg

--- a/Numix/22/emblems/vcs-removed.svg
+++ b/Numix/22/emblems/vcs-removed.svg
@@ -1,0 +1,1 @@
+emblem-remove.svg

--- a/Numix/22/emblems/vcs-update-required.svg
+++ b/Numix/22/emblems/vcs-update-required.svg
@@ -1,0 +1,1 @@
+emblem-ubuntuone-updating.svg

--- a/Numix/24/emblems/emblem-dropbox-selsync.svg
+++ b/Numix/24/emblems/emblem-dropbox-selsync.svg
@@ -1,4 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
- <path d="m 43.602 24 c 0 10.828 -8.773 19.602 -19.602 19.602 c -10.828 0 -19.602 -8.773 -19.602 -19.602 c -0.008 -10.828 8.773 -19.609 19.602 -19.609 c 10.828 0 19.609 8.781 19.602 19.609 Z" transform="scale(.5)" style="fill:#dc322f;fill-opacity:1;stroke:#777;stroke-width:0.792"/>
- <path d="m 5 10 0 4 14 0 0 -4 z" style="fill:#fff;fill-opacity:1"/>
-</svg>
+emblem-remove.svg

--- a/Numix/24/emblems/emblem-remove.svg
+++ b/Numix/24/emblems/emblem-remove.svg
@@ -1,1 +1,4 @@
-emblem-dropbox-selsync.svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+ <path d="m 43.602 24 c 0 10.828 -8.773 19.602 -19.602 19.602 c -10.828 0 -19.602 -8.773 -19.602 -19.602 c -0.008 -10.828 8.773 -19.609 19.602 -19.609 c 10.828 0 19.609 8.781 19.602 19.609 Z" transform="scale(.5)" style="fill:#dc322f;fill-opacity:1;stroke:#777;stroke-width:0.792"/>
+ <path d="m 5 10 0 4 14 0 0 -4 z" style="fill:#fff;fill-opacity:1"/>
+</svg>

--- a/Numix/24/emblems/vcs-added.svg
+++ b/Numix/24/emblems/vcs-added.svg
@@ -1,0 +1,1 @@
+emblem-added.svg

--- a/Numix/24/emblems/vcs-conflicting.svg
+++ b/Numix/24/emblems/vcs-conflicting.svg
@@ -1,0 +1,1 @@
+emblem-important.svg

--- a/Numix/24/emblems/vcs-locally-modified-unstaged.svg
+++ b/Numix/24/emblems/vcs-locally-modified-unstaged.svg
@@ -1,0 +1,1 @@
+emblem-development.svg

--- a/Numix/24/emblems/vcs-locally-modified.svg
+++ b/Numix/24/emblems/vcs-locally-modified.svg
@@ -1,0 +1,1 @@
+emblem-development.svg

--- a/Numix/24/emblems/vcs-normal.svg
+++ b/Numix/24/emblems/vcs-normal.svg
@@ -1,0 +1,1 @@
+emblem-ubuntuone-synchronized.svg

--- a/Numix/24/emblems/vcs-removed.svg
+++ b/Numix/24/emblems/vcs-removed.svg
@@ -1,0 +1,1 @@
+emblem-remove.svg

--- a/Numix/24/emblems/vcs-update-required.svg
+++ b/Numix/24/emblems/vcs-update-required.svg
@@ -1,0 +1,1 @@
+emblem-ubuntuone-updating.svg

--- a/Numix/32/emblems/emblem-dropbox-selsync.svg
+++ b/Numix/32/emblems/emblem-dropbox-selsync.svg
@@ -1,4 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
- <path d="m 43.605 24 c 0 10.828 -8.777 19.6 -19.605 19.6 c -10.828 0 -19.605 -8.771 -19.605 -19.6 c 0 -10.828 8.777 -19.605 19.605 -19.605 c 10.828 0 19.605 8.777 19.605 19.605 Z" transform="scale(.66667)" style="fill:#dc322f;fill-opacity:1;stroke:#777;stroke-width:0.792"/>
- <path d="m 7 13 0 6 18 0 0 -6 z" style="fill:#fff;fill-opacity:1"/>
-</svg>
+emblem-remove.svg

--- a/Numix/32/emblems/emblem-remove.svg
+++ b/Numix/32/emblems/emblem-remove.svg
@@ -1,1 +1,4 @@
-emblem-dropbox-selsync.svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+ <path d="m 43.605 24 c 0 10.828 -8.777 19.6 -19.605 19.6 c -10.828 0 -19.605 -8.771 -19.605 -19.6 c 0 -10.828 8.777 -19.605 19.605 -19.605 c 10.828 0 19.605 8.777 19.605 19.605 Z" transform="scale(.66667)" style="fill:#dc322f;fill-opacity:1;stroke:#777;stroke-width:0.792"/>
+ <path d="m 7 13 0 6 18 0 0 -6 z" style="fill:#fff;fill-opacity:1"/>
+</svg>

--- a/Numix/32/emblems/vcs-added.svg
+++ b/Numix/32/emblems/vcs-added.svg
@@ -1,0 +1,1 @@
+emblem-added.svg

--- a/Numix/32/emblems/vcs-conflicting.svg
+++ b/Numix/32/emblems/vcs-conflicting.svg
@@ -1,0 +1,1 @@
+emblem-important.svg

--- a/Numix/32/emblems/vcs-locally-modified-unstaged.svg
+++ b/Numix/32/emblems/vcs-locally-modified-unstaged.svg
@@ -1,0 +1,1 @@
+emblem-development.svg

--- a/Numix/32/emblems/vcs-locally-modified.svg
+++ b/Numix/32/emblems/vcs-locally-modified.svg
@@ -1,0 +1,1 @@
+emblem-development.svg

--- a/Numix/32/emblems/vcs-normal.svg
+++ b/Numix/32/emblems/vcs-normal.svg
@@ -1,0 +1,1 @@
+emblem-ubuntuone-synchronized.svg

--- a/Numix/32/emblems/vcs-removed.svg
+++ b/Numix/32/emblems/vcs-removed.svg
@@ -1,0 +1,1 @@
+emblem-remove.svg

--- a/Numix/32/emblems/vcs-update-required.svg
+++ b/Numix/32/emblems/vcs-update-required.svg
@@ -1,0 +1,1 @@
+emblem-ubuntuone-updating.svg

--- a/Numix/48/emblems/emblem-dropbox-selsync.svg
+++ b/Numix/48/emblems/emblem-dropbox-selsync.svg
@@ -1,4 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
- <path d="m 43.604 24 a 19.604 19.604 0 0 1 -39.21 0 19.604 19.604 0 1 1 39.21 0 z" style="fill:#dc322f;fill-opacity:1;stroke:#777;stroke-width:0.792"/>
- <path d="m 37 20 -26 0 0 8 26 0 z" style="fill:#fff;fill-opacity:1"/>
-</svg>
+emblem-remove.svg

--- a/Numix/48/emblems/emblem-remove.svg
+++ b/Numix/48/emblems/emblem-remove.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+ <path d="m 43.604 24 a 19.604 19.604 0 0 1 -39.21 0 19.604 19.604 0 1 1 39.21 0 z" style="fill:#dc322f;fill-opacity:1;stroke:#777;stroke-width:0.792"/>
+ <path d="m 37 20 -26 0 0 8 26 0 z" style="fill:#fff;fill-opacity:1"/>
+</svg>

--- a/Numix/48/emblems/vcs-added.svg
+++ b/Numix/48/emblems/vcs-added.svg
@@ -1,0 +1,1 @@
+emblem-new.svg

--- a/Numix/48/emblems/vcs-conflicting.svg
+++ b/Numix/48/emblems/vcs-conflicting.svg
@@ -1,0 +1,1 @@
+emblem-important.svg

--- a/Numix/48/emblems/vcs-locally-modified-unstaged.svg
+++ b/Numix/48/emblems/vcs-locally-modified-unstaged.svg
@@ -1,0 +1,1 @@
+emblem-development.svg

--- a/Numix/48/emblems/vcs-locally-modified.svg
+++ b/Numix/48/emblems/vcs-locally-modified.svg
@@ -1,0 +1,1 @@
+emblem-development.svg

--- a/Numix/48/emblems/vcs-normal.svg
+++ b/Numix/48/emblems/vcs-normal.svg
@@ -1,0 +1,1 @@
+emblem-ubuntuone-synchronized.svg

--- a/Numix/48/emblems/vcs-removed.svg
+++ b/Numix/48/emblems/vcs-removed.svg
@@ -1,0 +1,1 @@
+emblem-dropbox-selsync.svg

--- a/Numix/48/emblems/vcs-removed.svg
+++ b/Numix/48/emblems/vcs-removed.svg
@@ -1,1 +1,1 @@
-emblem-dropbox-selsync.svg
+emblem-remove.svg

--- a/Numix/48/emblems/vcs-update-required.svg
+++ b/Numix/48/emblems/vcs-update-required.svg
@@ -1,0 +1,1 @@
+emblem-ubuntuone-updating.svg

--- a/Numix/64/emblems/emblem-dropbox-selsync.svg
+++ b/Numix/64/emblems/emblem-dropbox-selsync.svg
@@ -1,4 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
- <path d="m 43.605 24 c -0.003 10.825 -8.78 19.603 -19.605 19.603 c -10.825 0 -19.603 -8.777 -19.605 -19.603 c 0 -10.828 8.777 -19.605 19.605 -19.605 c 10.828 0 19.605 8.777 19.605 19.605 Z" transform="scale(1.33333)" style="fill:#dc322f;fill-opacity:1;stroke:#777;stroke-width:0.792"/>
- <path d="m 49 27 -34 0 0 10 34 0 z" style="fill:#fff;fill-opacity:1"/>
-</svg>
+emblem-remove.svg

--- a/Numix/64/emblems/emblem-remove.svg
+++ b/Numix/64/emblems/emblem-remove.svg
@@ -1,1 +1,4 @@
-emblem-dropbox-selsync.svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+ <path d="m 43.605 24 c -0.003 10.825 -8.78 19.603 -19.605 19.603 c -10.825 0 -19.603 -8.777 -19.605 -19.603 c 0 -10.828 8.777 -19.605 19.605 -19.605 c 10.828 0 19.605 8.777 19.605 19.605 Z" transform="scale(1.33333)" style="fill:#dc322f;fill-opacity:1;stroke:#777;stroke-width:0.792"/>
+ <path d="m 49 27 -34 0 0 10 34 0 z" style="fill:#fff;fill-opacity:1"/>
+</svg>

--- a/Numix/64/emblems/vcs-added.svg
+++ b/Numix/64/emblems/vcs-added.svg
@@ -1,0 +1,1 @@
+emblem-added.svg

--- a/Numix/64/emblems/vcs-conflicting.svg
+++ b/Numix/64/emblems/vcs-conflicting.svg
@@ -1,0 +1,1 @@
+emblem-important.svg

--- a/Numix/64/emblems/vcs-locally-modified-unstaged.svg
+++ b/Numix/64/emblems/vcs-locally-modified-unstaged.svg
@@ -1,0 +1,1 @@
+emblem-development.svg

--- a/Numix/64/emblems/vcs-locally-modified.svg
+++ b/Numix/64/emblems/vcs-locally-modified.svg
@@ -1,0 +1,1 @@
+emblem-development.svg

--- a/Numix/64/emblems/vcs-normal.svg
+++ b/Numix/64/emblems/vcs-normal.svg
@@ -1,0 +1,1 @@
+emblem-ubuntuone-synchronized.svg

--- a/Numix/64/emblems/vcs-removed.svg
+++ b/Numix/64/emblems/vcs-removed.svg
@@ -1,0 +1,1 @@
+emblem-remove.svg

--- a/Numix/64/emblems/vcs-update-required.svg
+++ b/Numix/64/emblems/vcs-update-required.svg
@@ -1,0 +1,1 @@
+emblem-ubuntuone-updating.svg


### PR DESCRIPTION
These emblems are used by [Dolphin's VCS and Dropbox integration plugins](https://cgit.kde.org/dolphin-plugins.git/tree/). Without the applicable icons or icons to take their place, all of these emblems show something like the [unknown file type icon](https://github.com/numixproject/numix-icon-theme/blob/master/Numix/22/mimetypes/unknown.svg) instead (which in itself is a weird fallback IMHO...)

These links are not one to one matches (e.g. the "locally modified" and "update required" icons), but still preserve the original emblems' intents to some degree. I am not a designer myself, so I don't think I can do much more here.

A quick comparison with Breeze:
![numix-vcs-symlinks](https://user-images.githubusercontent.com/4644601/39743167-ee8aaf14-5254-11e8-974d-3c5f7309b89e.png)
