### PR TITLE
Make view-sidebar-symbolic unique

### DIFF
--- a/Numix-Light/scalable/actions/view-sidebar-symbolic.svg
+++ b/Numix-Light/scalable/actions/view-sidebar-symbolic.svg
@@ -1,7 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
- <g transform="matrix(0.60002,0,0,1,-18.80147,-746)" style="fill:#353535;color:#353535">
-  <rect height="2" y="749" x="36.33" width="16.665"/>
-  <rect height="2" y="753" x="36.33" width="16.665"/>
-  <rect height="2" y="757" x="36.33" width="16.665"/>
- </g>
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+ <path d="m2 2v12h12v-12zm4 2h6v8h-6z" style="color:#bebebe;fill:#353535"/>
 </svg>

--- a/Numix/scalable/actions/view-sidebar-symbolic.svg
+++ b/Numix/scalable/actions/view-sidebar-symbolic.svg
@@ -1,7 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
- <g transform="matrix(0.60002,0,0,1,-18.80147,-746)" style="fill:#bebebe;color:#bebebe">
-  <rect height="2" y="749" x="36.33" width="16.665"/>
-  <rect height="2" y="753" x="36.33" width="16.665"/>
-  <rect height="2" y="757" x="36.33" width="16.665"/>
- </g>
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+ <path d="m2 2v12h12v-12zm4 2h6v8h-6z" style="color:#bebebe;fill:#bebebe"/>
 </svg>


### PR DESCRIPTION
Previously this was the same as open-menu-symbolic,
which was confusing in places like evince's toolbar,
where both icons existed.

![2018-11-05_131045_321x90_screenshot](https://user-images.githubusercontent.com/5386578/47999879-c1584200-e0fb-11e8-9b5e-24bbb12e1da7.png)
