### PR TITLE
Add missing panel icons for insync 1.5

### DIFF
--- a/Numix-Light/16/panel/insync-paused.svg
+++ b/Numix-Light/16/panel/insync-paused.svg
@@ -1,0 +1,1 @@
+insync-pause.svg

--- a/Numix-Light/16/panel/insync-syncing.svg
+++ b/Numix-Light/16/panel/insync-syncing.svg
@@ -1,0 +1,1 @@
+insync-syncing-2.svg

--- a/Numix-Light/22/panel/insync-paused.svg
+++ b/Numix-Light/22/panel/insync-paused.svg
@@ -1,0 +1,1 @@
+insync-pause.svg

--- a/Numix-Light/22/panel/insync-syncing.svg
+++ b/Numix-Light/22/panel/insync-syncing.svg
@@ -1,0 +1,1 @@
+insync-syncing-2.svg

--- a/Numix-Light/24/panel/insync-paused.svg
+++ b/Numix-Light/24/panel/insync-paused.svg
@@ -1,0 +1,1 @@
+insync-pause.svg

--- a/Numix-Light/24/panel/insync-syncing.svg
+++ b/Numix-Light/24/panel/insync-syncing.svg
@@ -1,0 +1,1 @@
+insync-syncing-2.svg

--- a/Numix/16/panel/insync-paused.svg
+++ b/Numix/16/panel/insync-paused.svg
@@ -1,0 +1,1 @@
+insync-pause.svg

--- a/Numix/16/panel/insync-syncing.svg
+++ b/Numix/16/panel/insync-syncing.svg
@@ -1,0 +1,1 @@
+insync-syncing-2.svg

--- a/Numix/22/panel/insync-paused.svg
+++ b/Numix/22/panel/insync-paused.svg
@@ -1,0 +1,1 @@
+insync-pause.svg

--- a/Numix/22/panel/insync-syncing.svg
+++ b/Numix/22/panel/insync-syncing.svg
@@ -1,0 +1,1 @@
+insync-syncing-2.svg

--- a/Numix/24/panel/insync-paused.svg
+++ b/Numix/24/panel/insync-paused.svg
@@ -1,0 +1,1 @@
+insync-pause.svg

--- a/Numix/24/panel/insync-syncing.svg
+++ b/Numix/24/panel/insync-syncing.svg
@@ -1,0 +1,1 @@
+insync-syncing-2.svg


### PR DESCRIPTION
There is no syncing icon rotation anymore, but it switches between `insync-share` and `insync-syncing` and since `insync-syncing-2` is the least similar to other icons i used this for now.